### PR TITLE
chore(flake/nixvim): `f13bdef0` -> `dbf6f7bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723323133,
-        "narHash": "sha256-g3wit604jFhBvjDBziJgulDUXDl/ApafMXq7o7ioMxo=",
+        "lastModified": 1723481641,
+        "narHash": "sha256-9djT72/Ab2E3SpUbB3l0WmqZQ5mj05+LIVoorcjCWgE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "f13bdef0bc697261c51eab686c28c7e2e7b7db3c",
+        "rev": "dbf6f7bc997dc3a9ab1f014ea075600357226950",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`dbf6f7bc`](https://github.com/nix-community/nixvim/commit/dbf6f7bc997dc3a9ab1f014ea075600357226950) | `` update-script/rust-analyzer: Filter out headers from option descriptions `` |
| [`ad704ddb`](https://github.com/nix-community/nixvim/commit/ad704ddba70415a982a686257563609c25a22101) | `` generated,rust-analyzer: Handle objects with defined properties ``          |
| [`f823d010`](https://github.com/nix-community/nixvim/commit/f823d01002acd7e1adab01680e42e31b8edc50f5) | `` flake.lock: Update ``                                                       |
| [`d9055abe`](https://github.com/nix-community/nixvim/commit/d9055abe2044f4bf9e81f414215cca81c02cbd72) | `` plugins/markview: init ``                                                   |