### PR TITLE
chore(flake/treefmt-nix): `768acdb0` -> `c9f97032`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722330636,
-        "narHash": "sha256-uru7JzOa33YlSRwf9sfXpJG+UAV+bnBEYMjrzKrQZFw=",
+        "lastModified": 1723402464,
+        "narHash": "sha256-xjunKUFQs9D7u0TpVoXhrRYb4tbVkutRoFUHj0lEydE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "768acdb06968e53aa1ee8de207fd955335c754b7",
+        "rev": "c9f97032be6816fa234f24803b8ae79dc7753a91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                            |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`c9f97032`](https://github.com/numtide/treefmt-nix/commit/c9f97032be6816fa234f24803b8ae79dc7753a91) | `` fixup! fix: only eval enable option if visible (#214) (#218) `` |
| [`14c092e0`](https://github.com/numtide/treefmt-nix/commit/14c092e0326de759e16b37535161b3cb9770cea3) | `` Add renovate.json (#215) ``                                     |
| [`5a3a9f95`](https://github.com/numtide/treefmt-nix/commit/5a3a9f956673111759d9643cf1a3ab81ee94cbf4) | `` fix: only eval enable option if visible (#214) ``               |