### PR TITLE
chore(flake/nixvim): `6cbf441c` -> `9307b201`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726604448,
-        "narHash": "sha256-Y9myeRO551JhU5GLoczhHPMquhR0bhtq8Mih1TSu+l0=",
+        "lastModified": 1726676531,
+        "narHash": "sha256-i8Pbd7JszwuCb0HqzAPypv2ytdcsFeAMFqbrmLaN4BE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6cbf441c22b2c26a1561993f5993e20612a6df1c",
+        "rev": "9307b201a3dc57d5b71ded4f897ea9d096544877",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`9307b201`](https://github.com/nix-community/nixvim/commit/9307b201a3dc57d5b71ded4f897ea9d096544877) | `` plugins/telescope-live-grep-args: init ``          |
| [`11b9de72`](https://github.com/nix-community/nixvim/commit/11b9de7264bc721dd78a4db533523fe2593aa01a) | `` plugins/telescope-manix: fix manixPackage usage `` |
| [`b34379e9`](https://github.com/nix-community/nixvim/commit/b34379e9819d171b7ab8f268bdf05dc0b699b3c6) | `` plugins/package-info: add telescope integration `` |
| [`d4b18276`](https://github.com/nix-community/nixvim/commit/d4b1827606e57b417c882d1a525bd34d67999cfc) | `` plugins/package-info: init ``                      |
| [`04ad7937`](https://github.com/nix-community/nixvim/commit/04ad7937c0f74db1a8a1b8af44c895bd91792e15) | `` plugins/nvim-surround: init ``                     |
| [`092d1a8a`](https://github.com/nix-community/nixvim/commit/092d1a8a9c764f3892894ceabbbe21b53d63896d) | `` plugins/surround: rename to vim-surround ``        |
| [`061d47f7`](https://github.com/nix-community/nixvim/commit/061d47f7c526946fd2d62202835032d7adaf8b65) | `` plugins/tokyonight: add moon style to settings ``  |
| [`650e204c`](https://github.com/nix-community/nixvim/commit/650e204c071a0faaf1f4073f5a0f0536cd738fed) | `` plugins/telescope-manix: init ``                   |