### PR TITLE
chore(flake/nixvim): `4c8d3559` -> `8234ee85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724455584,
-        "narHash": "sha256-9I5x60BDMcD4NKjw6skIVUzocVDuZlQK52JRsgD54ns=",
+        "lastModified": 1724528976,
+        "narHash": "sha256-5W13nD/5ySIsxSvDqXHlj4bg2F3tNcYGKCGudWzpNzw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4c8d3559ac4548723eeba9861a94ab63219b0d43",
+        "rev": "8234ee85eaa2c8b7f2c74f5b4cdf02c4965b07fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`8234ee85`](https://github.com/nix-community/nixvim/commit/8234ee85eaa2c8b7f2c74f5b4cdf02c4965b07fc) | `` tests/plugins/lightline: fix test ``                                      |
| [`89b876dc`](https://github.com/nix-community/nixvim/commit/89b876dc0deb83fb3b3d1773f0cbe59aafb261d4) | `` plugins/conform-nvim: migrate to mkNeovimPlugin ``                        |
| [`a1c7932b`](https://github.com/nix-community/nixvim/commit/a1c7932bdbaa566996d7d7de6afb05b1ddf05fb1) | `` plugins/rustaceanvim: fix checkhealth error with neotest configuration `` |
| [`1e74f3de`](https://github.com/nix-community/nixvim/commit/1e74f3deabefdbc2e5ebc4f49e08950f3c234c20) | `` plugins/lsp: make lspOnAttach available globally ``                       |
| [`8a272143`](https://github.com/nix-community/nixvim/commit/8a272143ee5e862a41ebb7b376bf59055397fac6) | `` modules/opts: move options to top of init.lua ``                          |
| [`203d3181`](https://github.com/nix-community/nixvim/commit/203d31810f2e88335d70e97ab108502927189f24) | `` top-level/output: add global table top of init.lua ``                     |
| [`45081d5f`](https://github.com/nix-community/nixvim/commit/45081d5f21b71b44e292b70c0f64bf9ac898eab8) | `` flake-modules/list-plugins: add extra filters ``                          |
| [`3a04cc75`](https://github.com/nix-community/nixvim/commit/3a04cc75e6d113ec7eb952a0c6cf9068980e9470) | `` flake-modules/dev: add isort ``                                           |
| [`88b1e6a3`](https://github.com/nix-community/nixvim/commit/88b1e6a369a172b46589ec45bfb2ac01bfb77705) | `` flake.lock: Update ``                                                     |
| [`b10ccc52`](https://github.com/nix-community/nixvim/commit/b10ccc5250c17d3f48e6226ed56d8641eb4f3c6f) | `` docs: fix markdown issue with tree-sitter docs ``                         |
| [`f4dd8924`](https://github.com/nix-community/nixvim/commit/f4dd8924b189f2ec1c00577b4168ed9c5919d65e) | `` docs: document how to install custom tree-sitter grammars ``              |
| [`1181535e`](https://github.com/nix-community/nixvim/commit/1181535e34e433775ec3dbe962e50b1ebf85d44e) | `` plugins/lsp/extensions: remove `with lib` + fix `mkRaw` reference ``      |