### PR TITLE
chore(flake/nixvim): `f1881b4e` -> `95b322a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726353028,
-        "narHash": "sha256-vU1PB7D7FqcCAVpSjuNmx85wWTZUoU0/gQ5haauO9Xs=",
+        "lastModified": 1726441328,
+        "narHash": "sha256-WGZuGGjWq4Rac3MwdnXaojvTOMo2HjqXEWughqCYMAk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "f1881b4e4b7007cbf22d3ff005fdb8a876bddea2",
+        "rev": "95b322a5220744a5cac725e62fa4e612851edbc2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`95b322a5`](https://github.com/nix-community/nixvim/commit/95b322a5220744a5cac725e62fa4e612851edbc2) | `` plugins/helpview: init ``                                                   |
| [`336ba155`](https://github.com/nix-community/nixvim/commit/336ba155ffcb20902b93873ad84527a833f57dc8) | `` plugins/overseer: fix strategy option ``                                    |
| [`9e81cb73`](https://github.com/nix-community/nixvim/commit/9e81cb73913b730467d74fde21c4613c525e77c7) | `` plugins/glow: support style path ``                                         |
| [`0999f925`](https://github.com/nix-community/nixvim/commit/0999f92567412ba871f9734543a51c1c90dd0b82) | `` plugins/glow: remove helpers ``                                             |
| [`accf5e67`](https://github.com/nix-community/nixvim/commit/accf5e67b16a857e546abd321877af061319147d) | `` plugins/smartcolumn: init ``                                                |
| [`fcb782cd`](https://github.com/nix-community/nixvim/commit/fcb782cd9c340f1d9f610ca4c75309c82ec89bff) | `` flake: add an empty `nixvimConfiguration` to the `legacyPackages` output `` |
| [`ccc2469e`](https://github.com/nix-community/nixvim/commit/ccc2469e4f1fce144c98e18bd59c022289cf91e8) | `` tests/neotest: disable on darwin ``                                         |
| [`f88402d5`](https://github.com/nix-community/nixvim/commit/f88402d5a7085697e8a2953428e66b9d8b420785) | `` plugins/coq-thirdparty: remove copilot ``                                   |
| [`1a1de277`](https://github.com/nix-community/nixvim/commit/1a1de2779bd50ff683c7e847676dcf1872f18945) | `` tests/lsp: remove tsserver test ``                                          |
| [`f0bd18b4`](https://github.com/nix-community/nixvim/commit/f0bd18b4200becfe752e98baf1bd608496081a96) | `` generated: Updated efmls-configs.nix ``                                     |
| [`9a32aecc`](https://github.com/nix-community/nixvim/commit/9a32aeccfca5e927988cda89c3243979f738c3c3) | `` flake.lock: Update ``                                                       |
| [`f76051e0`](https://github.com/nix-community/nixvim/commit/f76051e06e40921cfb3eb0b4bc718880a6f1d9b1) | `` plugins/compiler: init ``                                                   |
| [`4f01fd98`](https://github.com/nix-community/nixvim/commit/4f01fd981af20ba998fb591317b56cd94491f628) | `` plugins/ts-comments-nvim: init ``                                           |
| [`add9aca7`](https://github.com/nix-community/nixvim/commit/add9aca76eee69831f44f57caf12eb4bf2fc23a1) | `` plugins/overseer: init ``                                                   |
| [`a20d9562`](https://github.com/nix-community/nixvim/commit/a20d95625bee35b6230503ee21f930d3fe7dfa2c) | `` plugins/precognition: init ``                                               |
| [`57219622`](https://github.com/nix-community/nixvim/commit/57219622b8d27c80b06024346e105cb67c2b5d74) | `` typo ``                                                                     |
| [`61be7a6e`](https://github.com/nix-community/nixvim/commit/61be7a6eed7b6e70db9731cdf32d6a3e163cee73) | `` plugins/nvim-jdtls: use jdtLanguageServerPackage option ``                  |
| [`b42d4588`](https://github.com/nix-community/nixvim/commit/b42d4588ae5350ceb291389f8d9280568bd23bff) | `` plugins/neoclip: sqlite-lua assertion ``                                    |
| [`e3e37741`](https://github.com/nix-community/nixvim/commit/e3e37741771d47b3c57329db9077f5eef30a9777) | `` plugins/neorg: use neorgTelescopePackage option ``                          |
| [`7a9bb2ee`](https://github.com/nix-community/nixvim/commit/7a9bb2ee9527dc14f20176b42de5df6357938af8) | `` plugins/fzf-lua: remove extra fzf package include ``                        |
| [`875b8125`](https://github.com/nix-community/nixvim/commit/875b8125591e68892f8d9bcdbfcf9481fc37f09b) | `` plugins/rest: remove extra curl package include ``                          |
| [`59d03e76`](https://github.com/nix-community/nixvim/commit/59d03e76d97342ef2e155b28554fbe16947f3981) | `` colorschemes/palette: use lsp package ``                                    |
| [`068f5e97`](https://github.com/nix-community/nixvim/commit/068f5e97fcb6041e50aa46b44bebd434c9abfd8e) | `` plugins/tagbar: use tagsPackage ``                                          |
| [`0e9b8351`](https://github.com/nix-community/nixvim/commit/0e9b8351da90b776c9469dc5f07db3117b07747a) | `` plugins/typescript-tools: remove redundant extraPlugins ``                  |
| [`34297f5e`](https://github.com/nix-community/nixvim/commit/34297f5e040f739981b5943440e2caeb6b3cb10d) | `` plugins/yanky: sqlite-lua assertion ``                                      |
| [`da1a10d0`](https://github.com/nix-community/nixvim/commit/da1a10d0f3104d9f588f049b7dfe86ce5bcc3373) | `` plugins/efmls: use efmLangServerPackage option ``                           |
| [`9832cb86`](https://github.com/nix-community/nixvim/commit/9832cb86fb1384089a6a95cb62120faf12c6210c) | `` plugins/vimtex: use package options for extraPackages ``                    |
| [`ff3fee3a`](https://github.com/nix-community/nixvim/commit/ff3fee3ae5490fbccf8529aac2c7805c87fc4975) | `` plugins/direnv: use direnvPackage ``                                        |
| [`6bf63e88`](https://github.com/nix-community/nixvim/commit/6bf63e8871af9bdb1d1005f9dabecd9d1837eecd) | `` plugins/typst-vim: use typstPackage ``                                      |
| [`dfea1785`](https://github.com/nix-community/nixvim/commit/dfea17859073c8a3e56a8674e5e64bb7b32ae11f) | `` plugins/octo: use ghPackage ``                                              |
| [`4d460d61`](https://github.com/nix-community/nixvim/commit/4d460d6151b27bd045a5442b40c2aa1427592efb) | `` plugins/rust-tools: use lsp package ``                                      |
| [`9c476a09`](https://github.com/nix-community/nixvim/commit/9c476a094874683ed462ab8efbaaeb5f028bb1c1) | `` plugins/lsp: use package option ``                                          |
| [`873d7b51`](https://github.com/nix-community/nixvim/commit/873d7b51a73d2c35950c3ec8a5a017d801c11715) | `` plugins/telescope: add batPackage ``                                        |
| [`93b8b75f`](https://github.com/nix-community/nixvim/commit/93b8b75ff3ee3218fd330e263cf29933aa46fbf4) | `` plugins/image: add curlPackage and ueberzugPackage ``                       |
| [`6915b851`](https://github.com/nix-community/nixvim/commit/6915b851a2c260e6743ea0dc2573cfc0e0831577) | `` plugins/neogit: use whichPackage ``                                         |
| [`5316141e`](https://github.com/nix-community/nixvim/commit/5316141e5095459afe34f6fc835189cc47cdcfa2) | `` plugins/packer: use package option ``                                       |
| [`1364f071`](https://github.com/nix-community/nixvim/commit/1364f071adc9335723a631e9e82eca6c0d8e7ba0) | `` plugins/lazy: use package option ``                                         |