### PR TITLE
chore(flake/nixvim): `cdb2e79e` -> `84249a9d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725478192,
-        "narHash": "sha256-cFNboKDdDCaGWugw2726jq0myzCCiotZ0M/DruWFu8c=",
+        "lastModified": 1725563454,
+        "narHash": "sha256-RQ9aKwXmqNHMBFOlHEUVrAFo7YHJSVn4nBgi2rcaCY4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "cdb2e79e5179029a99a7e1e0d4bb450861ef7c29",
+        "rev": "84249a9dabdf930d968d248024c4d6240ee14548",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`84249a9d`](https://github.com/nix-community/nixvim/commit/84249a9dabdf930d968d248024c4d6240ee14548) | `` plugins/vim-numbertoggle: init ``                                        |
| [`4df57466`](https://github.com/nix-community/nixvim/commit/4df5746694560ac05fe9ab9625447e92e522449c) | `` plugins/vim-autosource: init ``                                          |
| [`9248da3c`](https://github.com/nix-community/nixvim/commit/9248da3c3b27c7b5a7677fbf58daef0c51ef73ce) | `` plugins/vim-repeat: init ``                                              |
| [`83aed0e6`](https://github.com/nix-community/nixvim/commit/83aed0e6a331a95f7948a29ffe9b9f34d224f620) | `` plugins/nvim-web-devicons: init ``                                       |
| [`8ae9e4d8`](https://github.com/nix-community/nixvim/commit/8ae9e4d8a1e111e8532131362992debcdc8a9d98) | `` plugins/mini: migrate to mkNeovimPlugin ``                               |
| [`ac4629ee`](https://github.com/nix-community/nixvim/commit/ac4629eecc81fcb80e9671d88bcf525943b85e98) | `` plugins/codeium-nvim: move to plulgins/completion ``                     |
| [`b072a4a6`](https://github.com/nix-community/nixvim/commit/b072a4a68fcec3eee693781cbf0244e62ceaa4b0) | `` plugins/codeium-nvim: migrate to mkNeovimPlugin ``                       |
| [`c8328e6d`](https://github.com/nix-community/nixvim/commit/c8328e6d5938fe02fa7859d1aa88b96012c5c8c4) | `` contributing: update plugin declaration docs ``                          |
| [`e48da949`](https://github.com/nix-community/nixvim/commit/e48da949cf41597d43f8e3880fc1389129ad7427) | `` tests/package-options: init ``                                           |
| [`fd923a3d`](https://github.com/nix-community/nixvim/commit/fd923a3dd3aedd9b11419335951d7bbde49235fd) | `` lib/options: remove deprecated package option helpers ``                 |
| [`7409e80b`](https://github.com/nix-community/nixvim/commit/7409e80bd2dbbc5d653b27170d2fb33082150df3) | `` plugins: remove all uses of `lib.nixvim.mkPluginPackageOption` ``        |
| [`ae3a2c9d`](https://github.com/nix-community/nixvim/commit/ae3a2c9d106b4acc793c46b92def586a21c838a4) | `` plugins: remove all use of `lib.nixvim.mkPackageOption` ``               |
| [`84676128`](https://github.com/nix-community/nixvim/commit/84676128f8e6b3175d4736f2422944c10a73389f) | `` plugins/dap/extensions: use `lib.mkPackageOption` ``                     |
| [`bf1d22e6`](https://github.com/nix-community/nixvim/commit/bf1d22e65cc96ff2afe741e8a1b4288c34fce06b) | `` plugins/neotest/adapters: use `lib.mkPackageOption` ``                   |
| [`37165453`](https://github.com/nix-community/nixvim/commit/37165453a964310ff6d76baa677aa1b802095206) | `` plugins/lsp: use `mkPackageOption` for pylsp + rust-analyzer ``          |
| [`848246bc`](https://github.com/nix-community/nixvim/commit/848246bc64f01f679f5862d2fbd56931827ace80) | `` plugins/telescope/media-files: use `mkPackageOption` for dependencies `` |
| [`80150aba`](https://github.com/nix-community/nixvim/commit/80150abad6d9f0a51f83fb527b6efbe95acd1344) | `` plugins/spectre: cleanup package options ``                              |
| [`e26f0443`](https://github.com/nix-community/nixvim/commit/e26f044339ff3b042f565ee19efdf3bb688279e6) | `` plugins/treesitter: use `mkPackageOption` ``                             |
| [`2132702a`](https://github.com/nix-community/nixvim/commit/2132702a470e492fb8921b22cc393d516519de32) | `` plugins: use `mkPackageOption` for `iconsPackage` options ``             |
| [`c4a54da4`](https://github.com/nix-community/nixvim/commit/c4a54da4a50769279b6add0b0f831aaade5e1159) | `` modules/output: use `mkPackageOption` for `package` option ``            |