### PR TITLE
chore(flake/nixvim): `b473bdc5` -> `47364df4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727031271,
-        "narHash": "sha256-OvekOLCj7kEq6X8Ncgyda1ud4BMD+OxHu7bdIsCtl/g=",
+        "lastModified": 1727118532,
+        "narHash": "sha256-nRzlwdPaSb1UCoqndT52AUNpx9e8wLCEjY28eAkCHIg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b473bdc5ae1260296d0f43f8f1fba6248b1ee078",
+        "rev": "47364df49645e89d8aa03aa61c893e12ecbac366",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`47364df4`](https://github.com/nix-community/nixvim/commit/47364df49645e89d8aa03aa61c893e12ecbac366) | `` lib/types/pluginLuaConfig: use `lib.optional` instead of `lib.mkIf` `` |
| [`a9345dcf`](https://github.com/nix-community/nixvim/commit/a9345dcfc31519734361fecd246d32164feafbca) | `` plugins/markview: mode -> modes ``                                     |