### PR TITLE
chore(flake/nixvim): `2bc6a949` -> `b473bdc5`

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -81,6 +81,7 @@
       enable = true;
       enableSurround = true;
     };
+    web-devicons.enable = true;
     which-key.enable = true;
   };
 

--- a/config/telescope.nix
+++ b/config/telescope.nix
@@ -1,5 +1,6 @@
 {
   plugins = {
+    web-devicons.enable = true;
     telescope = {
       enable = true;
       extensions = {

--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726950811,
-        "narHash": "sha256-3ixqPAhMafMP70M4VjOKoLeCCNIvzv2WPzGuphxajcM=",
+        "lastModified": 1727031271,
+        "narHash": "sha256-OvekOLCj7kEq6X8Ncgyda1ud4BMD+OxHu7bdIsCtl/g=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2bc6a949924319f61619d32695115a61394741f8",
+        "rev": "b473bdc5ae1260296d0f43f8f1fba6248b1ee078",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`b473bdc5`](https://github.com/nix-community/nixvim/commit/b473bdc5ae1260296d0f43f8f1fba6248b1ee078) | `` treewide: consolidate iconsPackage removal and warning ``               |
| [`38a18356`](https://github.com/nix-community/nixvim/commit/38a183564ba441f80bcf18dab448d1ed8348f440) | `` plugins/telescope: iconsPackage -> icons provider options ``            |
| [`5ff98645`](https://github.com/nix-community/nixvim/commit/5ff98645ce3e52fced5f1a9f07bb9b741993ca7c) | `` plugins/lspsaga: iconsPackage -> icons provider options ``              |
| [`254b15d0`](https://github.com/nix-community/nixvim/commit/254b15d066bfb997a321e44b8880eca2aad2068b) | `` plugins/nvim-tree: iconsPackage -> icons provider options ``            |
| [`e23bd547`](https://github.com/nix-community/nixvim/commit/e23bd5475c992cda52c9e08aad431e73c9f54692) | `` plugins/neo-tree: iconsPackage -> icons provider options ``             |
| [`2e281c43`](https://github.com/nix-community/nixvim/commit/2e281c43e06437eb698ce653b4950c8650344bfb) | `` plugins/trouble: iconsPackage -> icons provider options ``              |
| [`b2929765`](https://github.com/nix-community/nixvim/commit/b2929765ab12fc7bdd5082eab0b9192e3dabdf3f) | `` plugins/alpha: iconsPackage -> icons provider options ``                |
| [`7a3423ae`](https://github.com/nix-community/nixvim/commit/7a3423ae18a3ec653fae5c5f6e430ccb9ac52ab0) | `` plugins/diffview: iconsPackage -> icons provider options ``             |
| [`cf13d60c`](https://github.com/nix-community/nixvim/commit/cf13d60cd64db7cac50a996637f124993d31bcfc) | `` plugins/fzf-lua: iconsPackage -> icons provider options ``              |
| [`59a9652a`](https://github.com/nix-community/nixvim/commit/59a9652aeeb05e629ad838646e870d8a6975b59d) | `` plugins/bufferline: iconsPackage -> icons provider options ``           |
| [`2cf80fd6`](https://github.com/nix-community/nixvim/commit/2cf80fd66fb25bf896292c5598080f1e69e46bbb) | `` plugins/barbar: iconsPackage -> icons provider options ``               |
| [`23a903f1`](https://github.com/nix-community/nixvim/commit/23a903f13c42f897063addc1958160a366295b16) | `` plugins/chadtree: iconsPackage -> icons provider options ``             |
| [`81ae3feb`](https://github.com/nix-community/nixvim/commit/81ae3febd21dfee1371486f82a2e22cb7ed7edb2) | `` lib: throw when deprecated builders are used on a lib without `pkgs` `` |
| [`1116ae63`](https://github.com/nix-community/nixvim/commit/1116ae633278947af22180d2d3a20cf49ef8f0f5) | `` docs: use `evalNixvim` helper ``                                        |
| [`191b0a95`](https://github.com/nix-community/nixvim/commit/191b0a950237e02bc4478b5174c7b5fcf67cc4ef) | `` treewide: avoid passing `pkgs` to our lib ``                            |
| [`76df0961`](https://github.com/nix-community/nixvim/commit/76df09619d081b23b9dcb3cfd96e541c7f895759) | `` lib/types/pluginLuaConfig: only merge `pre` and `post` when defined ``  |
| [`d2f9e011`](https://github.com/nix-community/nixvim/commit/d2f9e011d9c6e3d765422b78039e61ddf9e69749) | `` lib/neovim-plugin: Add lua configuration scoped to the plugin ``        |