### PR TITLE
chore(flake/nixvim): `7bda0f1c` -> `6a1bf6bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727286212,
-        "narHash": "sha256-iab+k8m6+MBkwQoyqMcMYggwILHCkMSkgNYd1GN0FbM=",
+        "lastModified": 1727370276,
+        "narHash": "sha256-CgMTCzKYilIzRSTCrui/4OvMj3yYXjPV+uSFPT9d2MM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7bda0f1ce49e9da252bcee20b5f700e6dcd3cf8d",
+        "rev": "6a1bf6bdc30e0d92139165d30977db9d6ace4c69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`6a1bf6bd`](https://github.com/nix-community/nixvim/commit/6a1bf6bdc30e0d92139165d30977db9d6ace4c69) | `` modules/output: check warnings+assertions on `build.package` `` |
| [`2ea7009e`](https://github.com/nix-community/nixvim/commit/2ea7009e61ea02e08e480c94c06e71e640a59132) | `` tests/none-ls: re-enable clojure ``                             |
| [`1e289328`](https://github.com/nix-community/nixvim/commit/1e28932840f3cc9174b2c95432fb8ade057bf415) | `` tests/lsp: re-enable ols ``                                     |
| [`803bded9`](https://github.com/nix-community/nixvim/commit/803bded988cb9ab0cf88fcf31f694df18079aca5) | `` tests/lsp: re-enable omnisharp ``                               |
| [`5e8f822a`](https://github.com/nix-community/nixvim/commit/5e8f822af5fb3f39cba09dd156531c0aebd624ec) | `` flake-modules/dev: treefmt re-enable taplo linux ``             |
| [`3510cade`](https://github.com/nix-community/nixvim/commit/3510cade90bab98d978d3b045445022107f83671) | `` tests/lint: re-enable clojure ``                                |
| [`59ae79ce`](https://github.com/nix-community/nixvim/commit/59ae79ce79bacaf3a4963ed9de6aa465227d8961) | `` tests/lsp: re-enable taplo ``                                   |
| [`3f17f500`](https://github.com/nix-community/nixvim/commit/3f17f500b389c2d3ba84375373df33945692fc66) | `` lib/maintainers: remove duplicate entry ``                      |
| [`ac14f62e`](https://github.com/nix-community/nixvim/commit/ac14f62e22d8d5b2c0f06029c42847bf404b1789) | `` tests/none-ls: re-enable prisma_format ``                       |
| [`07a65fbd`](https://github.com/nix-community/nixvim/commit/07a65fbd3c1881ef6bcb99aa623e5e1375953b3b) | `` tests/lsp: re-enable prismals ``                                |
| [`6e1f3a50`](https://github.com/nix-community/nixvim/commit/6e1f3a504df1c77e9980c175e4bfcbb47631028f) | `` flake.lock: Update ``                                           |
| [`2ab8751b`](https://github.com/nix-community/nixvim/commit/2ab8751b8be55accb78ca0ca58f1f4ff387001d7) | `` modules/output: add `build.initSource` option ``                |
| [`692e3931`](https://github.com/nix-community/nixvim/commit/692e39311ec19cdd3e623dc14450b64f2aa94d57) | `` modules/{output,files,test}: move outputs to `build` scope ``   |