### PR TITLE
chore(flake/nixvim): `3f9cf9f9` -> `cdb2e79e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725391554,
-        "narHash": "sha256-m8NSagGZpMAQ8LZ+fLxAtD0Miwzy0nJoLSRf41k+3SE=",
+        "lastModified": 1725478192,
+        "narHash": "sha256-cFNboKDdDCaGWugw2726jq0myzCCiotZ0M/DruWFu8c=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "3f9cf9f961ba734d85021248c01b38cd8f2aa173",
+        "rev": "cdb2e79e5179029a99a7e1e0d4bb450861ef7c29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`cdb2e79e`](https://github.com/nix-community/nixvim/commit/cdb2e79e5179029a99a7e1e0d4bb450861ef7c29) | `` lib/pkg-lists: move to common location ``                  |
| [`d2aad107`](https://github.com/nix-community/nixvim/commit/d2aad1071fa0da286abba5f4fbc3d42ea56bea2b) | `` plugins/none-ls: use `defaultText` in package options ``   |
| [`a8a7e405`](https://github.com/nix-community/nixvim/commit/a8a7e405f413708ce42dca436105e6210a15278a) | `` plugins/efmls: use `mkPackageOption` ``                    |
| [`2ef97418`](https://github.com/nix-community/nixvim/commit/2ef974182ef62a6a6992118f0beb54dce812ae9b) | `` plugins/efmls: minor cleanup ``                            |
| [`35788bbc`](https://github.com/nix-community/nixvim/commit/35788bbc5ab247563e13bad3ce64acd897bca043) | `` lib: cleanup with lib ``                                   |
| [`c76e5070`](https://github.com/nix-community/nixvim/commit/c76e5070b9715c98006f40e7708d2dc676d91bc9) | `` wrappers: cleanup with lib ``                              |
| [`1c9ba58a`](https://github.com/nix-community/nixvim/commit/1c9ba58aef721bbd2216e19ab44ff4bef1cec07f) | `` modules: cleanup with lib ``                               |
| [`ff042dfc`](https://github.com/nix-community/nixvim/commit/ff042dfc938467aceddcd4ddd4c96d372ea7d4fe) | `` docs/mdbook: cleanup with lib ``                           |
| [`9c11b540`](https://github.com/nix-community/nixvim/commit/9c11b54065a554d9976089cfc8a08dee35cabcaa) | `` plugins/lsp/servers: use `lib.mkPackageOption` ``          |
| [`0b86bf51`](https://github.com/nix-community/nixvim/commit/0b86bf519b5c04279074751b99d3e701e7ce47ea) | `` plugins/cmp/sources: use `lib.mkPackageOption` ``          |
| [`dfb754cd`](https://github.com/nix-community/nixvim/commit/dfb754cdc4544ddb66f0e258f4f86d798bf6fab4) | `` plugins/telescope/extensions: use `lib.mkPackageOption` `` |
| [`1fd4b6c7`](https://github.com/nix-community/nixvim/commit/1fd4b6c7399ca85ea8184699141ff9f9e98a678f) | `` plugins: migrate `defaultPackage` -> `package` ``          |
| [`285f6cbd`](https://github.com/nix-community/nixvim/commit/285f6cbd7b2f37c56f57c9fa3e24a59236f9b1ad) | `` lib/*-plugin: use `lib.mkPackageOption` internally ``      |
| [`c8bb7880`](https://github.com/nix-community/nixvim/commit/c8bb7880bf518670547616d5c5849beaa09ff4a6) | `` plugins/barbecue: migrate to mkNeovimPlugin ``             |
| [`27925829`](https://github.com/nix-community/nixvim/commit/279258294b1aeb0457e4830e49f918440806473b) | `` plugins/navic: migrate to mkNeovimPlugin ``                |
| [`0d73ab93`](https://github.com/nix-community/nixvim/commit/0d73ab939cb46547ba38607faf9d2796801cb43e) | `` plugins/project-nvim: migrate to mkNeovimPlugin ``         |
| [`d928d6de`](https://github.com/nix-community/nixvim/commit/d928d6deb18274b12edfc10681e52e50b51c3e35) | `` colorschemes/dracula-nvim: fixes ``                        |