### PR TITLE
chore(flake/nixvim): `dbf6f7bc` -> `a96aa973`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723481641,
-        "narHash": "sha256-9djT72/Ab2E3SpUbB3l0WmqZQ5mj05+LIVoorcjCWgE=",
+        "lastModified": 1723670331,
+        "narHash": "sha256-bQaWqflbYdOn28NJHMTMMPgswlQRXhZh+a3WQAeyaFE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "dbf6f7bc997dc3a9ab1f014ea075600357226950",
+        "rev": "a96aa9730af8c85dd7ed15e359ac23e9686f0a9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                 |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`a96aa973`](https://github.com/nix-community/nixvim/commit/a96aa9730af8c85dd7ed15e359ac23e9686f0a9a) | `` tests/plugins/utils/spectre: enable tests on Darwin ``               |
| [`cb398ce4`](https://github.com/nix-community/nixvim/commit/cb398ce4ba243c7a3a8d1fbfea1b56a44de6b3c9) | `` plugins/bufferline: migrate to mkNeovimPlugin ``                     |
| [`db4c4e5b`](https://github.com/nix-community/nixvim/commit/db4c4e5b1707f334a3e11530cb253d2f41051a3f) | `` lib/deprecation: expose `mkSettingsRenamedOptionModules` publicly `` |
| [`e3ec1c4a`](https://github.com/nix-community/nixvim/commit/e3ec1c4a468f046595d0d3657b3bab5f00d776ff) | `` plugins/which-key: move listOfLen to lib.types ``                    |
| [`4eb2ad7d`](https://github.com/nix-community/nixvim/commit/4eb2ad7db7ff0cb76a296b5af23b072418ad5be7) | `` lib/lua: support nixpkg's "lua-inline" type ``                       |