### PR TITLE
chore(flake/nixpkgs): `5e0ca229` -> `a58bc8ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723175592,
-        "narHash": "sha256-M0xJ3FbDUc4fRZ84dPGx5VvgFsOzds77KiBMW/mMTnI=",
+        "lastModified": 1723362943,
+        "narHash": "sha256-dFZRVSgmJkyM0bkPpaYRtG/kRMRTorUIDj8BxoOt1T4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
+        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`15f19585`](https://github.com/NixOS/nixpkgs/commit/15f19585941e98b6912d0857978ba4a6a8d81e7f) | `` python312Packages.laundrify-aio: 1.2.1 -> 1.2.2 ``                          |
| [`bc2dda1b`](https://github.com/NixOS/nixpkgs/commit/bc2dda1bece9c0c93901a1639334cf3999f45450) | `` python311Packages.clip-anytorch: add patch for setuptools ``                |
| [`a0c83616`](https://github.com/NixOS/nixpkgs/commit/a0c83616e8e300a00bd5bd626bb0ee95b342238f) | `` vkquake: 1.31.0 -> 1.31.1.1 ``                                              |
| [`e54897b7`](https://github.com/NixOS/nixpkgs/commit/e54897b75c80f05a5a0b7f1f2415afa8f8fa485a) | `` iosevka: 31.0.0 -> 31.2.0 ``                                                |
| [`7815302b`](https://github.com/NixOS/nixpkgs/commit/7815302bb48fa980646d58e94ecae5915c865660) | `` dua: 2.29.0 -> 2.29.2 ``                                                    |
| [`e4cada29`](https://github.com/NixOS/nixpkgs/commit/e4cada29fb3abed190208ea6ea887166e97dfff5) | `` python312Packages.plantuml-markdown: 3.10.0 -> 3.10.2 ``                    |
| [`2778c1e5`](https://github.com/NixOS/nixpkgs/commit/2778c1e5ee80ddf9c18e02650be59d2a94068a10) | `` ctlptl: 0.8.30 -> 0.8.31 ``                                                 |
| [`002b4957`](https://github.com/NixOS/nixpkgs/commit/002b4957ec705538272bf6054c7ad3e599a65803) | `` tfupdate: 0.8.4 -> 0.8.5 ``                                                 |
| [`5811b36e`](https://github.com/NixOS/nixpkgs/commit/5811b36ef4ef75091c98d787f09e7fae64ad52a4) | `` xiu: 0.12.7 -> 0.13.0 ``                                                    |
| [`446caa95`](https://github.com/NixOS/nixpkgs/commit/446caa9598e090ef5cfb262fa5e8018e9d3bd487) | `` aardvark-dns: 1.12.0 -> 1.12.1 ``                                           |
| [`87aa59b6`](https://github.com/NixOS/nixpkgs/commit/87aa59b62c8b7acc97cd25ea46f7d1a934795aaa) | `` gallery-dl: 1.27.2 -> 1.27.3 ``                                             |
| [`1d4928ac`](https://github.com/NixOS/nixpkgs/commit/1d4928ac6f3ba3c66af1939e7c0ef0b81df196f3) | `` python312Packages.yalexs: 6.4.3 -> 6.4.4 ``                                 |
| [`7e5f6cba`](https://github.com/NixOS/nixpkgs/commit/7e5f6cbaa4c69155a92d78beeb9b726ba4930f97) | `` polylith: 0.2.20 -> 0.2.21 ``                                               |
| [`6fb8229c`](https://github.com/NixOS/nixpkgs/commit/6fb8229c8e9c2169507baa51383a3e9c294dc04c) | `` php83Extensions.ast: 1.1.1 -> 1.1.2 ``                                      |
| [`448b8431`](https://github.com/NixOS/nixpkgs/commit/448b8431b67969b26eb38c41692b4a841e698d1c) | `` dissent: 0.0.26 -> 0.0.27 ``                                                |
| [`63c5dcaf`](https://github.com/NixOS/nixpkgs/commit/63c5dcafd1df0af99326832c5d7a60758e7307a5) | `` nzbhydra2: 7.3.0 -> 7.4.0 ``                                                |
| [`eb7c9569`](https://github.com/NixOS/nixpkgs/commit/eb7c956947080cbc4223ec6b26b40db9384fbc97) | `` python312Packages.uvcclient: 0.11.1 -> 0.12.1 ``                            |
| [`25e7a68e`](https://github.com/NixOS/nixpkgs/commit/25e7a68e96c8ada8eeda97cdbc4ff2adb939fce9) | `` androidStudioPackages.beta: 2024.1.2.10 -> 2024.1.2.11 ``                   |
| [`bc4bd283`](https://github.com/NixOS/nixpkgs/commit/bc4bd283d055751361d6b10c962d3b2d3a37abbe) | `` flashmq: 1.15.4 -> 1.16.0 ``                                                |
| [`b4ba57c0`](https://github.com/NixOS/nixpkgs/commit/b4ba57c0144cda7f29e79c6d4a30733df726aa7c) | `` k3d: 5.7.2 -> 5.7.3 ``                                                      |
| [`679c2b9c`](https://github.com/NixOS/nixpkgs/commit/679c2b9c45a85459da245da98708878ada64294b) | `` cargo-mobile2: 0.13.0 -> 0.13.1 ``                                          |
| [`a07066a0`](https://github.com/NixOS/nixpkgs/commit/a07066a031adba3ecb1c03f92c691a9154f6793e) | `` cargo-update: 13.4.0 -> 14.0.0 ``                                           |
| [`685087de`](https://github.com/NixOS/nixpkgs/commit/685087de71ebb5b2e008d151c5826d2ba3ddd9ce) | `` v2ray-domain-list-community: 20240726161926 -> 20240810010807 ``            |
| [`7eb334ec`](https://github.com/NixOS/nixpkgs/commit/7eb334ec5266175c9a39e796e110c8e9a542ddff) | `` antimicrox: 3.4.0 -> 3.4.1 ``                                               |
| [`d61fb175`](https://github.com/NixOS/nixpkgs/commit/d61fb1753854e398c95e93836a13b3a3446d387e) | `` android-studio: 2024.1.1.12 -> 2024.1.1.13 ``                               |
| [`f7a629d9`](https://github.com/NixOS/nixpkgs/commit/f7a629d9343358306324e9449d141d87a51dc046) | `` androidStudioPackages.canary: 2024.1.3.3 -> 2024.2.1.1 ``                   |
| [`f6fad2f0`](https://github.com/NixOS/nixpkgs/commit/f6fad2f068287e6354b6ef8c29bcb5fcc46c063b) | `` qq: 3.2.12-26740 -> 3.2.12 ``                                               |
| [`f0ec6f20`](https://github.com/NixOS/nixpkgs/commit/f0ec6f203f9fe549aac9e50405713d6e1da37d67) | `` nh: 3.5.19 -> 3.5.21 ``                                                     |
| [`8a310ff8`](https://github.com/NixOS/nixpkgs/commit/8a310ff87d3f671730704c6200d0d919ca3e74f1) | `` xen: add patch to fix hydra failure ``                                      |
| [`2481532a`](https://github.com/NixOS/nixpkgs/commit/2481532a3eae5b0b424a4c84cd9d0786c84788b8) | `` python312Packages.mypy-boto3-builder: refactor ``                           |
| [`0f6d7a82`](https://github.com/NixOS/nixpkgs/commit/0f6d7a8249b1c31c0991694835f8bc3b006f5ab6) | `` python312Packages.aioopenexchangerates: 0.4.16 -> 0.6.0 ``                  |
| [`55fea4ee`](https://github.com/NixOS/nixpkgs/commit/55fea4ee8a32441587dd716f3c962ed1850aaad1) | `` mpvScripts: remove trailing period from meta.description ``                 |
| [`23f10740`](https://github.com/NixOS/nixpkgs/commit/23f1074023d246e15f78eaa45a28f1d8f33ee7ce) | `` python312Packages.dvc-task: disable flaky test ``                           |
| [`f327119d`](https://github.com/NixOS/nixpkgs/commit/f327119de8f8a53f55479683db617268b639bdd3) | `` bash-language-server: allow user to override shellcheck ``                  |
| [`d1e42ebf`](https://github.com/NixOS/nixpkgs/commit/d1e42ebf09484f81202f5877087a328dd085a150) | `` bash-language-server: fix build phase ``                                    |
| [`ccc56996`](https://github.com/NixOS/nixpkgs/commit/ccc56996869035249c55c4b86954c7254c74680e) | `` llama-cpp: 3499 -> 3565 ``                                                  |
| [`bbcf6823`](https://github.com/NixOS/nixpkgs/commit/bbcf6823ea7809111a65f2d8639c7fe80ce45b4d) | `` files-cli: 2.13.100 -> 2.13.107 ``                                          |
| [`3c0b4d62`](https://github.com/NixOS/nixpkgs/commit/3c0b4d62a10151912b2b2d466229c2646d69407d) | `` bash-language-server: add version test ``                                   |
| [`ab2278ad`](https://github.com/NixOS/nixpkgs/commit/ab2278add6a152a845a890c2a483cd96c63d0171) | `` libpanel: fix cross compilation, enable strictDeps ``                       |
| [`c7caf3fa`](https://github.com/NixOS/nixpkgs/commit/c7caf3faca1500072f56268cef216631035a4fb7) | `` mealie: run tests ``                                                        |
| [`e1d92cda`](https://github.com/NixOS/nixpkgs/commit/e1d92cda6fd1bcec60e4938ce92fcee619eea793) | `` yggstack: add peigongdsd as maintainer ``                                   |
| [`ed59f08e`](https://github.com/NixOS/nixpkgs/commit/ed59f08ee82acdbe48f52c350b53995c8540f372) | `` yggstack: 0-unstable-2024-07-26 -> 1.0.1 ``                                 |
| [`9318bf78`](https://github.com/NixOS/nixpkgs/commit/9318bf784c7c66a85adb915885032ce8814adce2) | `` mealie: modernize ``                                                        |
| [`0cc9cd97`](https://github.com/NixOS/nixpkgs/commit/0cc9cd972e92f14a64b7a92041be1163f7a95958) | `` svdtools: 0.3.17 -> 0.3.18 ``                                               |
| [`0ac8e9e2`](https://github.com/NixOS/nixpkgs/commit/0ac8e9e2b6dc18c2e9b4363973b00abc8d3562dd) | `` svdtools: move to pkgs/by-name ``                                           |
| [`5f6bcaa6`](https://github.com/NixOS/nixpkgs/commit/5f6bcaa60a935be2b67a05a8ac67195cc6950d35) | `` nixosTests.quake3: fix build timeout ``                                     |
| [`3ed3b456`](https://github.com/NixOS/nixpkgs/commit/3ed3b4565842165f2635a32b599753024eca0eec) | `` grub2: generate manpages ``                                                 |
| [`a36371c9`](https://github.com/NixOS/nixpkgs/commit/a36371c97d82e5ba08d6e3951a890e9573d3d99b) | `` gamescope: 3.14.26 -> 3.14.29 ``                                            |
| [`fc32bc9e`](https://github.com/NixOS/nixpkgs/commit/fc32bc9ebf971f9754f64e8e64a0e8ad8878c931) | `` clipqr: fix build on nixpkgs unstable ``                                    |
| [`168c7859`](https://github.com/NixOS/nixpkgs/commit/168c78599e6c9c57aa3ddf5bb17cdc27a6020156) | `` git-workspace: 1.4.0 -> 1.5.0 ``                                            |
| [`60c9ceb3`](https://github.com/NixOS/nixpkgs/commit/60c9ceb3e60910c0b94dc323f5838dfcdc330efc) | `` mpvScripts.encode: init at 0-unstable-2024-01-11 ``                         |
| [`1aea8cb8`](https://github.com/NixOS/nixpkgs/commit/1aea8cb8347d5d3c1e6fb00a54022b5a3b1be73f) | `` mpvScripts.crop: init at 0-unstable-2024-01-11 ``                           |
| [`ac264ec2`](https://github.com/NixOS/nixpkgs/commit/ac264ec238ca8dcfb8d7213c4f225680ff80b56b) | `` python312Packages.m3u8: 5.2.0 -> 6.0.0 ``                                   |
| [`ee74566f`](https://github.com/NixOS/nixpkgs/commit/ee74566fdd2898351faa2e70ed27d18024a7a18d) | `` nodePackages."@astrojs/language-server": fix alias ``                       |
| [`2d2404ab`](https://github.com/NixOS/nixpkgs/commit/2d2404abaf133fe2e2438bff4b58a177ab35753d) | `` vimPlugins.markview-nvim: add nvim-web-devicons dependency ``               |
| [`c128793c`](https://github.com/NixOS/nixpkgs/commit/c128793cc60efcea5fea272fb7f2ef46610be818) | `` grype: 0.79.4 -> 0.79.5 ``                                                  |
| [`67c3ad84`](https://github.com/NixOS/nixpkgs/commit/67c3ad840cb475067c308d8b40b2d59e934099bf) | `` traefik: 3.1.1 -> 3.1.2 ``                                                  |
| [`78132ff6`](https://github.com/NixOS/nixpkgs/commit/78132ff6bc09950c9815054232b58d3e97a99490) | `` ticktick: 2.0.30 -> 6.0.0 ``                                                |
| [`28490c6b`](https://github.com/NixOS/nixpkgs/commit/28490c6b0e494f89777c12bffcc36fcec0542568) | `` cargo-geiger: fix build with rust 1.80 ``                                   |
| [`4432c834`](https://github.com/NixOS/nixpkgs/commit/4432c83446ddcd122efbeeeb3327fb00acc08417) | `` simdutf: 5.3.1 -> 5.3.4 ``                                                  |
| [`09e84d4c`](https://github.com/NixOS/nixpkgs/commit/09e84d4cb19d0c378e45563cf54d48416b88b682) | `` zk-shell: drop ``                                                           |
| [`b6eb36b2`](https://github.com/NixOS/nixpkgs/commit/b6eb36b253a80b2ac5e793f14f8c48bab333bec7) | `` home-assistant-custom-components.volkswagen_we_connect_id: init at 0.2.0 `` |
| [`152b0f10`](https://github.com/NixOS/nixpkgs/commit/152b0f10beaadce2e72b0b5c70f8f196825944e8) | `` python312Packages.django-admin-sortable2: 2.2.1 -> 2.2.2 ``                 |
| [`87617618`](https://github.com/NixOS/nixpkgs/commit/8761761830565f827cf8d0d48d10a58c4e055da7) | `` unpackerr: 0.14.3 -> 0.14.5 ``                                              |
| [`a2fdc9b6`](https://github.com/NixOS/nixpkgs/commit/a2fdc9b679c8642471be6f9e6090704dd51305c5) | `` python312Packages.mypy-boto3-builder: 7.25.0 -> 7.25.3 ``                   |
| [`ef3869e9`](https://github.com/NixOS/nixpkgs/commit/ef3869e9543a0b595ff37827159bc95372175da1) | `` resvg: 0.42.0 -> 0.43.0 ``                                                  |
| [`5751d3fe`](https://github.com/NixOS/nixpkgs/commit/5751d3fec40f1c927fca2db6f4ee59e7e1b59de3) | `` cilium-cli: 0.16.14 -> 0.16.15 ``                                           |
| [`c96884d3`](https://github.com/NixOS/nixpkgs/commit/c96884d3f205dc769947a2f5ec8bfbc8c1629dab) | `` ironbar: 0.15.1 -> 0.16.0 ``                                                |