### PR TITLE
chore(flake/nixvim): `2e3083e4` -> `6cbf441c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726502324,
-        "narHash": "sha256-I/WFSIBeIjlY3CgSJ6IRYxP2aEJ6b42Y1HAeATlBh48=",
+        "lastModified": 1726604448,
+        "narHash": "sha256-Y9myeRO551JhU5GLoczhHPMquhR0bhtq8Mih1TSu+l0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2e3083e42509c399b224239f6d7fa17976b18536",
+        "rev": "6cbf441c22b2c26a1561993f5993e20612a6df1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`6cbf441c`](https://github.com/nix-community/nixvim/commit/6cbf441c22b2c26a1561993f5993e20612a6df1c) | `` plugins/nvim-jdtls: configuration allow raw lua `` |
| [`5a5b9b80`](https://github.com/nix-community/nixvim/commit/5a5b9b8004520c0eb550740b7a59400f55175673) | `` plugins/otter: remove myself as maintainer ``      |