### PR TITLE
chore(flake/treefmt-nix): `070f8347` -> `3ffd842a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724338379,
-        "narHash": "sha256-kKJtaiU5Ou+e/0Qs7SICXF22DLx4V/WhG1P6+k4yeOE=",
+        "lastModified": 1724833132,
+        "narHash": "sha256-F4djBvyNRAXGusJiNYInqR6zIMI3rvlp6WiKwsRISos=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "070f834771efa715f3e74cd8ab93ecc96fabc951",
+        "rev": "3ffd842a5f50f435d3e603312eefa4790db46af5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                         |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`3ffd842a`](https://github.com/numtide/treefmt-nix/commit/3ffd842a5f50f435d3e603312eefa4790db46af5) | `` feat(programs): add fish_indent (#199) ``                    |
| [`eb283bca`](https://github.com/numtide/treefmt-nix/commit/eb283bca8b2bac3634747eafcaa57ebd71e2cdcb) | `` globally ignore go.mod/go.sum (#222) ``                      |
| [`0b9a6936`](https://github.com/numtide/treefmt-nix/commit/0b9a69360f18b7da94ee2c4395eb025901a62f29) | `` chore(ruff): split into ruff-format and ruff-check (#213) `` |