### PR TITLE
chore(flake/nixvim): `eac092c8` -> `48141474`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724710305,
-        "narHash": "sha256-qotbY/mgvykExLqRLAKN4yeufPfIjnMaK6hQQFhE2DE=",
+        "lastModified": 1724800090,
+        "narHash": "sha256-7KxGFZ40pidca5gcdI2weGanfB74yDxrErFNElOZWqA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "eac092c876e4c4861c6df0cff93e25b972b1842c",
+        "rev": "4814147442cd3f12f8160ecad9e36751f68cdc22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`48141474`](https://github.com/nix-community/nixvim/commit/4814147442cd3f12f8160ecad9e36751f68cdc22) | `` modules/test: add `config` and `options` passthrus `` |
| [`af310635`](https://github.com/nix-community/nixvim/commit/af31063538fa20d0bbd9460a1147a69e75032909) | `` modules/test: switch to `runCommand` ``               |
| [`1085bcd7`](https://github.com/nix-community/nixvim/commit/1085bcd7ccf561577ff52dba76b1cb8d35f2c124) | `` plugins/which-key: fix icon examples ``               |
| [`60ea38d2`](https://github.com/nix-community/nixvim/commit/60ea38d2c450537eb2adadff9527c8d0db6f9fea) | `` tests: test the tests ``                              |