### PR TITLE
chore(flake/nixvim): `8f991cc8` -> `7bda0f1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727186381,
-        "narHash": "sha256-T6vSJAvbYSBsaUkwh2adbIt7liE2xpcRhmlosMNZnDo=",
+        "lastModified": 1727286212,
+        "narHash": "sha256-iab+k8m6+MBkwQoyqMcMYggwILHCkMSkgNYd1GN0FbM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8f991cc8bc417ddbd1d5c7732268255557c13f4a",
+        "rev": "7bda0f1ce49e9da252bcee20b5f700e6dcd3cf8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`7bda0f1c`](https://github.com/nix-community/nixvim/commit/7bda0f1ce49e9da252bcee20b5f700e6dcd3cf8d) | `` modules/output: don't remove "site" dir when `impureRtp` is disabled `` |
| [`11924e15`](https://github.com/nix-community/nixvim/commit/11924e15935a359c232cebf7756df1a809f05ae9) | `` modules/output: add `impureRtp` option ``                               |
| [`fb7cda28`](https://github.com/nix-community/nixvim/commit/fb7cda2868fa9646fb9718da37605b9191f71f30) | `` modules/output: refactor `wrapRc` default ``                            |
| [`a8f678da`](https://github.com/nix-community/nixvim/commit/a8f678da24418e1c84eb0818e1d154d67c982033) | `` wrappers: explicitly set `_file` for wrapper modules ``                 |
| [`b3a90d73`](https://github.com/nix-community/nixvim/commit/b3a90d737d5e69d784a07f359ea71178b506b8dd) | `` modules/files: don't set `shorthandOnlyDefinesConfig` ``                |
| [`5b55858f`](https://github.com/nix-community/nixvim/commit/5b55858fe3e59cf3d6587202dfd4d48ca99aa457) | `` wrappers: use `(evalModules {}).type` for nixvim submodule ``           |