### PR TITLE
chore(flake/nixvim): `facf6b2d` -> `fc7e9b29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725921389,
-        "narHash": "sha256-RBpN0ToD8O3qniBjqUiB1d2/LQJt5kH5P3Gt6dF91L0=",
+        "lastModified": 1726000537,
+        "narHash": "sha256-Y1dEuf2wZkg2rhE8sf73x9K0zknUald4Ia6zXnGEfjg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "facf6b2d0c9e22d858956d1d458eac6baf155a08",
+        "rev": "fc7e9b29271a03459191955f78d4128451b7cd81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`fc7e9b29`](https://github.com/nix-community/nixvim/commit/fc7e9b29271a03459191955f78d4128451b7cd81) | `` colorschemes/modus: add new configuration option ``   |
| [`d0c08212`](https://github.com/nix-community/nixvim/commit/d0c082124535acd6f0f786be42b38c32abe89d64) | `` docs: patch nixos-render-docs to output GFM alerts `` |
| [`79010edc`](https://github.com/nix-community/nixvim/commit/79010edc14353e5815bd0e0375001daeb87c2e1a) | `` docs/user-guide: update "not found in pkgs" FAQ ``    |
| [`faa2e630`](https://github.com/nix-community/nixvim/commit/faa2e6306c0a1ae8e67dfdb0d75cd5ecd427ca5d) | `` docs: Render alerts using mdbook-alerts ``            |