### PR TITLE
chore(flake/nixvim): `caefb266` -> `3f9cf9f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725139609,
-        "narHash": "sha256-tjMrSaxGXC7JQkENchdPPxWv4gPbelPwSoPs5A5e0vU=",
+        "lastModified": 1725391554,
+        "narHash": "sha256-m8NSagGZpMAQ8LZ+fLxAtD0Miwzy0nJoLSRf41k+3SE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "caefb266bee301922a4cf4d4564b1b000a0a21c3",
+        "rev": "3f9cf9f961ba734d85021248c01b38cd8f2aa173",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`3f9cf9f9`](https://github.com/nix-community/nixvim/commit/3f9cf9f961ba734d85021248c01b38cd8f2aa173) | `` Remove config ``                                                 |
| [`f3a811cf`](https://github.com/nix-community/nixvim/commit/f3a811cf250c4ec562eb4e03e9cd728e6c1b6660) | `` plugins/dracula.nvim: init ``                                    |
| [`18b7597e`](https://github.com/nix-community/nixvim/commit/18b7597e6ca4b98a6c3f20ddc9783165d5998018) | `` lib/neovim-plugin: drop `config` arg ``                          |
| [`2a054b03`](https://github.com/nix-community/nixvim/commit/2a054b039e172d4f1cc5469dfbd5a02d21a4902f) | `` lib/vim-plugin: drop `config` arg ``                             |
| [`9b0e2ba7`](https://github.com/nix-community/nixvim/commit/9b0e2ba7e5b7f5c75557f910694290241845c5f9) | `` plugins/scope: init ``                                           |
| [`204f1aec`](https://github.com/nix-community/nixvim/commit/204f1aecf201c442d6c8ec1976d459cf4fa93247) | `` maintainers: add insipx ``                                       |
| [`2b30ee87`](https://github.com/nix-community/nixvim/commit/2b30ee87031fb40f0f894de00c23ea41714d940e) | `` plugins/nvim-orgmode: init ``                                    |
| [`f3362d2e`](https://github.com/nix-community/nixvim/commit/f3362d2e9d11fcde9e41431d9e10aa05ea6285b0) | `` lib/maintainers: add refaelsh ``                                 |
| [`433673a7`](https://github.com/nix-community/nixvim/commit/433673a7b8b439b77a35ca4db53becdd1a0d0c7d) | `` plugins/cmp: add description to elevate autoEnableSource info `` |
| [`b993182f`](https://github.com/nix-community/nixvim/commit/b993182f1533db7ef2d49081fcf57ae888ef1498) | `` readme: fix installation link ``                                 |
| [`e3f57964`](https://github.com/nix-community/nixvim/commit/e3f57964038381c6822a2c2b61ca469ccc5797d0) | `` plugins/lualine: support custom extensions ``                    |
| [`5241c9f8`](https://github.com/nix-community/nixvim/commit/5241c9f83ea1bcec9879585b7bd2da572924f5e1) | `` plugins/TEMPLATE: drop helpers and adopt new style ``            |