### PR TITLE
chore(flake/nixvim): `fc7e9b29` -> `11c133e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726000537,
-        "narHash": "sha256-Y1dEuf2wZkg2rhE8sf73x9K0zknUald4Ia6zXnGEfjg=",
+        "lastModified": 1726027257,
+        "narHash": "sha256-hsdIfpIB5wzEehgOSaifBJwY3Tn0P0wiU9pTf8nRBQc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "fc7e9b29271a03459191955f78d4128451b7cd81",
+        "rev": "11c133e89e4090c43445a2c3b5af2322831d7219",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`11c133e8`](https://github.com/nix-community/nixvim/commit/11c133e89e4090c43445a2c3b5af2322831d7219) | `` plugins/rest-nvim: add telescope integration `` |
| [`7484be88`](https://github.com/nix-community/nixvim/commit/7484be88c7a6806403a2fd28c2a4cf88f5a890ff) | `` plugins/rest-nvim: revert by-name migration ``  |