### PR TITLE
chore(flake/nixvim): `312db6b6` -> `851edc8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724036242,
-        "narHash": "sha256-/+gGF0tsAg2dF7Ds9Yt9Sne7ETmILKz1QVnDr+T2S2g=",
+        "lastModified": 1724188973,
+        "narHash": "sha256-JaP6B9kjXccjRp/7CY2QPSSMarjPJMB0vytfqBdJU7E=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "312db6b6e2d98dd8d22223fe383c7e0b4bab60c6",
+        "rev": "851edc8df1347aef556a646c80d469a3137331ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`851edc8d`](https://github.com/nix-community/nixvim/commit/851edc8df1347aef556a646c80d469a3137331ba) | `` lib/modules: add `evalNixvim` ``                                                  |
| [`bc7a7ad1`](https://github.com/nix-community/nixvim/commit/bc7a7ad1d674a332555c8fc299adf194804c49ed) | `` module/outputs: use `mkIf` for `wrapRc` ``                                        |
| [`6975ee09`](https://github.com/nix-community/nixvim/commit/6975ee09f55b4a1518b76a31e3c9fe5b7618d3f3) | `` modules/outputs: make `type` readOnly at the top-level ``                         |
| [`c4fcbb0d`](https://github.com/nix-community/nixvim/commit/c4fcbb0dcf153a8bac18d5aced9f8c025c74a66d) | `` modules/context: add `isTopLevel` option ``                                       |
| [`cb413995`](https://github.com/nix-community/nixvim/commit/cb413995e1e101c76d755b7f131ce60c7ea3985d) | `` plugins/todo-comments: migrate keymaps to mkMapOptionSubmodule ``                 |
| [`39081a41`](https://github.com/nix-community/nixvim/commit/39081a41067a7bdb66f6f85a3fee9693ff8a21b1) | `` tests/plugins/lsp: re-enable vala-ls on linux ``                                  |
| [`9a218fed`](https://github.com/nix-community/nixvim/commit/9a218fed3127d5c3da8a0f081be81a66dd7429b5) | `` tests/plugins/none-ls: re-enable d2_fmt and yamlfix ``                            |
| [`366f2559`](https://github.com/nix-community/nixvim/commit/366f25598a4f35f590a6b5887628e763df0eb939) | `` tests/plugins/lsp: re-enable omnisharp on darwin ``                               |
| [`ec9d2991`](https://github.com/nix-community/nixvim/commit/ec9d29918321173c57a5fa8ca5a93106c373d12c) | `` tests/plugins/openscad: re-enable on darwin ``                                    |
| [`a1a34887`](https://github.com/nix-community/nixvim/commit/a1a34887791489d571fd996bbdd772899757a49c) | `` tests/plugins/lsp: disable vscode-langservers-extracted tests (broken package) `` |
| [`f7cdecba`](https://github.com/nix-community/nixvim/commit/f7cdecbad86da43ed1a85586a3e0a50143b60505) | `` tests/plugins/none-ls: disable prisma_format test (broken package) ``             |
| [`a9ffb6c9`](https://github.com/nix-community/nixvim/commit/a9ffb6c9582caacc7a0367f34a16f56f77b105ed) | `` tests/plugins/lsp: disable prismals test (broken package) ``                      |
| [`f62d77d3`](https://github.com/nix-community/nixvim/commit/f62d77d3fa88622ed2ea82a2727756b5b7fea3fd) | `` plugins/lsp: python3Packages.ruff-lsp -> ruff-lsp fallback ``                     |
| [`ec9e5c07`](https://github.com/nix-community/nixvim/commit/ec9e5c071ade143b59cadd885b5b96aa142ef7ef) | `` plugins/markview: remove unnecessary extraPlugin ``                               |
| [`94fb980f`](https://github.com/nix-community/nixvim/commit/94fb980f352fd8c2701faa3a811a9004a5b93691) | `` plugins/yazi: remove unnecessary extraPlugin ``                                   |
| [`460b4799`](https://github.com/nix-community/nixvim/commit/460b47997f534a5c452068b46287bcd5a67d227e) | `` tests/plugins/lsp: disable typst-lsp test (broken package) ``                     |
| [`fc6d40d7`](https://github.com/nix-community/nixvim/commit/fc6d40d798518218bb934e255b62cedd465bd048) | `` tests/plugins/lsp: typst-lsp -> tinymist ``                                       |
| [`b4065751`](https://github.com/nix-community/nixvim/commit/b4065751768e12edf5ca760453f51c799758ad79) | `` plugins/lsp/astro: remove unnecessary alternative package path ``                 |
| [`d3cb90aa`](https://github.com/nix-community/nixvim/commit/d3cb90aa6e1d117270a1c4479a168bff2d5e0348) | `` generated: Updated rust-analyzer.nix ``                                           |
| [`907c249a`](https://github.com/nix-community/nixvim/commit/907c249abad4cd57d74d98411c9e3aef3b88bac7) | `` flake.lock: Update ``                                                             |
| [`123a55ed`](https://github.com/nix-community/nixvim/commit/123a55ed6f8ae2daec76af5a0ee7e495ccb7e884) | `` tests: remove special treatment of `module` ``                                    |
| [`7b2a6cd9`](https://github.com/nix-community/nixvim/commit/7b2a6cd9e62b4c797508104d7f2904468892c63d) | `` tests: `tests.dontRun` -> `test.runNvim` ``                                       |
| [`f47374fd`](https://github.com/nix-community/nixvim/commit/f47374fd268e2c8842dde8cc08f4ab06a6026745) | `` modules/test: init, replacing `dontRun` arg ``                                    |