### PR TITLE
chore(flake/nixvim): `9307b201` -> `400d1d92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726676531,
-        "narHash": "sha256-i8Pbd7JszwuCb0HqzAPypv2ytdcsFeAMFqbrmLaN4BE=",
+        "lastModified": 1726785706,
+        "narHash": "sha256-eEa/EHO8UKYBTcQECyzF9pZm2ualqO8mr79djYJuYWE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "9307b201a3dc57d5b71ded4f897ea9d096544877",
+        "rev": "400d1d927d76791b46ae30d431d908c60e411a26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`400d1d92`](https://github.com/nix-community/nixvim/commit/400d1d927d76791b46ae30d431d908c60e411a26) | `` lib: fix escaping bugs in wrapVimscriptForLua and wrapLuaForVimscript `` |
| [`2df1bdd1`](https://github.com/nix-community/nixvim/commit/2df1bdd14d564235a55552dfc6a9dd5018cbad9b) | `` plugins/lsp/gopls: add goPackage ``                                      |
| [`5660c401`](https://github.com/nix-community/nixvim/commit/5660c4011c68f2e7af64dbb1ed356c3f99eff9e5) | `` plugins/alpha: proper terminal support ``                                |
| [`beb42716`](https://github.com/nix-community/nixvim/commit/beb42716ff7d4935c2bd1d8fddf8cce96eaf226a) | `` plugins/alpha: remove helpers and with lib ``                            |
| [`17b79813`](https://github.com/nix-community/nixvim/commit/17b79813bfefaba19e80bcb7a9cafdef4406f6e4) | `` plugins/alpha: rawLua support ``                                         |