### PR TITLE
chore(flake/treefmt-nix): `77dd46bf` -> `41266e63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726560002,
-        "narHash": "sha256-3zr63B6CDZ8FnzrRUvNZlsxLmFjaNyis6R91GjUCIhU=",
+        "lastModified": 1726646204,
+        "narHash": "sha256-Ftjw+30n/HeFxtvw/c0+hzT6d3kbwPnGruhbrKnbwOI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "77dd46bf0ec7febbc0022bb6e4449cdc49af95d7",
+        "rev": "41266e63a00c55b488f8f977051d4bd20e77f644",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                      |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`41266e63`](https://github.com/numtide/treefmt-nix/commit/41266e63a00c55b488f8f977051d4bd20e77f644) | `` feat(programs): add dart format (#232) `` |