### PR TITLE
chore(flake/nixvim): `9a156ae6` -> `810eacf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725631974,
-        "narHash": "sha256-7r3WWcombWthNv28cHRzNChG3Jt6a3Wdp/zq1HsCQRg=",
+        "lastModified": 1725744583,
+        "narHash": "sha256-bzJ5iUPaEjSt24fIoQihBGN+Q7mye73hd/jbubHhyZA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "9a156ae60cacce99bdec4d94275f38e7d5ca12fe",
+        "rev": "810eacf5163b16b666ca70b6617c6a85ce412e0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`810eacf5`](https://github.com/nix-community/nixvim/commit/810eacf5163b16b666ca70b6617c6a85ce412e0a) | `` tests: set `_file` to avoid `<unknown-file>` messages `` |
| [`ce4c3a72`](https://github.com/nix-community/nixvim/commit/ce4c3a72c146a253f4f032bbe8a3bf8dd553ff7e) | `` tests/fetch-test: tweak signature ``                     |
| [`d12045e0`](https://github.com/nix-community/nixvim/commit/d12045e057c2a183d60ef098f7530fb9440233a0) | `` plugins/lualine: migrate to mkNeovimPlugin ``            |
| [`c4135d72`](https://github.com/nix-community/nixvim/commit/c4135d720a5a57b7ddbd7ee918544c26b2c6f732) | `` flake/pre-commit: check maintainers when modified ``     |
| [`5c929a16`](https://github.com/nix-community/nixvim/commit/5c929a161f1ef339ff3e8c7d339f4eb2074a6235) | `` flake: remove pre-commit from `checks` output ``         |
| [`86a40215`](https://github.com/nix-community/nixvim/commit/86a4021597c860a6cd1953305a9995f44e60d4d5) | `` plugins: add top-level `deprecation` file ``             |