### PR TITLE
chore(flake/nixvim): `4e5bd1d7` -> `f1881b4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726250726,
-        "narHash": "sha256-Z9/tIEMhQIEtt5BYTu75dp4kyDqqS/zb+47oakNQ6sA=",
+        "lastModified": 1726353028,
+        "narHash": "sha256-vU1PB7D7FqcCAVpSjuNmx85wWTZUoU0/gQ5haauO9Xs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4e5bd1d79bb88b98e4d23241096989373150112c",
+        "rev": "f1881b4e4b7007cbf22d3ff005fdb8a876bddea2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`f1881b4e`](https://github.com/nix-community/nixvim/commit/f1881b4e4b7007cbf22d3ff005fdb8a876bddea2) | `` plugins/markdown-preview: fix browserFunc rename ``       |
| [`2d5949f6`](https://github.com/nix-community/nixvim/commit/2d5949f65ca6060552ca5841716119c6d7d4bb54) | `` plugins/sqlite-lua: init ``                               |
| [`908721cd`](https://github.com/nix-community/nixvim/commit/908721cdbd25efb05d0975ada5d980e89bba64fa) | `` tests/darwin: add system.stateversion ``                  |
| [`79f0f738`](https://github.com/nix-community/nixvim/commit/79f0f738594b327f1f8a9f00bdb76100b5f6b7e1) | `` flake.lock: Update ``                                     |
| [`e170e4b5`](https://github.com/nix-community/nixvim/commit/e170e4b5981f98c052257617580f95a307802bf9) | `` plugins/lsp/idris2-lsp: init ``                           |
| [`8fd162d9`](https://github.com/nix-community/nixvim/commit/8fd162d9513b0d1acc8ce58848febf2dbe2e7733) | `` plugins/wtf: add history and grep_history keymaps ``      |
| [`87e3c4a1`](https://github.com/nix-community/nixvim/commit/87e3c4a1b2a62f6b79ae946ba1a2b53b0cbb0499) | `` plugins/todo-comments: support conditional key mapping `` |