### PR TITLE
chore(flake/nixvim): `47364df4` -> `8f991cc8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727118532,
-        "narHash": "sha256-nRzlwdPaSb1UCoqndT52AUNpx9e8wLCEjY28eAkCHIg=",
+        "lastModified": 1727186381,
+        "narHash": "sha256-T6vSJAvbYSBsaUkwh2adbIt7liE2xpcRhmlosMNZnDo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "47364df49645e89d8aa03aa61c893e12ecbac366",
+        "rev": "8f991cc8bc417ddbd1d5c7732268255557c13f4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                 |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`8f991cc8`](https://github.com/nix-community/nixvim/commit/8f991cc8bc417ddbd1d5c7732268255557c13f4a) | `` wrappers/shared: only propagate files when nixvim is enabled ``      |
| [`87509bac`](https://github.com/nix-community/nixvim/commit/87509bac1f73517d9bb5d696b6d73ba7622cef90) | `` wrappers: move assertion propagation to `_shared.nix` ``             |
| [`6da94195`](https://github.com/nix-community/nixvim/commit/6da94195c2e3ac849eea8fc84febfccbedcbef95) | `` modules/misc: include `assertions` and `meta` modules in the repo `` |
| [`901346e3`](https://github.com/nix-community/nixvim/commit/901346e38b81c236305e29934dd02c1f64bd8621) | `` plugins/luasnip: fix `extend_filetypes` -> `filetype_extend` ``      |
| [`e64c5118`](https://github.com/nix-community/nixvim/commit/e64c511811559033e65d1c57b4d3df83deac7683) | `` tests/package-options: allow option defaults to throw ``             |
| [`a75c2235`](https://github.com/nix-community/nixvim/commit/a75c2235d920dfd443d52c134bb51aa458f26814) | `` plugins/rest: v3 migration ``                                        |
| [`78816c0c`](https://github.com/nix-community/nixvim/commit/78816c0c9c0ecef977b1b3b3ffd4555d6c86120c) | `` flake.lock: Update ``                                                |
| [`9bcba520`](https://github.com/nix-community/nixvim/commit/9bcba520c8148eb65b5de6042828d389a283eccc) | `` plugins/otter: remove cmp source registration ``                     |