### PR TITLE
chore(flake/nixvim): `ebd2182b` -> `00f32f04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723754845,
-        "narHash": "sha256-gzso/eDMTitt3gUzpLuQRFB/bwvxz2ukq301ASOEtc4=",
+        "lastModified": 1723816538,
+        "narHash": "sha256-h37ltjdifkd7iLtMtBXSBBeYSTuBEKMW6ClFoC7nReQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ebd2182b44150fcab0f92cdc4be8ff2ed93fd2cf",
+        "rev": "00f32f0430f82c74919c72af84bc95bf5ae434e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`00f32f04`](https://github.com/nix-community/nixvim/commit/00f32f0430f82c74919c72af84bc95bf5ae434e4) | `` tests/lua-loader: builtins.match -> lib.hasInfix `` |
| [`6ab17b1b`](https://github.com/nix-community/nixvim/commit/6ab17b1b2e6bc2c10718025105d452dd929cc058) | `` top-level/output: include meta in package ``        |