### PR TITLE
chore(flake/nixvim): `11c133e8` -> `4e5bd1d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726027257,
-        "narHash": "sha256-hsdIfpIB5wzEehgOSaifBJwY3Tn0P0wiU9pTf8nRBQc=",
+        "lastModified": 1726250726,
+        "narHash": "sha256-Z9/tIEMhQIEtt5BYTu75dp4kyDqqS/zb+47oakNQ6sA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "11c133e89e4090c43445a2c3b5af2322831d7219",
+        "rev": "4e5bd1d79bb88b98e4d23241096989373150112c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                              |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`4e5bd1d7`](https://github.com/nix-community/nixvim/commit/4e5bd1d79bb88b98e4d23241096989373150112c) | `` lib: segregate and deprecate functions that need `pkgs` ``        |
| [`f47e8f8f`](https://github.com/nix-community/nixvim/commit/f47e8f8f79f2095aeb60c2c8ac8681206b16753b) | `` lib: use `lib.fix` and `self` internally ``                       |
| [`7a147234`](https://github.com/nix-community/nixvim/commit/7a147234f8c151e9be1500e1fa687de9b2b8c401) | `` lib: rename `helpers.nix` -> `default.nix` ``                     |
| [`0b665b20`](https://github.com/nix-community/nixvim/commit/0b665b200b4935aed7f525bf04abf87e91ea4c83) | `` plugins/lsp/harper-ls: init ``                                    |
| [`aa15c244`](https://github.com/nix-community/nixvim/commit/aa15c244371ac3090486e7c1294efc090832f2eb) | `` tests/lsp: disable swift ``                                       |
| [`5143afee`](https://github.com/nix-community/nixvim/commit/5143afeebcef0cdc206e970e46552ad82be9fa09) | `` tests/efmls: disable swift ``                                     |
| [`6e22c9e8`](https://github.com/nix-community/nixvim/commit/6e22c9e8dbd98606fdf306241ecb1b782672b36d) | `` tests/none-ls: disable swift ``                                   |
| [`890cc143`](https://github.com/nix-community/nixvim/commit/890cc1438ea80d4bdd9495a9bbd76ea7fe136cff) | `` tests/neoclip: disable sqlite test ``                             |
| [`1107a528`](https://github.com/nix-community/nixvim/commit/1107a52878fe224c5f8a0a9b4bbe86fcd1197145) | `` tests/yanky: disable sqlite test ``                               |
| [`3d3bf1e4`](https://github.com/nix-community/nixvim/commit/3d3bf1e4b3d9f61c4855bd2ebc323dc09fb3b879) | `` tests/lsp: disable taplo ``                                       |
| [`1310eaf6`](https://github.com/nix-community/nixvim/commit/1310eaf606c0c5a63162208f337940e5a0e9c404) | `` flake/treefmt: disable taplo for now ``                           |
| [`3c9af619`](https://github.com/nix-community/nixvim/commit/3c9af6191e6a0a9b888b5ee5f52bec362fa12d04) | `` plugins/efmls: move `eslint` pkg ref to top-level ``              |
| [`46c3048a`](https://github.com/nix-community/nixvim/commit/46c3048a61df3d3ec284d0a9f06532a0e4925de3) | `` generated: Updated rust-analyzer.nix ``                           |
| [`6e5d4bf4`](https://github.com/nix-community/nixvim/commit/6e5d4bf44c0537ca82d98d630c9a1aa7f299e255) | `` flake.lock: Update ``                                             |
| [`8eab77b5`](https://github.com/nix-community/nixvim/commit/8eab77b51b6c2522eceaae4ff18fb8a9b5abe495) | `` docs: Support GFM style admonitions in option descriptions ``     |
| [`cab2a30a`](https://github.com/nix-community/nixvim/commit/cab2a30ae1e12905ec1611b7b5ddf9dc9b12c578) | `` docs: Create a markdown-it plugin ``                              |
| [`66655215`](https://github.com/nix-community/nixvim/commit/6665521525b288d5824314bedf983cc24e217e6a) | `` docs: move pkgs overlays to their own file ``                     |
| [`27a0dd43`](https://github.com/nix-community/nixvim/commit/27a0dd435dd3563f4cf9d788601fadfce8c59db6) | `` lib/types: simplify `eitherRecursive` by defining it only once `` |
| [`a5152c2f`](https://github.com/nix-community/nixvim/commit/a5152c2f8e7516a71951ee65b1700cf31913d3da) | `` docs: remove unused `oneOfRecursive` ``                           |
| [`4697b96a`](https://github.com/nix-community/nixvim/commit/4697b96a0124944929ecefa09d488c7997419e43) | `` mergify: fix "update PR" logic ``                                 |
| [`6cbcac1d`](https://github.com/nix-community/nixvim/commit/6cbcac1d435d979cc45ca479c58b48ca0ea0c9b2) | `` mergify: use @nix-infra-bot to update queued PRs ``               |