### PR TITLE
chore(flake/treefmt-nix): `3ffd842a` -> `9fb342d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724833132,
-        "narHash": "sha256-F4djBvyNRAXGusJiNYInqR6zIMI3rvlp6WiKwsRISos=",
+        "lastModified": 1725271838,
+        "narHash": "sha256-VcqxWT0O/gMaeWTTjf1r4MOyG49NaNxW4GHTO3xuThE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3ffd842a5f50f435d3e603312eefa4790db46af5",
+        "rev": "9fb342d14b69aefdf46187f6bb80a4a0d97007cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                         |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`14b9565b`](https://github.com/numtide/treefmt-nix/commit/14b9565b02f77e3c1c89293a05e703942d62fbde) | `` mypy: fix python path not beeing set ``                      |
| [`65e10308`](https://github.com/numtide/treefmt-nix/commit/65e10308caf73e744c6e408307c9f1887a1fd4c7) | `` feat: update nixpkgs input ``                                |
| [`966dfb4a`](https://github.com/numtide/treefmt-nix/commit/966dfb4afff31af74f5a7a9a34d80f869fb3b4af) | `` mypy: don't set any PYTHONPATH if we don't have a package `` |
| [`c8a2bda8`](https://github.com/numtide/treefmt-nix/commit/c8a2bda80cd465167f4ccc021d91877a84205fe4) | `` mypy: fix include when no module is specified ``             |