### PR TITLE
chore(flake/treefmt-nix): `41266e63` -> `ee41a466`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726646204,
-        "narHash": "sha256-Ftjw+30n/HeFxtvw/c0+hzT6d3kbwPnGruhbrKnbwOI=",
+        "lastModified": 1726734507,
+        "narHash": "sha256-VUH5O5AcOSxb0uL/m34dDkxFKP6WLQ6y4I1B4+N3L2w=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "41266e63a00c55b488f8f977051d4bd20e77f644",
+        "rev": "ee41a466c2255a3abe6bc50fc6be927cdee57a9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                               |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`01abe60f`](https://github.com/numtide/treefmt-nix/commit/01abe60f41e6227ca2b68759dba975e764a2f3fe) | `` chore: fmt ``                      |
| [`c58f3be1`](https://github.com/numtide/treefmt-nix/commit/c58f3be12ab7d4bc589604c413cf0ac50575e28c) | `` feat(programs): add latexindent `` |
| [`284529ce`](https://github.com/numtide/treefmt-nix/commit/284529cebe0f41f459210c617100d6d723ae37a7) | `` Add meson to README ``             |
| [`434a5069`](https://github.com/numtide/treefmt-nix/commit/434a50690c715fe3a2b35852433a29763f54fdf9) | `` Add meson example ``               |
| [`2ca2bf4e`](https://github.com/numtide/treefmt-nix/commit/2ca2bf4e3e821451e8936549279024f08ef5a139) | `` Add meson's formatter ``           |