### PR TITLE
chore(flake/nixpkgs): `d0e1602d` -> `71e91c40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724479785,
-        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
+        "lastModified": 1724819573,
+        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`71e91c40`](https://github.com/NixOS/nixpkgs/commit/71e91c409d1e654808b2621f28a327acfdad8dc2) | `` ananicy-rules-cachyos: 0-unstable-2024-07-27 -> 0-unstable-2024-08-26 (#337863) `` |
| [`6a3ccb0d`](https://github.com/NixOS/nixpkgs/commit/6a3ccb0d744f2ef51fe27a593b11a95bdc3577aa) | `` maa-cli: 0.4.11 -> 0.4.12 ``                                                       |
| [`9cb3abed`](https://github.com/NixOS/nixpkgs/commit/9cb3abed2df59fb093f40b88c5603814cb542a91) | `` meteor-git: 0.22.0 -> 0.23.0 ``                                                    |
| [`d3c10bb4`](https://github.com/NixOS/nixpkgs/commit/d3c10bb4a8e5400d5e1404d8e915e1577ff46ec3) | `` mosdepth: 0.3.8 -> 0.3.9 ``                                                        |
| [`36f56cf8`](https://github.com/NixOS/nixpkgs/commit/36f56cf802b5bcf84a4088d5e1e55424d70b6631) | `` uv: 0.3.3 -> 0.3.5 ``                                                              |
| [`329316ce`](https://github.com/NixOS/nixpkgs/commit/329316ce755723ae06e0afb2ff52202a56003351) | `` python312Packages.langchain-aws: 0.1.16 -> 0.1.17 ``                               |
| [`2b2bd543`](https://github.com/NixOS/nixpkgs/commit/2b2bd5438c70ce79d1f2fa16dead809fdbf35158) | `` gdb: support aarch64-darwin as a hostPlatform ``                                   |
| [`e47a32e1`](https://github.com/NixOS/nixpkgs/commit/e47a32e1f59119a7477a412cfff1e7650c7f7522) | `` eaglemode: add runtime deps for file archives ``                                   |
| [`ce8769f7`](https://github.com/NixOS/nixpkgs/commit/ce8769f7da1ca7b09ca5ee92d05d34f1c0f53cbb) | `` eaglemode: add missing htmldoc runtime dependency ``                               |
| [`43fae4b2`](https://github.com/NixOS/nixpkgs/commit/43fae4b2424e281fc0abe98ef8654bb0f59c5c2c) | `` eaglemode: 0.96.1 -> 0.96.2 ``                                                     |
| [`87da5b40`](https://github.com/NixOS/nixpkgs/commit/87da5b40457d5d73d041dd858da804b0e2cd8cda) | `` eaglemode: apply new RFC formatting ``                                             |
| [`b41c7a02`](https://github.com/NixOS/nixpkgs/commit/b41c7a0208b80e216e441d9d355b3001bc1ba424) | `` renovate: 38.46.2 -> 38.55.4 ``                                                    |
| [`422d214c`](https://github.com/NixOS/nixpkgs/commit/422d214c1422814058968350afe3bda6577b3a76) | `` hydra_unstable: Fix CVE-2024-45049 ``                                              |
| [`3f4ecf8a`](https://github.com/NixOS/nixpkgs/commit/3f4ecf8adcf1d9da54e50ebcc7c84d722d2131c8) | `` python3Packages.nanobind: 2.0.0 -> 2.1.0 ``                                        |
| [`56864b3b`](https://github.com/NixOS/nixpkgs/commit/56864b3bb6b01e52cbe797908e6916e9fd93aeaf) | `` python312Packages.multiset: refactor ``                                            |
| [`7c1649c4`](https://github.com/NixOS/nixpkgs/commit/7c1649c4e7165d866e627d23bf33f00266df8718) | `` python312Packages.multiset: add changelog to meta ``                               |
| [`4ed84fdc`](https://github.com/NixOS/nixpkgs/commit/4ed84fdc4263137567d828ff73baeb071ae8b628) | `` python312Packages.pyexploitdb: 0.2.31 -> 0.2.32 ``                                 |
| [`6d0d5910`](https://github.com/NixOS/nixpkgs/commit/6d0d591025088efbf036d368b4bef25bb4e55438) | `` python312Packages.jsonargparse: 4.32.0 -> 4.32.1 ``                                |
| [`363df5ad`](https://github.com/NixOS/nixpkgs/commit/363df5ad86ddad600a69694d472b1328c53ac9ab) | `` nixos/sddm: add layer-shell-qt to the wrapper when kwin is used ``                 |
| [`f6896e57`](https://github.com/NixOS/nixpkgs/commit/f6896e5787d61004c92b96b8fb61c3064cce349b) | `` avrdude: 7.3 -> 8.0 ``                                                             |
| [`094e80f6`](https://github.com/NixOS/nixpkgs/commit/094e80f6ff07705d9f4ace748029265647eeb4df) | `` nixos/sddm: don't set kwin related config if Wayland isn't enabled ``              |
| [`0dfb94db`](https://github.com/NixOS/nixpkgs/commit/0dfb94dbdf05f5dbf7918533e9cf3d0d970e3014) | `` nixos/sddm: remove LANG=C.UTF-8 ``                                                 |
| [`a6a44e0d`](https://github.com/NixOS/nixpkgs/commit/a6a44e0de9a7b4f227641c87fdab2e5cc9d4815c) | `` cargo-leptos: 0.2.18 -> 0.2.20 ``                                                  |
| [`fec78fd6`](https://github.com/NixOS/nixpkgs/commit/fec78fd61d13ca28848c9646b83b097ecc14dbce) | `` python312Packages.libknot: 3.3.8 -> 3.3.9 ``                                       |
| [`4f882c8b`](https://github.com/NixOS/nixpkgs/commit/4f882c8b876cdd1e7d60263d484e47bb278a6c3b) | `` prometheus-knot-exporter: 3.3.8 -> 3.3.9 ``                                        |
| [`7b92e73b`](https://github.com/NixOS/nixpkgs/commit/7b92e73b2fafec3c81c983207f152e68aa1e7872) | `` nbqa: format with nixfmt ``                                                        |
| [`576e7101`](https://github.com/NixOS/nixpkgs/commit/576e710170ee4adf57c4f1d1bc58efd9d4e2d3e7) | `` nbqa: move to pkgs/by-name ``                                                      |
| [`7910f748`](https://github.com/NixOS/nixpkgs/commit/7910f748bfba559dc1e85ede7a907d00eb5cd67c) | `` nbqa: 1.8.7 -> 1.9.0 ``                                                            |
| [`ca77410a`](https://github.com/NixOS/nixpkgs/commit/ca77410a1d6beb8033368de5264acba1e2594f7e) | `` kodiPackages.youtube: 7.0.9 -> 7.0.9.2 ``                                          |
| [`69017878`](https://github.com/NixOS/nixpkgs/commit/69017878bf3739e04116d7c05979dc2523557616) | `` router: 1.52.0 -> 1.52.1 ``                                                        |
| [`e34f6f44`](https://github.com/NixOS/nixpkgs/commit/e34f6f4457df91e6bbdf66e652bdb84f3b29c10f) | `` aegisub: change --replace to --replace-fail ``                                     |
| [`68278df4`](https://github.com/NixOS/nixpkgs/commit/68278df416fdbfd02b514fd9f4557b81ee6a5898) | `` python312Packages.aioesphomeapi: 25.1.0 -> 25.2.1 (#337716) ``                     |
| [`f54df8a2`](https://github.com/NixOS/nixpkgs/commit/f54df8a2e9703e9f7b3467a3d488e4b393175420) | `` python312Packages.cyclopts: 2.9.7 -> 2.9.8 ``                                      |
| [`90f43215`](https://github.com/NixOS/nixpkgs/commit/90f4321519d270b495a79c240642900a6f034ede) | `` python312Packages.dirigera: 1.1.7 -> 1.1.8 ``                                      |
| [`f33eea32`](https://github.com/NixOS/nixpkgs/commit/f33eea32b2a11fdffb4a0fc8c75d313f522f48ea) | `` python312Packages.multiset: 3.1.0 -> 3.2.0 ``                                      |
| [`11985737`](https://github.com/NixOS/nixpkgs/commit/11985737dc144ba10f7a10d62d223b184d346234) | `` coqPackages.waterproof: init at 2.1.1+8.18 ``                                      |
| [`e6566050`](https://github.com/NixOS/nixpkgs/commit/e6566050f1bfdb1ff76701fc226a23609b131a9a) | `` cnspec: 11.18.0 -> 11.19.0 ``                                                      |
| [`3a35f2fc`](https://github.com/NixOS/nixpkgs/commit/3a35f2fcdb021caad5d0cf496159f35948629634) | `` maintainers: fix matrix address of blitz ``                                        |
| [`68a8df19`](https://github.com/NixOS/nixpkgs/commit/68a8df19a08078cebab5ea195aea4c45cc0e8272) | `` mdbook-alerts: 0.6.3 -> 0.6.4 ``                                                   |
| [`f442c0ab`](https://github.com/NixOS/nixpkgs/commit/f442c0ab52958c07540c14d7a3fdcc15980d0a97) | `` yandex-music: init at 5.13.2 ``                                                    |
| [`4a791bd5`](https://github.com/NixOS/nixpkgs/commit/4a791bd5d46a4bf4e531a3007e4e782e969b4b25) | `` zed-editor: 0.149.5 -> 0.149.6 ``                                                  |
| [`a1f7e3d1`](https://github.com/NixOS/nixpkgs/commit/a1f7e3d10e8c3ce6b983a677516e2c62ddef33ba) | `` nixos/invidious: remove machine.config in test ``                                  |
| [`4d3a22cf`](https://github.com/NixOS/nixpkgs/commit/4d3a22cf1c3b158ee1ea32bad686a63a26ca8ea2) | `` invidious: 2.20240427 -> 2.20240825.2 ``                                           |
| [`dd35b08c`](https://github.com/NixOS/nixpkgs/commit/dd35b08c36274ab70dce7197a89b0333c8751314) | `` gatus: 5.11.0 -> 5.12.0 ``                                                         |
| [`4992478d`](https://github.com/NixOS/nixpkgs/commit/4992478d6e8c9a5ad45eae6223c843804d7ef0ad) | `` amazon-ssm-agent: 3.3.551.0 -> 3.3.808.0 ``                                        |
| [`98ce61be`](https://github.com/NixOS/nixpkgs/commit/98ce61be576896913274454adf9506d15d1e63f7) | `` nixos/smokeping: do homedir management with systemd.tmpfiles (#332050) ``          |
| [`004e38bd`](https://github.com/NixOS/nixpkgs/commit/004e38bd5b4240652aa63faed831f2c1adb7f78c) | `` python3Packages.pytouchlinesl: 0.1.3 -> 0.1.5 ``                                   |
| [`e0d326ec`](https://github.com/NixOS/nixpkgs/commit/e0d326ec15014957c19da2fa0d48479d9e052bb2) | `` python312Packages.litellm: 1.42.12 -> 1.44.7 ``                                    |
| [`31c4c52f`](https://github.com/NixOS/nixpkgs/commit/31c4c52f76f59870d7aa65c1b73dc0ef1e728101) | `` opshin: 0.22.0 -> 0.23.0 ``                                                        |
| [`4b417eb2`](https://github.com/NixOS/nixpkgs/commit/4b417eb22b6f3a7272e746d3f0c31d22d3b1d597) | `` nixos/ollama: fix `rocmOverrideGfx` description ``                                 |
| [`56fab16f`](https://github.com/NixOS/nixpkgs/commit/56fab16fa9ed795637b96cdd5688d58cf178f46a) | `` syndicate-server: init 0.46.0 ``                                                   |
| [`51265569`](https://github.com/NixOS/nixpkgs/commit/51265569687ef6af8e82f6af608afee5942277b5) | `` warp-terminal: 0.2024.08.13.08.02.stable_04 -> 0.2024.08.20.08.02.stable_00 ``     |
| [`658984c6`](https://github.com/NixOS/nixpkgs/commit/658984c6e52b6969107a76a56cc77211bc55d175) | `` melonDS: 0.9.5-unstable-2024-08-19 -> 0.9.5-unstable-2024-08-21 ``                 |
| [`06f5514c`](https://github.com/NixOS/nixpkgs/commit/06f5514c2e113976ecfbc0145931b7d2e3887f23) | `` minio: 2024-08-17T01-24-54Z -> 2024-08-26T15-33-07Z ``                             |
| [`ae82befc`](https://github.com/NixOS/nixpkgs/commit/ae82befc9a567c7ef6b02b98b78483fb5ed8da01) | `` minio-client: 2024-08-17T11-33-50Z -> 2024-08-26T10-49-58Z ``                      |
| [`1c17f115`](https://github.com/NixOS/nixpkgs/commit/1c17f115578a15feb0d4cfd7b85b7f595374d32d) | `` immich-go: 1.21.3 -> 0.22.0 ``                                                     |
| [`9dc74ba4`](https://github.com/NixOS/nixpkgs/commit/9dc74ba4dc523f2a24aeda27baf6cd680d91d869) | `` k3s: Add frederictobiasc as maintainer ``                                          |
| [`03c1c48e`](https://github.com/NixOS/nixpkgs/commit/03c1c48e009ca1bb0806394544f16134629e2ae6) | `` checkov: 3.2.235 -> 3.2.236 ``                                                     |
| [`1a638589`](https://github.com/NixOS/nixpkgs/commit/1a638589b3d740a711ee5fb44f81831267752b27) | `` coqPackages.bbv: init at 1.5 ``                                                    |
| [`0cc19354`](https://github.com/NixOS/nixpkgs/commit/0cc19354e5b30230f6ec9d84a20f81f617d13239) | `` manga-tui: 0.2.0 -> 0.3.1 ``                                                       |
| [`59bd948e`](https://github.com/NixOS/nixpkgs/commit/59bd948ea0b818648a139d7615c17dea6bf5955c) | `` video-trimmer: add aleksana to maintainers ``                                      |
| [`295e1e95`](https://github.com/NixOS/nixpkgs/commit/295e1e95bc0dbeacc7dc355a2f150527759338d7) | `` video-trimmer: 0.8.1 -> 0.8.2 ``                                                   |
| [`f6c473d1`](https://github.com/NixOS/nixpkgs/commit/f6c473d14c8a787bf3fe12a44a156bd9b13ecec7) | `` video-trimmer: format with nixfmt-rfc-style ``                                     |
| [`f270e985`](https://github.com/NixOS/nixpkgs/commit/f270e98590b7f888e3be2a4d8ddc73dd2dad8736) | `` video-trimmer: move to pkgs/by-name ``                                             |
| [`ad0d3064`](https://github.com/NixOS/nixpkgs/commit/ad0d30646d4993f5bf367d931fa1c30b0e8e951e) | `` python312Packages.tencentcloud-sdk-python: 3.0.1218 -> 3.0.1219 ``                 |
| [`25ad5d0f`](https://github.com/NixOS/nixpkgs/commit/25ad5d0fba00dcc42d992b56ec089ab68df79d4d) | `` python312Packages.tencentcloud-sdk-python: 3.0.1216 -> 3.0.1218 ``                 |
| [`e0bbb1e3`](https://github.com/NixOS/nixpkgs/commit/e0bbb1e39bb5fd0cd095bc5994144279795bb5a8) | `` circleci-cli: 0.1.30888 -> 0.1.30995 ``                                            |
| [`134b2413`](https://github.com/NixOS/nixpkgs/commit/134b24130981ce6ecbf45021d707a73f386dc288) | `` nbfc-linux: 0.1.15 -> 0.2.7 ``                                                     |
| [`e8dd7856`](https://github.com/NixOS/nixpkgs/commit/e8dd7856cfbcb11fe754b6e103dc54f9445aec0e) | `` sgt-puzzles: 20240817.262f709 -> 20240827.52afffa ``                               |
| [`9d9da2f2`](https://github.com/NixOS/nixpkgs/commit/9d9da2f273e86af1d304e543d816ec34e64c4317) | `` wayfirePlugins.wcm: 0.8.0 -> 0.9.0 ``                                              |
| [`9a8c62f8`](https://github.com/NixOS/nixpkgs/commit/9a8c62f8412f4b2618de9a9bf14af5dbc576e5dd) | `` ast-grep: 0.24.1 -> 0.26.3 ``                                                      |
| [`183a78cb`](https://github.com/NixOS/nixpkgs/commit/183a78cb566b1c1595fb42a4e18e6f95d12930d5) | `` nixos/gitwatch: add module ``                                                      |
| [`bd1a1505`](https://github.com/NixOS/nixpkgs/commit/bd1a15057c89902e2e9663dd448688616fb9ff56) | `` gitwatch: init at v0.2 ``                                                          |
| [`f71eb566`](https://github.com/NixOS/nixpkgs/commit/f71eb566279f7e8f19bb12566ee754daa46bb282) | `` maintainers: add shved ``                                                          |
| [`094dcc1a`](https://github.com/NixOS/nixpkgs/commit/094dcc1a28793453829a94be4336b9b07822226e) | `` wdt: 1.27.1612021-unstable-2024-08-14 -> 1.27.1612021-unstable-2024-08-22 ``       |
| [`5b8ca119`](https://github.com/NixOS/nixpkgs/commit/5b8ca11960b1da1b4d4e2cea635fd15348b7afa3) | `` faircamp: 0.15.0 -> 0.15.1 ``                                                      |
| [`9d00f765`](https://github.com/NixOS/nixpkgs/commit/9d00f765b4b4b1f7cdf165ba4ba429606201aaa3) | `` md-tui: 0.8.4 -> 0.8.5 ``                                                          |
| [`246071ae`](https://github.com/NixOS/nixpkgs/commit/246071ae1da23bafcdcf612522635c585512a88b) | `` spyder: 5.5.5 -> 5.5.6 ``                                                          |
| [`709b1eb5`](https://github.com/NixOS/nixpkgs/commit/709b1eb5190b5cd709712f87cf27df9e9d1b130a) | `` python312Packages.python-lsp-server: 1.11.0 -> 1.12.0 ``                           |
| [`deb423b0`](https://github.com/NixOS/nixpkgs/commit/deb423b04d5ab6a43990f10094daa59d68954013) | `` python312Packages.qstylizer: 0.2.2 -> 0.2.3 ``                                     |
| [`fe368349`](https://github.com/NixOS/nixpkgs/commit/fe368349231df04eeb3bd116d2f6f9cf71246143) | `` python312Packages.homeassistant-stubs: 2024.8.2 -> 2024.8.3 ``                     |
| [`eb259987`](https://github.com/NixOS/nixpkgs/commit/eb25998735e7adda47db1e7e341262b346391d76) | `` mympd: 17.0.1 -> 17.0.3 ``                                                         |
| [`2c32d3f6`](https://github.com/NixOS/nixpkgs/commit/2c32d3f65ed0b48015a4f24070af56633c99ff55) | `` invidious: fix update script ``                                                    |
| [`104f4ee0`](https://github.com/NixOS/nixpkgs/commit/104f4ee0b65e4966419572171f9f8c567af99d8b) | `` kubectl-evict-pod: 0.0.13 -> 0.0.14 ``                                             |
| [`54b3dbc1`](https://github.com/NixOS/nixpkgs/commit/54b3dbc11a2e8970500fd151fd03d62cbe2bb634) | `` govc: 0.40.0 -> 0.42.0 ``                                                          |
| [`98648422`](https://github.com/NixOS/nixpkgs/commit/98648422e8a3a57f55109c51acdd795d40183949) | `` signal-desktop: replace unlicensed Apple emoji ``                                  |
| [`8bd7a3b3`](https://github.com/NixOS/nixpkgs/commit/8bd7a3b3b1e0955b60c1a724653cfd8fb77dcdbe) | `` signal-desktop: add myself to maintainers ``                                       |
| [`b857e318`](https://github.com/NixOS/nixpkgs/commit/b857e3185706eef17f925e6a7cb7783d87efe751) | `` invidious: switch to github repo ``                                                |
| [`780a7d3f`](https://github.com/NixOS/nixpkgs/commit/780a7d3fe0162bdd6fc996844189bd6ee536f26b) | `` eris-go: 20240128 -> 20240826 ``                                                   |
| [`f5b732e9`](https://github.com/NixOS/nixpkgs/commit/f5b732e9bf207a4812e354e3401acb48b696c911) | `` nixos/eris-server: update comment ``                                               |
| [`5ce13502`](https://github.com/NixOS/nixpkgs/commit/5ce13502b2a525fa8169a7e1cabdbb8ad7e8c58e) | `` python312Packages.langfuse: 2.43.3 -> 2.44.1 ``                                    |
| [`edbeaa80`](https://github.com/NixOS/nixpkgs/commit/edbeaa802c41dcee9d6e43c68f3cfb4f4759d642) | `` emacsPackages.consult-gh: set ignoreCompilationError to false ``                   |
| [`b7881a15`](https://github.com/NixOS/nixpkgs/commit/b7881a15ff43c650499eafd3b02717814ddef8a4) | `` emacsPackages.consult-gh: 1.0-unstable-2024-08-11 -> 1.0-unstable-2024-08-24 ``    |
| [`5ac1c03a`](https://github.com/NixOS/nixpkgs/commit/5ac1c03aceb9b883c7481c996ce92ba8872d119e) | `` python311Packages.soapysdr: unpin swig ``                                          |
| [`d7f277bf`](https://github.com/NixOS/nixpkgs/commit/d7f277bf85dedc5057b9ad7d6df87f1f7d73e8cf) | `` fityk: unpin swig3 ``                                                              |
| [`d73f94b8`](https://github.com/NixOS/nixpkgs/commit/d73f94b82e6118a3c3d113d6029b29a4e0c61235) | `` helm-ls: 0.0.21 -> 0.0.22 ``                                                       |
| [`cdc4bf28`](https://github.com/NixOS/nixpkgs/commit/cdc4bf28e4eddf5f3909a3a55ee354c539933246) | `` ghauri: 1.3.5 -> 1.3.7 ``                                                          |
| [`c087b371`](https://github.com/NixOS/nixpkgs/commit/c087b3711719c0948e27cf615aefa913cea70ad5) | `` clusterctl: 1.8.0 -> 1.8.1 ``                                                      |
| [`eaf6828e`](https://github.com/NixOS/nixpkgs/commit/eaf6828e90c73e5b9ec80e1f54e863120e8e9cff) | `` chamber: 3.0.1 -> 3.1.0 ``                                                         |
| [`38486e07`](https://github.com/NixOS/nixpkgs/commit/38486e07e86132ab8c2ef345cec6b8dcb29f8e80) | `` cirrus-cli: 0.122.2 -> 0.122.4 ``                                                  |
| [`3048112a`](https://github.com/NixOS/nixpkgs/commit/3048112aaf54882090a2388b0c3148df02eb31ec) | `` lubelogger: 1.3.5 -> 1.3.6 ``                                                      |
| [`8568b8e4`](https://github.com/NixOS/nixpkgs/commit/8568b8e4f0883178bf3d2e2fa3011d3d2cb9d2f0) | `` python312Packages.recipe-scrapers: 15.0.0 -> 15.1.0 ``                             |
| [`fd8a665d`](https://github.com/NixOS/nixpkgs/commit/fd8a665d2331675b8cac87972283fc09849b823d) | `` downonspot: 0.5.1 -> 0.6.0 ``                                                      |
| [`f6efc3ba`](https://github.com/NixOS/nixpkgs/commit/f6efc3bad94139f629db8ac9fa932c896320811d) | `` python312Packages.aiovlc: 0.4.2 -> 0.4.3 ``                                        |
| [`b7060332`](https://github.com/NixOS/nixpkgs/commit/b70603325285183c4c73843036f901dbe6420c1e) | `` railway: 3.12.2 -> 3.13.0 ``                                                       |
| [`1f237fc5`](https://github.com/NixOS/nixpkgs/commit/1f237fc5a0c916fab784ef2a43b0ad373dfd5a99) | `` rapidyaml: 0.7.1 -> 0.7.2 ``                                                       |
| [`775af7d1`](https://github.com/NixOS/nixpkgs/commit/775af7d1ef3cfc758d18159cdadded3db5deee0c) | `` python312Packages.qdrant-client: 1.11.0 -> 1.11.1 ``                               |
| [`220bfd1a`](https://github.com/NixOS/nixpkgs/commit/220bfd1a190f21d59d882892e4f2ee4ce668c613) | `` pretix: 2024.7.0 -> 2024.7.1 ``                                                    |
| [`6dc98f93`](https://github.com/NixOS/nixpkgs/commit/6dc98f933df9a7f48513edf188ea1055ad2409e3) | `` vcmi: 1.5.6 -> 1.5.7 ``                                                            |
| [`1969657e`](https://github.com/NixOS/nixpkgs/commit/1969657e76c4e6a96c55a44876509d15c9a2cc58) | `` python312Packages.tesserocr: 2.7.0 -> 2.7.1 ``                                     |
| [`88dc8089`](https://github.com/NixOS/nixpkgs/commit/88dc8089162bf0cd1d79679b8b9e365ed98292b4) | `` python312Packages.nextdns: 3.1.0 -> 3.2.0 ``                                       |
| [`4ef4389a`](https://github.com/NixOS/nixpkgs/commit/4ef4389aa4b57b1a272e9099200166b69f9dd479) | `` rcp: 0.11.0 -> 0.12.0 ``                                                           |
| [`6335206b`](https://github.com/NixOS/nixpkgs/commit/6335206bea61f9e671c63ee9a5d9994e8aaf8a0d) | `` glasskube: 0.16.0 -> 0.17.0 ``                                                     |