### PR TITLE
chore(flake/nixvim): `56208f9e` -> `caefb266`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725048799,
-        "narHash": "sha256-NaCb/odkjPjILD1XqXsr1Q7d0iIgf87m8ixGrowfC2A=",
+        "lastModified": 1725139609,
+        "narHash": "sha256-tjMrSaxGXC7JQkENchdPPxWv4gPbelPwSoPs5A5e0vU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "56208f9e3f46f034353636fa651df8663ec57fa3",
+        "rev": "caefb266bee301922a4cf4d4564b1b000a0a21c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`caefb266`](https://github.com/nix-community/nixvim/commit/caefb266bee301922a4cf4d4564b1b000a0a21c3) | `` flake-modules/dev: treefmt ignore .editorconfig `` |
| [`e05a9e45`](https://github.com/nix-community/nixvim/commit/e05a9e45b37a7f5bee61eda8ea4b296273afb2ab) | `` plugins/lsp: update `eslint` package name ``       |
| [`d7bdf1f4`](https://github.com/nix-community/nixvim/commit/d7bdf1f4b85d02ac3a080abcd40e324d57c0cfd3) | `` plugins/none-ls: update `prisma` package name ``   |
| [`a8dd7a56`](https://github.com/nix-community/nixvim/commit/a8dd7a5657f2ed09a2a35fd06c877ea1b8e778e7) | `` plugins/git-worktree: fix no package test ``       |
| [`3325dcb0`](https://github.com/nix-community/nixvim/commit/3325dcb00b05c3514b6e15260e210b0bc8b363d2) | `` plugins/gitgutter: add tests ``                    |
| [`b6d96387`](https://github.com/nix-community/nixvim/commit/b6d96387d10a27f507474171510aa807f2d117da) | `` plugins/gitgutter: fix grepPackage ``              |
| [`ee6ee48b`](https://github.com/nix-community/nixvim/commit/ee6ee48bbe1ffa88fd4b2af7d68ab0315bc817f0) | `` readme: fix incorrect description ``               |