### PR TITLE
chore(flake/nixvim): `a96aa973` -> `ebd2182b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723670331,
-        "narHash": "sha256-bQaWqflbYdOn28NJHMTMMPgswlQRXhZh+a3WQAeyaFE=",
+        "lastModified": 1723754845,
+        "narHash": "sha256-gzso/eDMTitt3gUzpLuQRFB/bwvxz2ukq301ASOEtc4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a96aa9730af8c85dd7ed15e359ac23e9686f0a9a",
+        "rev": "ebd2182b44150fcab0f92cdc4be8ff2ed93fd2cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`ebd2182b`](https://github.com/nix-community/nixvim/commit/ebd2182b44150fcab0f92cdc4be8ff2ed93fd2cf) | `` plugins/which-key: updated spec examples and tests `` |
| [`fb4e6c23`](https://github.com/nix-community/nixvim/commit/fb4e6c2361ffd88e3a0a48ac8e90034076f25527) | `` flake-modules/devshell: add getopt runtimeInput ``    |