### PR TITLE
chore(flake/nixvim): `2704133f` -> `56208f9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724968633,
-        "narHash": "sha256-eb2NCdLwfXL1MuTAkoDncSl2lCJwyylV5/NM1Ws2P/U=",
+        "lastModified": 1725048799,
+        "narHash": "sha256-NaCb/odkjPjILD1XqXsr1Q7d0iIgf87m8ixGrowfC2A=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2704133fe3ca616b22ed6685cc67180456eb4160",
+        "rev": "56208f9e3f46f034353636fa651df8663ec57fa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`56208f9e`](https://github.com/nix-community/nixvim/commit/56208f9e3f46f034353636fa651df8663ec57fa3) | `` plugins/telescope: add iconsPackage ``         |
| [`bcda408e`](https://github.com/nix-community/nixvim/commit/bcda408e78129786b132dcc0747a044c6d0e7ea8) | `` plugins/treesitter: revert add iconsPackage `` |