### PR TITLE
chore(flake/treefmt-nix): `35dfece1` -> `1bff2ba6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727098951,
-        "narHash": "sha256-gplorAc0ISAUPemUNOnRUs7jr3WiLiHZb3DJh++IkZs=",
+        "lastModified": 1727252110,
+        "narHash": "sha256-3O7RWiXpvqBcCl84Mvqa8dXudZ1Bol1ubNdSmQt7nF4=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "35dfece10c642eb52928a48bee7ac06a59f93e9a",
+        "rev": "1bff2ba6ec22bc90e9ad3f7e94cca0d37870afa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                          |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`1bff2ba6`](https://github.com/numtide/treefmt-nix/commit/1bff2ba6ec22bc90e9ad3f7e94cca0d37870afa3) | `` fix(programs): latexindent missing overwrite option (#237) `` |
| [`7f527da1`](https://github.com/numtide/treefmt-nix/commit/7f527da1f2a773a121ef7b52c1e9d39008d8177f) | `` rustfmt: add skip children (#240) ``                          |
| [`9ee50d37`](https://github.com/numtide/treefmt-nix/commit/9ee50d37acbbc37fc51335d9bfd0f4c8d2d9867b) | `` meson: format all meson files (#242) ``                       |