### PR TITLE
chore(flake/nixvim): `400d1d92` -> `3211ce35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726785706,
-        "narHash": "sha256-eEa/EHO8UKYBTcQECyzF9pZm2ualqO8mr79djYJuYWE=",
+        "lastModified": 1726846628,
+        "narHash": "sha256-0CH44sEwiljiN2q7eIFCvabyUm1WeEiF8ofP/z5ca0Q=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "400d1d927d76791b46ae30d431d908c60e411a26",
+        "rev": "3211ce356be612ae89a38c60799992bde8a47127",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`3211ce35`](https://github.com/nix-community/nixvim/commit/3211ce356be612ae89a38c60799992bde8a47127) | `` flake.lock: Update ``                |
| [`c2080ede`](https://github.com/nix-community/nixvim/commit/c2080ede4f0e6b838f1437c128e684004776afe3) | `` ci(Mergify): configuration update `` |