### PR TITLE
chore(flake/nixpkgs): `c3aa7b89` -> `8a335419`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723637854,
-        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
+        "lastModified": 1723991338,
+        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
+        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`34445ddb`](https://github.com/NixOS/nixpkgs/commit/34445ddb2de798c51bb54ccb4fa87f89b2de48d8) | `` pkgs/README: recommend & redirect to pkgs/by-name in versioning section ``                           |
| [`b4e3bdd7`](https://github.com/NixOS/nixpkgs/commit/b4e3bdd7f91e83e81f5fd85361635a4998475248) | `` python312Packages.pyfunctional: init at 1.4.3 (#329947) ``                                           |
| [`086aa4f3`](https://github.com/NixOS/nixpkgs/commit/086aa4f3a91c7ed2ba6dbaf8cbb808b3081d0b6d) | `` python3Packages: remove with statements in aliases ``                                                |
| [`4363ce78`](https://github.com/NixOS/nixpkgs/commit/4363ce78b52fe40421e9da0545744e549f356dbc) | `` theLoungePlugins: remove with statements ``                                                          |
| [`ba93ec21`](https://github.com/NixOS/nixpkgs/commit/ba93ec21612102f61dd3b19d1ff8efa84d707947) | `` pkgs: remove with statements in aliases ``                                                           |
| [`65ec5b64`](https://github.com/NixOS/nixpkgs/commit/65ec5b64ece70e4ac3a72a03c0a3e7aa6b0e68e0) | `` texlive: remove with statements ``                                                                   |
| [`a77b1b3b`](https://github.com/NixOS/nixpkgs/commit/a77b1b3bc847da13f5c44219d400dc7d723be01a) | `` asciidoc: remove with statements ``                                                                  |
| [`89bced95`](https://github.com/NixOS/nixpkgs/commit/89bced95af9daacad013a333f334470e2722ff0d) | `` rsyslog: remove with statements ``                                                                   |
| [`8e8bfb14`](https://github.com/NixOS/nixpkgs/commit/8e8bfb1443184f41a6826086197de867a5981639) | `` rofi-systemd: remove with statements ``                                                              |
| [`f1ab9757`](https://github.com/NixOS/nixpkgs/commit/f1ab9757fd6761df995fed469f2a3d44b25085e1) | `` nvtop: remove with statements ``                                                                     |
| [`3fb954dd`](https://github.com/NixOS/nixpkgs/commit/3fb954dd4feb19640ad6c443e1a3ecb61a7dd6b0) | `` monit: remove with statements ``                                                                     |
| [`2e0ccc25`](https://github.com/NixOS/nixpkgs/commit/2e0ccc25d9c6fa9ce9b2a472e6fe7e706296fcd4) | `` vaultwarden: remove with statements ``                                                               |
| [`3eb82a79`](https://github.com/NixOS/nixpkgs/commit/3eb82a79e45db61ec05622fe3e2880bcc4005ca1) | `` pass: remove with statements ``                                                                      |
| [`a5d230f9`](https://github.com/NixOS/nixpkgs/commit/a5d230f94227e972c796555d24e416536223e8bc) | `` ghidra: remove with statements ``                                                                    |
| [`4377a792`](https://github.com/NixOS/nixpkgs/commit/4377a792d4ed629d24f9569df7c0af68dc517847) | `` linux-router: remove with statements ``                                                              |
| [`6c28c49d`](https://github.com/NixOS/nixpkgs/commit/6c28c49df23201c49d5e2a6fa487d37c3340741b) | `` curl: remove with statements ``                                                                      |
| [`5ac2cd59`](https://github.com/NixOS/nixpkgs/commit/5ac2cd5911836d88f5b270d30abff9b473ff0915) | `` ultrastar-manager: remove with statements ``                                                         |
| [`85878e11`](https://github.com/NixOS/nixpkgs/commit/85878e1127d26125d52c18fe7f6ac07d5f55fb9b) | `` ultrastar-creator: remove with statements ``                                                         |
| [`6e44d534`](https://github.com/NixOS/nixpkgs/commit/6e44d53415f268f55c8402f5c8e1d72304143a90) | `` coreboot-utils: remove with statements ``                                                            |
| [`7173c946`](https://github.com/NixOS/nixpkgs/commit/7173c946c744adb8763d41d3096c5c1b359da283) | `` fim: remove with statements ``                                                                       |
| [`ebdb1636`](https://github.com/NixOS/nixpkgs/commit/ebdb16362ddfe44feac7d5456bdaebe14ef7e4da) | `` diagrams-builder: remove with statements ``                                                          |
| [`092a9b8d`](https://github.com/NixOS/nixpkgs/commit/092a9b8df196aa25caed532363d9fd977d5f42d3) | `` mtdutils: remove with statements ``                                                                  |
| [`31fa793e`](https://github.com/NixOS/nixpkgs/commit/31fa793eacbb08ca7136f8791cb9262da7a0cdf6) | `` mergerfs-tools: remove with statements ``                                                            |
| [`6245f786`](https://github.com/NixOS/nixpkgs/commit/6245f7868f5d19e562ea6f25746b16fc68025f41) | `` ceph: remove with statements ``                                                                      |
| [`fada673a`](https://github.com/NixOS/nixpkgs/commit/fada673a227ccfd040396683636a4e9de3f2372a) | `` xprompt: remove with statements ``                                                                   |
| [`60f99527`](https://github.com/NixOS/nixpkgs/commit/60f995275a179d2a3d71544b989c4bd42243b688) | `` xnotify: remove with statements ``                                                                   |
| [`abcb8ef2`](https://github.com/NixOS/nixpkgs/commit/abcb8ef242d2812d14fd8d0b07e157ff34d87e39) | `` tests.texlive: remove with statements ``                                                             |
| [`2cf5e918`](https://github.com/NixOS/nixpkgs/commit/2cf5e918df76ec7adfd371bb7334605068648f0a) | `` stdenv: remove with statements ``                                                                    |
| [`9ef28332`](https://github.com/NixOS/nixpkgs/commit/9ef28332db9b1127258f54329aca52bc4cd15a5a) | `` fish: remove with statements ``                                                                      |
| [`2cc74f92`](https://github.com/NixOS/nixpkgs/commit/2cc74f92a007b3b9b8b55bf78b4120062f2fb16f) | `` xorg: remove with statements in overrides ``                                                         |
| [`463a5e7c`](https://github.com/NixOS/nixpkgs/commit/463a5e7c03ce739eca5217d3fa9f3a4309bbbb47) | `` trickster: remove with statements ``                                                                 |
| [`31d91e9a`](https://github.com/NixOS/nixpkgs/commit/31d91e9af647d719115d8a161b1bb3e95016f61d) | `` sphinxsearch: remove with statements ``                                                              |
| [`07c45327`](https://github.com/NixOS/nixpkgs/commit/07c453277e6484c7e97c41e2e0be65ead7155e8f) | `` check-{mssql,nwc,ups}-health: remove with statements ``                                              |
| [`82929eb6`](https://github.com/NixOS/nixpkgs/commit/82929eb694f194cc359ba37f899c2de95640d1e5) | `` public-inbox: remove with statements ``                                                              |
| [`d6236f24`](https://github.com/NixOS/nixpkgs/commit/d6236f244afa3e6dba0f8d1e00b393dd4e2dcefb) | `` slurm: remove with statements ``                                                                     |
| [`6d77de48`](https://github.com/NixOS/nixpkgs/commit/6d77de48e2c1f4090ec0c6e03ef0d1410039dfda) | `` apacheKafka: remove with statements ``                                                               |
| [`1f6ce17b`](https://github.com/NixOS/nixpkgs/commit/1f6ce17b6d6e41e3a68cffe54442aff985fd49c9) | `` formats: remove with statements ``                                                                   |
| [`460c91c5`](https://github.com/NixOS/nixpkgs/commit/460c91c5aecba5580f17c89e49677370b5dbfa55) | `` nv-fabricmanager: remove with statements ``                                                          |
| [`9a689792`](https://github.com/NixOS/nixpkgs/commit/9a6897925d997bf27389a3b9611fea2514361cce) | `` deviceTree: remove with statements ``                                                                |
| [`17a74527`](https://github.com/NixOS/nixpkgs/commit/17a74527b5d3a2dfe75c43d58edb3d425dcee91c) | `` cryptsetup: remove with statements ``                                                                |
| [`7b3a3f3f`](https://github.com/NixOS/nixpkgs/commit/7b3a3f3f8bdde57169a2ceb26fea1dc2432b2167) | `` freebsd.mkDerivation: remove with statements ``                                                      |
| [`9062806b`](https://github.com/NixOS/nixpkgs/commit/9062806b52286d8e223e6110f75c43b80336fbd9) | `` brgenml1lpr: remove with statements ``                                                               |
| [`8ee773a2`](https://github.com/NixOS/nixpkgs/commit/8ee773a28e8a953ee751c28f90b33d9d5d04a73f) | `` ultrastardx: remove with statements ``                                                               |
| [`8910fea8`](https://github.com/NixOS/nixpkgs/commit/8910fea8d216e9aaab508da6996362263981a96b) | `` simutrans: remove with statements ``                                                                 |
| [`96d895f6`](https://github.com/NixOS/nixpkgs/commit/96d895f6a9eafa843c343090e953d4945ff20d61) | `` mindustry: remove with statements ``                                                                 |
| [`979820ea`](https://github.com/NixOS/nixpkgs/commit/979820ea65bfd00a8b43745633b292c703201507) | `` ezquake: remove with statements ``                                                                   |
| [`479dd4d0`](https://github.com/NixOS/nixpkgs/commit/479dd4d050ba787a2074189c5f354415be7c9f5d) | `` lsof: remove with statements ``                                                                      |
| [`d3d5b2d2`](https://github.com/NixOS/nixpkgs/commit/d3d5b2d2f56d1f02807904d4dcfd3cf6e1fa7d8b) | `` gdb: remove with statements ``                                                                       |
| [`623a7972`](https://github.com/NixOS/nixpkgs/commit/623a797295bc58026eed59c06e61affeb27516d1) | `` azure-static-sites-client: remove with statements ``                                                 |
| [`49ddbfef`](https://github.com/NixOS/nixpkgs/commit/49ddbfef6cffcf03fc0e5d3ce8b5600b65af0135) | `` python3Packages.vega-datasets: remove with statements ``                                             |
| [`c434f3c0`](https://github.com/NixOS/nixpkgs/commit/c434f3c029b6bfa1f97cc6e1c1e1cf428c2368d5) | `` python3Packages.tinyobjloader-py: remove with statements ``                                          |
| [`4785eeee`](https://github.com/NixOS/nixpkgs/commit/4785eeeea3a1230875c4913d8379a4a9e6dcfe36) | `` python311Packages.tensorflow: remove with statements ``                                              |
| [`8b61506f`](https://github.com/NixOS/nixpkgs/commit/8b61506fec468d408d042693d0f1418d5486edf8) | `` python311Packages.spacy: remove with statements ``                                                   |
| [`b45066a8`](https://github.com/NixOS/nixpkgs/commit/b45066a87529fcde506422846d735b1c55a0a6b7) | `` python-lsp-black: remove with statements ``                                                          |
| [`8d711729`](https://github.com/NixOS/nixpkgs/commit/8d7117294ca9645b44ae10d6ad09b8766f85847a) | `` gnupg: remove with statements ``                                                                     |
| [`633c8568`](https://github.com/NixOS/nixpkgs/commit/633c856885a635ee56fcbd162bcb3be64f59ba6c) | `` nodePackage: remove with statements in aliases ``                                                    |
| [`eded5c32`](https://github.com/NixOS/nixpkgs/commit/eded5c3275d376db93a167795ad539aa5e07dedf) | `` luaPackages: remove with sstatement in overrides ``                                                  |
| [`8526be06`](https://github.com/NixOS/nixpkgs/commit/8526be06d2717098c255d4723fca4d0b4c2abc64) | `` luaPackages.requiredLuaModules: remove with lib statement ``                                         |
| [`11cddcd4`](https://github.com/NixOS/nixpkgs/commit/11cddcd4ad0eef35cac9465496a15d576e276e52) | `` zeroc-mcpp: remove with statements ``                                                                |
| [`99219bdf`](https://github.com/NixOS/nixpkgs/commit/99219bdfbc1847e728c3649b9c29fca824d92320) | `` tensorrt: remove with statements ``                                                                  |
| [`2429bed6`](https://github.com/NixOS/nixpkgs/commit/2429bed6928bdc19e08c75aed5e70e977a3c72e9) | `` openssl: remove with statements ``                                                                   |
| [`e949a91d`](https://github.com/NixOS/nixpkgs/commit/e949a91d02555ced9029cc6ae16df91e0145b723) | `` opencv: remove with statements ``                                                                    |
| [`13deb3a2`](https://github.com/NixOS/nixpkgs/commit/13deb3a2a1ad07779b7206ed4b25404556c9b774) | `` opencv: remove with statements ``                                                                    |
| [`4d44b70c`](https://github.com/NixOS/nixpkgs/commit/4d44b70c86a70a62eda3bf703ee96c79643e395d) | `` mvapich: remove with statements ``                                                                   |
| [`97070902`](https://github.com/NixOS/nixpkgs/commit/97070902ca4ec5e40ffddab6e470e3584a604786) | `` libucl: remove with statements ``                                                                    |
| [`ead2eecb`](https://github.com/NixOS/nixpkgs/commit/ead2eecbb23f24cf16c2b607afe5cf8dd5e17dd3) | `` libplacebo: remove with statements ``                                                                |
| [`06198190`](https://github.com/NixOS/nixpkgs/commit/06198190ca3588528300d0721d370e67bd717d1d) | `` libint: remove with statements ``                                                                    |
| [`b77e53f5`](https://github.com/NixOS/nixpkgs/commit/b77e53f5523018d46a7ba80471c6852781967315) | `` getdns: remove with statements ``                                                                    |
| [`f8967b46`](https://github.com/NixOS/nixpkgs/commit/f8967b46f60d2864f83f7cf226b7634acd939356) | `` luajit: remove with lib statement ``                                                                 |
| [`ce3cb373`](https://github.com/NixOS/nixpkgs/commit/ce3cb3730a5c9027754a6a113202ec9fd7bef20d) | `` luajit_2_0: remove with lib statement ``                                                             |
| [`0abbed5d`](https://github.com/NixOS/nixpkgs/commit/0abbed5dd5d9ff19165579639b6c31bd4a6b6c6d) | `` haskellLib.checkUnusedPackages: remove with lib statement ``                                         |
| [`8e3651c9`](https://github.com/NixOS/nixpkgs/commit/8e3651c954987c526435810e3bc992397c57a9d0) | `` aeson: remove with statements ``                                                                     |
| [`1dbcead1`](https://github.com/NixOS/nixpkgs/commit/1dbcead1d720190c58cf9579bb795ccfe74752ed) | `` coqPackages.serapi: remove with statements ``                                                        |
| [`4b185239`](https://github.com/NixOS/nixpkgs/commit/4b1852399b68dfe3d7c1208b0df5c117177ada54) | `` coqPackages_8_10.mathcomp-abel: remove with statements ``                                            |
| [`58fe1a06`](https://github.com/NixOS/nixpkgs/commit/58fe1a068fa363da32c51fcff904fab84ae44b95) | `` coqPackages.QuickChick: remove with statements ``                                                    |
| [`835804ea`](https://github.com/NixOS/nixpkgs/commit/835804ea262ffa13497b0b8a597bface1dc4e7d8) | `` sbcl: remove with statements ``                                                                      |
| [`e9bf9df5`](https://github.com/NixOS/nixpkgs/commit/e9bf9df5e402035309ba3ffced78a77b687fba77) | `` mezzo: remove with statements ``                                                                     |
| [`99aabc6f`](https://github.com/NixOS/nixpkgs/commit/99aabc6f9e98baf357f51672b1d8ac18abedf726) | `` llvm: remove with statements from common.nix ``                                                      |
| [`37a0bd36`](https://github.com/NixOS/nixpkgs/commit/37a0bd368a42b7f5806a8c5c27cbf5ae36da600c) | `` elm.hs96Pkgs: remove with statements ``                                                              |
| [`344f63da`](https://github.com/NixOS/nixpkgs/commit/344f63daef9bd2448cb1f3e120585e3296740db8) | `` elm.hs92Pkgs: remove with statements ``                                                              |
| [`bdc75c92`](https://github.com/NixOS/nixpkgs/commit/bdc75c92355879a463c549a04716faa703cb00d5) | `` elm.hs810Pkgs: remove with statements ``                                                             |
| [`418495c4`](https://github.com/NixOS/nixpkgs/commit/418495c4f9d16c8bbba39d35667fef8f6c9345e6) | `` dotnet: remove with statements ``                                                                    |
| [`63b05516`](https://github.com/NixOS/nixpkgs/commit/63b05516687f10e84a7f605036bd25fdd1dd88d6) | `` ats2: remove with statements ``                                                                      |
| [`e659af6d`](https://github.com/NixOS/nixpkgs/commit/e659af6d2e4ab529438701f2516654e8066516cc) | `` smartgithg: remove with statements ``                                                                |
| [`faa935f4`](https://github.com/NixOS/nixpkgs/commit/faa935f4728f0070e58e827a02dbddf4b298b3d1) | `` mousecape: remove with statements ``                                                                 |
| [`aa20ccad`](https://github.com/NixOS/nixpkgs/commit/aa20ccad78ec5752e68e87304f71c37a14c02291) | `` modrinth-app-unwrapped: remove with statements ``                                                    |
| [`c58fcdeb`](https://github.com/NixOS/nixpkgs/commit/c58fcdeb91f773f5893396a589d9fadd105bbe2c) | `` libplacebo: remove with statements ``                                                                |
| [`e05d16a5`](https://github.com/NixOS/nixpkgs/commit/e05d16a57aaf60682fd9c45dcad22c87a9b17956) | `` labelife-label-printer: remove with statements ``                                                    |
| [`9996e83d`](https://github.com/NixOS/nixpkgs/commit/9996e83d771c5ffb2bf4e02898c969ec3ff4f6f7) | `` btrfs-auto-snapshot: remove with statements ``                                                       |
| [`661aa513`](https://github.com/NixOS/nixpkgs/commit/661aa513a13a93dc18cbf88daec4ca89bd12d6f2) | `` writers: remove with statements from aliases ``                                                      |
| [`c406a6ed`](https://github.com/NixOS/nixpkgs/commit/c406a6ed332e43bccb8fcf3ad6aae8a2653d8dfe) | `` fetchsvn: remove with statements ``                                                                  |
| [`e1854c33`](https://github.com/NixOS/nixpkgs/commit/e1854c33b254da8ad38001b12f536735102273a4) | `` singularity: remove with statements ``                                                               |
| [`e3c6d330`](https://github.com/NixOS/nixpkgs/commit/e3c6d330177b0f49db6bdf691a778afcfaa64024) | `` obs-studio: remove with statements ``                                                                |
| [`2d7ef182`](https://github.com/NixOS/nixpkgs/commit/2d7ef18297f24678fe736fc3e59cefad5daf4ee2) | `` mpv: remove with statements ``                                                                       |
| [`48e80830`](https://github.com/NixOS/nixpkgs/commit/48e8083013a577e18e0bc1f20194465c7df91410) | `` mplayer: remove with statements ``                                                                   |
| [`75923e26`](https://github.com/NixOS/nixpkgs/commit/75923e2640cdb6ad9a857f862f6e4b8c928cee9b) | `` git-sync: remove with statements ``                                                                  |
| [`24395a18`](https://github.com/NixOS/nixpkgs/commit/24395a180ddf126150ce4ce5a5752845b0240308) | `` wolfram-engine: remove with statements ``                                                            |
| [`66a0775d`](https://github.com/NixOS/nixpkgs/commit/66a0775dbe3cb29bc21f7647f358ce005d5caa3e) | `` coq: remove with statements ``                                                                       |
| [`6b764605`](https://github.com/NixOS/nixpkgs/commit/6b764605dc738238db0be382c6cbb8527e361ce5) | `` picoscope: remove with statements ``                                                                 |
| [`0b74a121`](https://github.com/NixOS/nixpkgs/commit/0b74a12120d8ae332af1b8a5996553744eb8dd87) | `` gwyddion: remove with statements ``                                                                  |
| [`ecc748b3`](https://github.com/NixOS/nixpkgs/commit/ecc748b3d1cc3ecacb1bd8eac601dc518c51c566) | `` synology-drive-client: remove with statements ``                                                     |
| [`62cb4575`](https://github.com/NixOS/nixpkgs/commit/62cb4575a758e906d09f1c4121c719f907866dca) | `` tremc: remove with statements ``                                                                     |
| [`926b6220`](https://github.com/NixOS/nixpkgs/commit/926b6220cd423f600dcd3bc03dffd07d0fc49b79) | `` ngadmin: remove with statements ``                                                                   |
| [`19b0d701`](https://github.com/NixOS/nixpkgs/commit/19b0d701817bf344e18774cf299b3acd41e2710a) | `` weechat: remove with statements ``                                                                   |
| [`bc794b79`](https://github.com/NixOS/nixpkgs/commit/bc794b796b56ff2441e1fc873d905f3a0833ac94) | `` links2: remove with statements ``                                                                    |
| [`642bfd67`](https://github.com/NixOS/nixpkgs/commit/642bfd678c06947fae185607c544f4bdb6bc6da5) | `` chromium: remove with statements ``                                                                  |
| [`b70b0ceb`](https://github.com/NixOS/nixpkgs/commit/b70b0ceb8ce816ece361a72f3c794a2b685420c6) | `` brig: remove with statements ``                                                                      |
| [`929615b5`](https://github.com/NixOS/nixpkgs/commit/929615b55cecd4475ee12851f53faf6b896aaca9) | `` workrave: remove with statements ``                                                                  |
| [`14197891`](https://github.com/NixOS/nixpkgs/commit/141978912008dabb4d7a53a67361d12766210890) | `` sweethome3d: remove with statements ``                                                               |
| [`6ecdcc65`](https://github.com/NixOS/nixpkgs/commit/6ecdcc651c4fdefd7f7778d4583859191ef87628) | `` goldendict: remove with statements ``                                                                |
| [`b4eeedc0`](https://github.com/NixOS/nixpkgs/commit/b4eeedc00b523a5ba0f3d62be2c9895f46b7ff01) | `` digitalbitbox: remove with statements ``                                                             |
| [`7dbea256`](https://github.com/NixOS/nixpkgs/commit/7dbea2568fb7385b0ffb6d11827d6244cc188656) | `` clight: remove with statements ``                                                                    |
| [`ae33a527`](https://github.com/NixOS/nixpkgs/commit/ae33a527a513f862161c28ed5f102d8b197e8506) | `` clightd: remove with statements ``                                                                   |
| [`36a37349`](https://github.com/NixOS/nixpkgs/commit/36a37349fb570e096a30012575f4e1b78fc5f19c) | `` bemenu: remove with statements ``                                                                    |
| [`dc3c6727`](https://github.com/NixOS/nixpkgs/commit/dc3c6727ed2b278a87dbb095a257215135dbfe06) | `` ape: remove with statements ``                                                                       |
| [`a50bd73a`](https://github.com/NixOS/nixpkgs/commit/a50bd73adf12a56eaff79a7f0a18586a1661afe6) | `` apeClex: remove with statements ``                                                                   |
| [`fe193f42`](https://github.com/NixOS/nixpkgs/commit/fe193f426266640805f4c73357c8f55b1a139b8e) | `` brscan5: remove with statements ``                                                                   |
| [`c6170292`](https://github.com/NixOS/nixpkgs/commit/c61702920fa9ebf257b0320b3f0d42b4ddf6d5f0) | `` brscan4: remove with statements ``                                                                   |
| [`549dbd2a`](https://github.com/NixOS/nixpkgs/commit/549dbd2a6b1e04dd59c70e4765fc6eecd516ab7f) | `` vimPlugins: remove with statements in aliases ``                                                     |
| [`167cc0be`](https://github.com/NixOS/nixpkgs/commit/167cc0bef41a4536a444c6de4078bdea6bed27bf) | `` rstudio: remove with statements ``                                                                   |
| [`729237c1`](https://github.com/NixOS/nixpkgs/commit/729237c1631481746ff4d3578dc2c963e50c3da1) | `` kakounePlugins: remove with statements ``                                                            |
| [`f88f22d6`](https://github.com/NixOS/nixpkgs/commit/f88f22d6b2e2dc703615ca7cb93ae5971361aeae) | `` jupyter-kernels: remove with statements ``                                                           |
| [`44f5fc12`](https://github.com/NixOS/nixpkgs/commit/44f5fc12643103991b4348cd25eea4f231ecfa07) | `` eclipse: remove with statements ``                                                                   |
| [`9c61e107`](https://github.com/NixOS/nixpkgs/commit/9c61e1077606f384e8af13b6e80a5e692f6d426d) | `` ly: remove with statements ``                                                                        |
| [`67c8ac6b`](https://github.com/NixOS/nixpkgs/commit/67c8ac6bc60833e20d780aade4305bc3af81cd60) | `` gpodder: remove with statements ``                                                                   |
| [`13c304eb`](https://github.com/NixOS/nixpkgs/commit/13c304eb480a7f3492ab9dc056ed5a90fad45f53) | `` Revert "erofs-utils: 1.7.1 -> 1.8.1" ``                                                              |
| [`52ee4c79`](https://github.com/NixOS/nixpkgs/commit/52ee4c79f6f502c1a4e90e910819da83340f2818) | `` Revert "erofs-utils: add jmbaur as maintainer" ``                                                    |
| [`d45aacd2`](https://github.com/NixOS/nixpkgs/commit/d45aacd26b0cd8f2f6a06c9456f8b7175b45602d) | `` Revert "erofs-utils: nixfmt" ``                                                                      |
| [`303f998c`](https://github.com/NixOS/nixpkgs/commit/303f998cbb4c531fe16def584811554504d4ebaa) | `` tarsnapper: drop nose dependency ``                                                                  |
| [`cc3dba11`](https://github.com/NixOS/nixpkgs/commit/cc3dba1134fe83023ce99ca3a2e2ced75b194c25) | `` gh-dash: 4.5.2 -> 4.5.4 ``                                                                           |
| [`c2d5ecc5`](https://github.com/NixOS/nixpkgs/commit/c2d5ecc50497601e1e16eb3bf75f01d243af4f86) | `` nixos/displayManager: mention how to get a list of currently available desktop sessions (#335208) `` |
| [`c0c00e14`](https://github.com/NixOS/nixpkgs/commit/c0c00e14164f85e7e8921aeef38df45c6df480f0) | `` libretro.dosbox-pure: unstable-2024-08-10 -> unstable-2024-08-16 ``                                  |
| [`0e45e7f3`](https://github.com/NixOS/nixpkgs/commit/0e45e7f3ceef91f7f38587de73bf762643f1288b) | `` libretro.gambatte: unstable-2024-08-09 -> unstable-2024-08-16 ``                                     |
| [`9e9bae2d`](https://github.com/NixOS/nixpkgs/commit/9e9bae2d0d3c64bb5d4ebc30931c9fae3559867e) | `` unciv: 4.11.17 -> 4.13.0-patch1 ``                                                                   |
| [`8e14c825`](https://github.com/NixOS/nixpkgs/commit/8e14c8255e6348803495238dfd1a835b2cb0c9ab) | `` evcc: 0.129.0 -> 0.130.0 ``                                                                          |
| [`a996a246`](https://github.com/NixOS/nixpkgs/commit/a996a246beb90099b47c579af7a596805263243a) | `` libretro.genesis-plus-gx: unstable-2024-08-09 -> unstable-2024-08-16 ``                              |
| [`0bc77525`](https://github.com/NixOS/nixpkgs/commit/0bc77525f181cec63f45c7d22d16e16bf3e758c7) | `` nightfox-gtk-theme: 0-unstable-2024-06-27 -> 0-unstable-2024-07-22 ``                                |
| [`2bbe39ca`](https://github.com/NixOS/nixpkgs/commit/2bbe39ca86c03d39933c2949dde77f9d476c8922) | `` libretro.bsnes: unstable-2024-08-09 -> unstable-2024-08-16 ``                                        |
| [`0031e07c`](https://github.com/NixOS/nixpkgs/commit/0031e07cd0a2e200640f58c859dacf09dfdc990b) | `` python312Packages.streamlit: 1.37.0 -> 1.37.1 ``                                                     |
| [`296f1b59`](https://github.com/NixOS/nixpkgs/commit/296f1b59e456cfd1a08c62667a9e628984b5d859) | `` powerpipe: 0.4.1 -> 0.4.2 ``                                                                         |
| [`7c87c474`](https://github.com/NixOS/nixpkgs/commit/7c87c474f1b4f020b1ab9d2b962fde094c2599cf) | `` avrdude: add libusb-compat-0_1 dependency ``                                                         |
| [`ff5ec08f`](https://github.com/NixOS/nixpkgs/commit/ff5ec08ff3e57e73ebbc15f97d479bc1d17799ab) | `` nrr: update .git-blame-ignore-revs ``                                                                |
| [`cffc27da`](https://github.com/NixOS/nixpkgs/commit/cffc27daf06c77c0d76bc35d24b929cb9d68c3c9) | `` nrr: format with nixfmt-rfc-style ``                                                                 |
| [`1460e067`](https://github.com/NixOS/nixpkgs/commit/1460e067737106a50a16597dcb9181b306c4d567) | `` nrr: add meta.homepage ``                                                                            |
| [`a186a7c2`](https://github.com/NixOS/nixpkgs/commit/a186a7c2c5dc7e0c11478b1d5bda8e4936ddcc79) | `` nrr: enable LTO by default ``                                                                        |
| [`27799a08`](https://github.com/NixOS/nixpkgs/commit/27799a0844070136ad13741684f29d8920c48b6f) | `` platformsh: 5.0.18 -> 5.0.19 ``                                                                      |
| [`380864c4`](https://github.com/NixOS/nixpkgs/commit/380864c4389961fe2d874005eaeb359bf5ba44c0) | `` libretro.fbneo: unstable-2024-08-09 -> unstable-2024-08-17 ``                                        |
| [`745c7c01`](https://github.com/NixOS/nixpkgs/commit/745c7c0165048f8108543f619ce46b160754503c) | `` qdiskinfo: suffix smartmontools ``                                                                   |
| [`36260d59`](https://github.com/NixOS/nixpkgs/commit/36260d596afa6db2d7ba807a69b567fbddb51d31) | `` libretro.mame2003-plus: unstable-2024-08-08 -> unstable-2024-08-18 ``                                |
| [`de2d1ba8`](https://github.com/NixOS/nixpkgs/commit/de2d1ba867af46fdf048fea72561de1579794cf8) | `` xen-guest-agent: 0.3.0 -> 0.4.0-unstable-2024-05-31 ``                                               |
| [`d50d09a7`](https://github.com/NixOS/nixpkgs/commit/d50d09a74719b2fe2795198cd07f7453edb6e8d7) | `` xen-guest-agent: format with nixfmt-rfc-style ``                                                     |
| [`2d51a4d3`](https://github.com/NixOS/nixpkgs/commit/2d51a4d3062f63a0c6f164e9772e98c4f1b99d20) | `` xen-guest-agent: move to by-name ``                                                                  |
| [`88bdd6b3`](https://github.com/NixOS/nixpkgs/commit/88bdd6b316fda075c28b8174a9fee654a710ada7) | `` libretro.mame2003: unstable-2024-08-08 -> unstable-2024-08-18 ``                                     |
| [`12f2a32f`](https://github.com/NixOS/nixpkgs/commit/12f2a32fdefb24c4000f4635222bbe76dc688969) | `` libretro.beetle-supergrafx: unstable-2024-08-09 -> unstable-2024-08-16 ``                            |
| [`02a1f8bf`](https://github.com/NixOS/nixpkgs/commit/02a1f8bf702a8f0f881d8ad63eb01f46fe6f342a) | `` python3Packages.xformers: enable parallel build ``                                                   |
| [`90bea001`](https://github.com/NixOS/nixpkgs/commit/90bea0017c38b4bf160acdb8d87922ddaa6b49d1) | `` libretro.pcsx-rearmed: unstable-2024-07-24 -> unstable-2024-08-16 ``                                 |
| [`9437db7f`](https://github.com/NixOS/nixpkgs/commit/9437db7f9afe5218ef55e3a5d8b2b24b1e6a561c) | `` libretro.beetle-psx-hw: unstable-2024-08-09 -> unstable-2024-08-16 ``                                |
| [`92dd9941`](https://github.com/NixOS/nixpkgs/commit/92dd99415769ead9d0407729c00d0517f15857f6) | `` libretro.beetle-pce-fast: unstable-2024-08-09 -> unstable-2024-08-16 ``                              |
| [`96745790`](https://github.com/NixOS/nixpkgs/commit/9674579019512975587820fea0ada9c8b30099e0) | `` libretro.mupen64plus: unstable-2024-07-19 -> unstable-2024-08-13 ``                                  |
| [`dfe7b7d8`](https://github.com/NixOS/nixpkgs/commit/dfe7b7d8b036d58ef168ba0f172d0d0c723fb567) | `` python312Packages.cvxpy: 1.5.2 -> 1.5.3 ``                                                           |
| [`e921b41e`](https://github.com/NixOS/nixpkgs/commit/e921b41e2a8f0f88c8fd936c4c9b3fe053321ae5) | `` python312Packages.moderngl: switch to pypa build ``                                                  |
| [`ed57c015`](https://github.com/NixOS/nixpkgs/commit/ed57c01589255f3474cb9195085e33806791b43d) | `` python312Packages.moderngl: 5.10.0 -> 5.11.1 ``                                                      |
| [`ed927408`](https://github.com/NixOS/nixpkgs/commit/ed9274081836aaa3befac122e3ad6c84266354cf) | `` uv: format with nixfmt ``                                                                            |
| [`03605dfc`](https://github.com/NixOS/nixpkgs/commit/03605dfc818cdd9c91513e678db3693566e8c116) | `` mesonlsp: 4.3.2 -> 4.3.3 ``                                                                          |