### PR TITLE
chore(flake/nixvim): `8234ee85` -> `eac092c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724528976,
-        "narHash": "sha256-5W13nD/5ySIsxSvDqXHlj4bg2F3tNcYGKCGudWzpNzw=",
+        "lastModified": 1724710305,
+        "narHash": "sha256-qotbY/mgvykExLqRLAKN4yeufPfIjnMaK6hQQFhE2DE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8234ee85eaa2c8b7f2c74f5b4cdf02c4965b07fc",
+        "rev": "eac092c876e4c4861c6df0cff93e25b972b1842c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`eac092c8`](https://github.com/nix-community/nixvim/commit/eac092c876e4c4861c6df0cff93e25b972b1842c) | `` readme: fix incorrect demo configuration ``               |
| [`7e3ed24e`](https://github.com/nix-community/nixvim/commit/7e3ed24e52e2d400b84b22524cba987a495a3f24) | `` plugins/lint: fix inconsistent description + examples ``  |
| [`9af4c397`](https://github.com/nix-community/nixvim/commit/9af4c3970c13c4508f5f724e2a6a315ba5ba88e3) | `` tests: fix tests by enabling `wrapRc` ``                  |
| [`fa205897`](https://github.com/nix-community/nixvim/commit/fa2058970c90bc636454e8d172aed5b43547507c) | `` lib/tests.nix: fix infinite recursion in args ``          |
| [`665680a5`](https://github.com/nix-community/nixvim/commit/665680a5caeb57ff73e0a112ac805f5456f2a91d) | `` plugins/lint: fix conform incorrect option description `` |
| [`aa1f5a74`](https://github.com/nix-community/nixvim/commit/aa1f5a74ffa348d4cf4ffc32792b901a0699da00) | `` plugins/comment-box-nvim: init ``                         |
| [`45bb6636`](https://github.com/nix-community/nixvim/commit/45bb6636e5e3d4903c321cd8019bb403570a68ee) | `` tests/lsp: re-enable typst-lsp ``                         |
| [`d0564ce4`](https://github.com/nix-community/nixvim/commit/d0564ce4cfd3d9eff700de66b86b943326b41946) | `` tests/example-configuration: re-enable jsonls ``          |
| [`9673ea70`](https://github.com/nix-community/nixvim/commit/9673ea70f429ba396e7f2e1fef27b6647ed86b88) | `` flake.lock: Update ``                                     |
| [`bb8ecad1`](https://github.com/nix-community/nixvim/commit/bb8ecad13c229e1c89301055c8e54d8d0e33e839) | `` plugins/nvim-jdtls: allow lua on nvim-jdtls.data ``       |