### PR TITLE
chore(flake/nixvim): `5330427e` -> `facf6b2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725838501,
-        "narHash": "sha256-hL20ZHRwkjp0e+9khPkuREocmWBmpZrrOSRLP9MkvM4=",
+        "lastModified": 1725921389,
+        "narHash": "sha256-RBpN0ToD8O3qniBjqUiB1d2/LQJt5kH5P3Gt6dF91L0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "5330427e2bac6cea0be59e8de0d1b1c119306073",
+        "rev": "facf6b2d0c9e22d858956d1d458eac6baf155a08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`facf6b2d`](https://github.com/nix-community/nixvim/commit/facf6b2d0c9e22d858956d1d458eac6baf155a08) | `` plugins/rest: remove with lib ``                                   |
| [`b7dea123`](https://github.com/nix-community/nixvim/commit/b7dea123751ba00a340661ea8c5e47a6bffcb9da) | `` plugins/rest: add dependencies ``                                  |
| [`6c9d178e`](https://github.com/nix-community/nixvim/commit/6c9d178ecceb1321bb0a153355f00b8f1dbfd92d) | `` plugins/rest: add filetype association option ``                   |
| [`9265d1ab`](https://github.com/nix-community/nixvim/commit/9265d1ab086c89f732ad842a0de0aa0742c4a127) | `` tests/rust-tools: add rust-analyzer-options test ``                |
| [`b1d0959b`](https://github.com/nix-community/nixvim/commit/b1d0959bc9803729b6b62b77eb8a7387b8c8cdc3) | `` plugins/languages: move to by-name ``                              |
| [`9d323f3e`](https://github.com/nix-community/nixvim/commit/9d323f3ec7aa28d25589f43fde16fa03aa17f8d9) | `` plugins/neotest: move to by-name ``                                |
| [`0f83298f`](https://github.com/nix-community/nixvim/commit/0f83298f2ca5d871ca2dbba0315974e79a8e7dcb) | `` tests/generated: use `runCommandNoCCLocal` and `structuedAttrs` `` |
| [`9f4c9ea7`](https://github.com/nix-community/nixvim/commit/9f4c9ea7e4389b95611558ab4b4ac3c62b8cdbcb) | `` tests/generated: check packages are found in `pkgs` ``             |
| [`49c0853b`](https://github.com/nix-community/nixvim/commit/49c0853ba5fe9ba62e4a9e7b6850ec2a0176db4e) | `` plugins/hardtime: add missing rename for `settings.enabled` ``     |
| [`ffa9b8f7`](https://github.com/nix-community/nixvim/commit/ffa9b8f7a0e8f9baa68c00f0da8dab063b373681) | `` plugins/hex: init ``                                               |
| [`1d6afdbc`](https://github.com/nix-community/nixvim/commit/1d6afdbce025d36cb90138a7b3ece7940cf8e933) | `` plugins/treesitter: clarify nixGrammars and ensure_installed ``    |
| [`54599ad5`](https://github.com/nix-community/nixvim/commit/54599ad5551c8308f71442e10331a5d752350a3b) | `` tests/plugins-by-name: test that required files exist ``           |
| [`34b61f9b`](https://github.com/nix-community/nixvim/commit/34b61f9b5b18fba36fc6878866a8e864c10a1091) | `` plugins/by-name: add missing test files ``                         |
| [`48e9af50`](https://github.com/nix-community/nixvim/commit/48e9af500ce61246243f880b7ce5368d7ba4466e) | `` plugins/by-name: remove `pathExists` check ``                      |
| [`6debe933`](https://github.com/nix-community/nixvim/commit/6debe9333f8275dec0a453247de9a5cf252bc4f3) | `` plugins/telescope: move to by-name ``                              |
| [`d07a9c78`](https://github.com/nix-community/nixvim/commit/d07a9c78ccae0f97bb87adc3265e38ba7c3b9d2f) | `` plugins/statuslines: move to by-name ``                            |
| [`82e7d153`](https://github.com/nix-community/nixvim/commit/82e7d153e452a7c9ef497eb3850547a6e2f7e24a) | `` plugins/snippets: move to by-name ``                               |
| [`2a91b894`](https://github.com/nix-community/nixvim/commit/2a91b8944524b356a6aa3d54dedef30797f343e7) | `` plugins/git: move to by-name ``                                    |
| [`d016b139`](https://github.com/nix-community/nixvim/commit/d016b139fc61a62940f7ceef5093f8a75c910770) | `` plugins/filetrees: move to by-name ``                              |
| [`ad85cd76`](https://github.com/nix-community/nixvim/commit/ad85cd760ef56b36f62b9d31c9f4409560e712d3) | `` plugins/completion: move to by-name ``                             |
| [`3211a633`](https://github.com/nix-community/nixvim/commit/3211a633062d79bf178cfd7182f4d1629dd681c6) | `` plugins/bufferlines: move to by-name ``                            |
| [`4491ce4d`](https://github.com/nix-community/nixvim/commit/4491ce4db2fc480fdb8d210a31911230055174b1) | `` plugins/treesitter: move to `by-name` ``                           |
| [`8815180c`](https://github.com/nix-community/nixvim/commit/8815180c625e9766b2cb3126756b97e994998228) | `` plugins/lsp: move related plugins to `by-name` ``                  |
| [`91c6b628`](https://github.com/nix-community/nixvim/commit/91c6b62881e8ba4c90b004446cd0b1cf5fb67241) | `` plugins/ui: move to `by-name` ``                                   |
| [`2456370a`](https://github.com/nix-community/nixvim/commit/2456370ab21c2d7021f4c0f8fb782d208566a384) | `` plugins/ai: move to `by-name` ``                                   |
| [`672b9e1c`](https://github.com/nix-community/nixvim/commit/672b9e1ceba4de35cafed63bdb9391dea6603b40) | `` plugins/dap: move to `by-name` ``                                  |
| [`52f12567`](https://github.com/nix-community/nixvim/commit/52f125679f233c88e8421dad3f206987b9a1b49b) | `` plugins/utils: move to by-name ``                                  |
| [`faff32b9`](https://github.com/nix-community/nixvim/commit/faff32b9f1f5ada447d2ddfb4dcdcbeb7ec01c0b) | `` plugins/by-name: init ``                                           |
| [`6df27354`](https://github.com/nix-community/nixvim/commit/6df273540c1ec51b484fab65988761ae877c6a62) | `` plugins/rustaceanvim: add lsp assertion ``                         |
| [`68aeb57a`](https://github.com/nix-community/nixvim/commit/68aeb57a3500c609852157ba4283137da7a2bac7) | `` tests/one: fix deprecation warning ``                              |
| [`4e6bb696`](https://github.com/nix-community/nixvim/commit/4e6bb696809ba80c3c82b59f363a4326e1e8b573) | `` plugins/none-ls: fix pkg names ``                                  |