### PR TITLE
chore(flake/flake-parts): `8471fe90` -> `af510d4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1725024810,
+        "narHash": "sha256-ODYRm8zHfLTH3soTFWE452ydPYz2iTvr9T8ftDMUQ3E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "af510d4a62d071ea13925ce41c95e3dec816c01d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                             |
| -------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`f112e301`](https://github.com/hercules-ci/flake-parts/commit/f112e301b33a8c0fbe7f65eac7a793e2dd8d3bf6) | `` Fix test ``                                      |
| [`1728089f`](https://github.com/hercules-ci/flake-parts/commit/1728089f3e8a28df678f60cc52cff4219ade477d) | `` flakeModules.partitions: Improve and fix docs `` |
| [`1957ef2c`](https://github.com/hercules-ci/flake-parts/commit/1957ef2c4ba04e213c59380a19e46c9fcee38d0e) | `` Dogfood flakeModules.partitions ``               |
| [`0d5122e8`](https://github.com/hercules-ci/flake-parts/commit/0d5122e84c0d7606363f89f0924245317c2fe3a0) | `` Add flakeModules.partitions ``                   |
| [`c07ef7e5`](https://github.com/hercules-ci/flake-parts/commit/c07ef7e578fbb1a2e964615e0faee1949371cd22) | `` Dogfood lib.mkFlake ``                           |
| [`3ea68936`](https://github.com/hercules-ci/flake-parts/commit/3ea689365998db56cc4c84aa4de4ddd15d550baa) | `` refact: Add let binding to flake.nix ``          |
| [`358ab837`](https://github.com/hercules-ci/flake-parts/commit/358ab8370e9726e60c16cb299c8138228fb0301e) | `` reference to Nix manual ``                       |
| [`309636f1`](https://github.com/hercules-ci/flake-parts/commit/309636f1b058eb305c974882967577225a3ee29a) | `` correct typo ``                                  |
| [`4a41226e`](https://github.com/hercules-ci/flake-parts/commit/4a41226e755f18ff9cd0d3914698c680ee0b804c) | `` apps: Add `meta` option ``                       |