### PR TITLE
chore(flake/nixvim): `1854d591` -> `4c8d3559`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724340365,
-        "narHash": "sha256-SFJuLI6FpuLHI0PdZAIOAJoeR6Z+cRkbTUQ5TuqJw5s=",
+        "lastModified": 1724455584,
+        "narHash": "sha256-9I5x60BDMcD4NKjw6skIVUzocVDuZlQK52JRsgD54ns=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1854d591cb0e5be6ad97f5091766cdf28e948265",
+        "rev": "4c8d3559ac4548723eeba9861a94ab63219b0d43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`4c8d3559`](https://github.com/nix-community/nixvim/commit/4c8d3559ac4548723eeba9861a94ab63219b0d43) | `` plugins/lightline: migrate to mkNeovimPlugin ``        |
| [`052ee66d`](https://github.com/nix-community/nixvim/commit/052ee66dbb975960cc151db0b5db6a893503582a) | `` docs/mdbook: move description to bottom ``             |
| [`9033f1cf`](https://github.com/nix-community/nixvim/commit/9033f1cf2d46da308cb38e258f82fed2e6da7310) | `` plugins/neotest: fix missing toLuaObject definition `` |