### PR TITLE
chore(flake/nixvim): `3211ce35` -> `2bc6a949`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726846628,
-        "narHash": "sha256-0CH44sEwiljiN2q7eIFCvabyUm1WeEiF8ofP/z5ca0Q=",
+        "lastModified": 1726950811,
+        "narHash": "sha256-3ixqPAhMafMP70M4VjOKoLeCCNIvzv2WPzGuphxajcM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "3211ce356be612ae89a38c60799992bde8a47127",
+        "rev": "2bc6a949924319f61619d32695115a61394741f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`2bc6a949`](https://github.com/nix-community/nixvim/commit/2bc6a949924319f61619d32695115a61394741f8) | `` plugins/lsp/ts_ls: add pluginDefault filetypes `` |
| [`a8ab7343`](https://github.com/nix-community/nixvim/commit/a8ab73432aab0086a299182376087d5b77b86f5f) | `` plugins/lsp/volar: add ts-ls integration ``       |
| [`384f97cf`](https://github.com/nix-community/nixvim/commit/384f97cf50c534a18f5a8feac81d40623267aa81) | `` flake.lock: Update ``                             |
| [`2f09998b`](https://github.com/nix-community/nixvim/commit/2f09998b654db4fd9c81d11ece3a40d74e7bf3ac) | `` plugins/otter: add autoActivate ``                |