### PR TITLE
chore(flake/nixvim): `6a1bf6bd` -> `b5c19b6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727370276,
-        "narHash": "sha256-CgMTCzKYilIzRSTCrui/4OvMj3yYXjPV+uSFPT9d2MM=",
+        "lastModified": 1727471696,
+        "narHash": "sha256-3r/VNQp5aJK9Gj8hKdfSYqeXcc0kqpfFYhEg8ioWttE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6a1bf6bdc30e0d92139165d30977db9d6ace4c69",
+        "rev": "b5c19b6abb0fb0156b1cb76793b363e430e2cb47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`b5c19b6a`](https://github.com/nix-community/nixvim/commit/b5c19b6abb0fb0156b1cb76793b363e430e2cb47) | `` plugins/deprecation: update icons warning ``                             |
| [`ae2b9bd4`](https://github.com/nix-community/nixvim/commit/ae2b9bd445ebe5d5342172c66ecbf60028070d32) | `` plugins/idris2: init ``                                                  |
| [`6b0c5d59`](https://github.com/nix-community/nixvim/commit/6b0c5d594ac88e7765c97deeda10c5b6e812f7a7) | `` lib/modules: assert that `specialArgs` has a valid `lib` ``              |
| [`5020e587`](https://github.com/nix-community/nixvim/commit/5020e58798abe56f98a484757dba465e3d713641) | `` lib/modules: remove `specialArgsWith` ``                                 |
| [`4b7a4127`](https://github.com/nix-community/nixvim/commit/4b7a41276ae64dab0a046a4e5833892234b6598a) | `` modules/nixpkgs: initial `pkgs` option, drop `defaultPkgs` specialArg `` |
| [`8c3d521b`](https://github.com/nix-community/nixvim/commit/8c3d521bff0142f9b690bccd62c29b3ce8c71ac8) | `` modules: move `nixpkgs` module to top-level modules ``                   |
| [`31579dc2`](https://github.com/nix-community/nixvim/commit/31579dc201e6097e2bad05c8660c82a109ee2c24) | `` plugins/wrapping: init ``                                                |
| [`10925d81`](https://github.com/nix-community/nixvim/commit/10925d811ce6302f28e0272e04a04436527ed38d) | `` maintainers: add ZainKergaye ``                                          |
| [`2f49c76a`](https://github.com/nix-community/nixvim/commit/2f49c76a6a158ce056c3e7c56e7e0a3d80658c90) | `` lib: remove `nixvimTypes` alias ``                                       |
| [`bafc6308`](https://github.com/nix-community/nixvim/commit/bafc6308f64f9a96f6bdb25b5f2a416b5d48958c) | `` plugins/none-ls/settings: cleanup lib usage ``                           |
| [`a32d2e6d`](https://github.com/nix-community/nixvim/commit/a32d2e6df07024b9f04e0c0f1f9693d0599ca164) | `` plugins: cleanup lib usage in several plugins ``                         |
| [`d718446b`](https://github.com/nix-community/nixvim/commit/d718446b61eb88bd5da5b72624cb2bd0513632d3) | `` lib: remove `maintainers` alias ``                                       |
| [`cb2b76c1`](https://github.com/nix-community/nixvim/commit/cb2b76c1a9ec067ed0c449080f4973fecf8532ef) | `` docs/home-manager: eval options without checking config definitions ``   |