### PR TITLE
chore(flake/nixvim): `4852f94f` -> `f13bdef0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723230145,
-        "narHash": "sha256-FyjcuYZMqXdiKOXkHaIC2ubag+TPV9Z12urC/sdVI6A=",
+        "lastModified": 1723323133,
+        "narHash": "sha256-g3wit604jFhBvjDBziJgulDUXDl/ApafMXq7o7ioMxo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4852f94f8ccae551514df0092a077014bafb95ca",
+        "rev": "f13bdef0bc697261c51eab686c28c7e2e7b7db3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`f13bdef0`](https://github.com/nix-community/nixvim/commit/f13bdef0bc697261c51eab686c28c7e2e7b7db3c) | `` plugins/lsp/astro: fix package attribute path `` |
| [`988906f8`](https://github.com/nix-community/nixvim/commit/988906f8edc76d20cecdc97de78f93ed89187e70) | `` flake.lock: Update ``                            |