### PR TITLE
chore(flake/nixpkgs): `30439d93` -> `1925c603`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727122398,
-        "narHash": "sha256-o8VBeCWHBxGd4kVMceIayf5GApqTavJbTa44Xcg5Rrk=",
+        "lastModified": 1727348695,
+        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "30439d93eb8b19861ccbe3e581abf97bdc91b093",
+        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`a86a3f14`](https://github.com/NixOS/nixpkgs/commit/a86a3f14c2e79e6ecab2878179806e78e7de1aa9) | `` lnd: add default release tags to tags ``                                 |
| [`0801744c`](https://github.com/NixOS/nixpkgs/commit/0801744c61eaed6a0f88072dd5b167d9c2a0cec9) | `` lnd: format tags as lines ``                                             |
| [`4100f019`](https://github.com/NixOS/nixpkgs/commit/4100f0190b6a667a924b666596d34409c0b9c73e) | `` oidc-agent: 5.2.1 -> 5.2.2 ``                                            |
| [`ec02fa6d`](https://github.com/NixOS/nixpkgs/commit/ec02fa6d399b9810553e1a0e577f1d453c9cb65b) | `` open-webui: 0.3.29 -> 0.3.30 ``                                          |
| [`4e9b9096`](https://github.com/NixOS/nixpkgs/commit/4e9b90969a4e1d1a99a02dbb20ca8b1b48023de9) | `` nixVersions.nix_2_24: 2.24.7 -> 2.24.8 ``                                |
| [`9d43cd13`](https://github.com/NixOS/nixpkgs/commit/9d43cd139e683307b081d36101217c3050848693) | `` kty: init at 0.3.1 ``                                                    |
| [`39fbc9ce`](https://github.com/NixOS/nixpkgs/commit/39fbc9ce2412372861d88946500f5f26a4188963) | `` tar2ext4: 0.12.6 -> 0.12.7 ``                                            |
| [`6f733a03`](https://github.com/NixOS/nixpkgs/commit/6f733a03df80085f85444f4e0714061388527553) | `` Revert "closure-info: switch to stdenvNoCC (#344456)" ``                 |
| [`9be3c09d`](https://github.com/NixOS/nixpkgs/commit/9be3c09dca2838e332aa28179821fcdaf38fe7ad) | `` cloudflare-dynamic-dns: 4.3.2 -> 4.3.3 ``                                |
| [`ec22f512`](https://github.com/NixOS/nixpkgs/commit/ec22f5123146d859bb11b74733c53a7bee5f9f61) | `` picotool: 1.1.2 -> 2.0.0 ``                                              |
| [`c4fc0521`](https://github.com/NixOS/nixpkgs/commit/c4fc0521a90c10d3093e771197e270d466c10148) | `` kubetui: init at 1.5.3 ``                                                |
| [`434cc988`](https://github.com/NixOS/nixpkgs/commit/434cc988e4dd2bd2d6bbe1adb269a3598b0345ca) | `` zed-editor: 0.153.6 -> 0.154.1 ``                                        |
| [`732d3652`](https://github.com/NixOS/nixpkgs/commit/732d36522f4426e3f7e839e2694d28bbaead3f72) | `` nixos/influxdb2: wait until service is ready ``                          |
| [`6311f6f3`](https://github.com/NixOS/nixpkgs/commit/6311f6f3587cf9d45c2d386207d263db9af20933) | `` python312Packages.google-cloud-firestore: 2.18.0 -> 2.19.0 ``            |
| [`545aadd2`](https://github.com/NixOS/nixpkgs/commit/545aadd2f23d9d204373ff066655c4bcaa8034a1) | `` rainfrog: 0.2.4 -> 0.2.5 ``                                              |
| [`335e2788`](https://github.com/NixOS/nixpkgs/commit/335e2788947ce94199c6d792811a4b91f338cb21) | `` home-assistant-custom-lovelace-modules.hourly-weather: 6.1.0 -> 6.2.0 `` |
| [`45791789`](https://github.com/NixOS/nixpkgs/commit/45791789e72d600db1d4d061cff2346963dd88c0) | `` python312Packages.aiohttp-session: 2.12.0 -> 2.12.1 ``                   |
| [`11f1d318`](https://github.com/NixOS/nixpkgs/commit/11f1d318f610442c75a4238429ad0e7aafcff8bc) | `` nixos/graphics: fix typo ``                                              |
| [`c0467c68`](https://github.com/NixOS/nixpkgs/commit/c0467c6864100acfce2a3c382d4b383e5aec4f8c) | `` eigenlayer: 0.10.3 -> 0.10.4 ``                                          |
| [`f28f4bd3`](https://github.com/NixOS/nixpkgs/commit/f28f4bd3c088bc54d566a2e065c052aebe555089) | `` python312Packages.transformers: 4.44.2 -> 4.45.0 ``                      |
| [`499be502`](https://github.com/NixOS/nixpkgs/commit/499be5024e6aacf1c2f4d207f0afa2e3acc5bbb0) | `` python312Packages.tokenizers: add GaetanLepage as maintainer ``          |
| [`2ff0b234`](https://github.com/NixOS/nixpkgs/commit/2ff0b234530014bcfd7c399ddf6fa58e841e9b34) | `` python312Packages.tokenizers: 0.19.1 -> 0.20.0 ``                        |
| [`1908a62e`](https://github.com/NixOS/nixpkgs/commit/1908a62e49e630c8ca3030c902f6e76fed01bc54) | `` CODEOWNERS: Add ElvishJerricco to ISO image. ``                          |
| [`66f1354c`](https://github.com/NixOS/nixpkgs/commit/66f1354c911a6bc5a0005f3fd67153efed22301e) | `` python312Packages.snakemake-storage-plugin-xrootd: 0.1.3 -> 0.1.4 ``     |
| [`4e54d109`](https://github.com/NixOS/nixpkgs/commit/4e54d109121d12c87bdc5685d8bf335c65f5706e) | `` nixos/qemu-vm: Ensure 9pnet_virtio module is loaded for shared dirs ``   |
| [`68324b7d`](https://github.com/NixOS/nixpkgs/commit/68324b7d54eee424a83db49dfbfb652eea0c9cc3) | `` zoneminder: 1.36.33 -> 1.36.34 ``                                        |
| [`4aa2d486`](https://github.com/NixOS/nixpkgs/commit/4aa2d486e1b20082bd21f8fc484e87b689a46a05) | `` linuxPackages.nvidiaPackages.production: 550.107.02 -> 550.120 ``        |
| [`fe866c65`](https://github.com/NixOS/nixpkgs/commit/fe866c653c24adf1520628236d4e70bbb2fdd949) | `` luaPackages.neotest: disable checks on darwin ``                         |
| [`bca8954e`](https://github.com/NixOS/nixpkgs/commit/bca8954e145b6f94907f1471c3d1fd889699aa5c) | `` vimPlugins.nvim-treesitter: update grammars ``                           |
| [`574aa35e`](https://github.com/NixOS/nixpkgs/commit/574aa35e288f14d4bc4ce52f7408a317812bd8df) | `` vimPlugins: update on 2024-09-24 ``                                      |
| [`c25250c4`](https://github.com/NixOS/nixpkgs/commit/c25250c471f6b5edf34c3cfd7725b9fd3c70f1a5) | `` luaPackages: update on 2024-09-24 ``                                     |
| [`c7412922`](https://github.com/NixOS/nixpkgs/commit/c7412922a1d6acdc40250ba8e6460fd39c3fc2c7) | `` deno: mark x86 darwin broken ``                                          |
| [`dfb72de3`](https://github.com/NixOS/nixpkgs/commit/dfb72de3dbe62ff47e59894d50934e03f0602072) | `` deno: 1.46.2 -> 1.46.3 ``                                                |
| [`cadf53ea`](https://github.com/NixOS/nixpkgs/commit/cadf53ea4da3161000a30ebf0ad56a46cac9b2a0) | `` deno: move to by-name ``                                                 |
| [`8a7af382`](https://github.com/NixOS/nixpkgs/commit/8a7af3824a78d188f1f8951ed57eca43eb6ac6df) | `` deno: format ``                                                          |
| [`4cb379f4`](https://github.com/NixOS/nixpkgs/commit/4cb379f4d78080cd004a6056f6ce5ccac9db7eaa) | `` treewide: use `nativeBuildInputs` in appimage builder derivations ``     |
| [`9ae5068b`](https://github.com/NixOS/nixpkgs/commit/9ae5068b42afbe1e43276750fa302406cec3a5aa) | `` caido: 0.40 -> 0.41 ``                                                   |
| [`f7ef27a9`](https://github.com/NixOS/nixpkgs/commit/f7ef27a9822bf11daec0673a4330732fdc494b6a) | `` {buildFHSEnvBubblewrap,buildFHSEnvChroot}: add `nativeBuildInputs` ``    |
| [`a4d8aa61`](https://github.com/NixOS/nixpkgs/commit/a4d8aa61eeb7ec1bf48e874c87dd7b71eec6a8a4) | `` cosmic-osd: inline repo pname ``                                         |
| [`5fcd8ed7`](https://github.com/NixOS/nixpkgs/commit/5fcd8ed7e61d53fe1430c381da15f1a47cac2f6f) | `` siyuan: use buildGo123Module ``                                          |
| [`a0326554`](https://github.com/NixOS/nixpkgs/commit/a0326554232a57ed1eeee5a4e8008f52ccc0042b) | `` cosmic-notifications: substituteInPlace prefer --replace-fail ``         |
| [`020cd950`](https://github.com/NixOS/nixpkgs/commit/020cd9506a5d97bd371cc974684aa6b97eaefb9a) | `` cosmic-notifications: 1.0.0-alpha.1 -> 1.0.0-alpha.2 ``                  |
| [`bde04503`](https://github.com/NixOS/nixpkgs/commit/bde04503be310499e7472165fb5a031a70f8d3eb) | `` surrealdb: 2.0.1 -> 2.0.2 ``                                             |
| [`f3e646b7`](https://github.com/NixOS/nixpkgs/commit/f3e646b76a2b6d208160027da3e831b84033cfed) | `` cosmic-screenshot: 1.0.0-alpha.1 -> 1.0.0-alpha.2 ``                     |
| [`7f64091a`](https://github.com/NixOS/nixpkgs/commit/7f64091ac1e3db76fbdb06d3ad6d050d59d44699) | `` cosmic-randr: 1.0.0-alpha.1 -> 1.0.0-alpha.2 ``                          |
| [`7532ca92`](https://github.com/NixOS/nixpkgs/commit/7532ca92bb0952d670c55dcdb0f73b4baf17014d) | `` cosmic-osd: 1.0.0-alpha.1 -> 1.0.0-alpha.2 ``                            |
| [`3b5971e7`](https://github.com/NixOS/nixpkgs/commit/3b5971e7a306482771178dd89d71ae2754406c49) | `` file .git-blame-ignore-revs: add "fetchurl: nixfmt-rfc-style" ``         |
| [`ce21e97a`](https://github.com/NixOS/nixpkgs/commit/ce21e97a1f20dee15da85c084f9d1148d84f853b) | `` fetchurl: nixfmt-rfc-style ``                                            |
| [`a32c7a11`](https://github.com/NixOS/nixpkgs/commit/a32c7a11dd2aa586abf8821c2b8569ca736f97ce) | `` fetchurl: fixup typo on a comment ``                                     |
| [`448240f6`](https://github.com/NixOS/nixpkgs/commit/448240f6e2714834d0d5ecd83d82d3ae41188535) | `` nixos/nfsd: fix typo that breaks services.nfs.settings (#342200) ``      |
| [`57b9f127`](https://github.com/NixOS/nixpkgs/commit/57b9f127287e50a77c643c37bca92825c9b4cebd) | `` nixos/scion: init scion ip gateway config in test ``                     |
| [`6c527bf0`](https://github.com/NixOS/nixpkgs/commit/6c527bf0fbadcd61e56cf4bcfab600e89233604e) | `` nixos/scion: init scion-ip-gateway module ``                             |
| [`828ce9b1`](https://github.com/NixOS/nixpkgs/commit/828ce9b12347f041294392de552e11f591025df5) | `` nixos/scion: breakout bootstrap.sh in freestanding ``                    |
| [`fb1b5a4a`](https://github.com/NixOS/nixpkgs/commit/fb1b5a4ac8356c97b0c24108d334ed97a41f84d3) | `` python312Packages.awesomeversion: 24.2.0 -> 24.6.0 (#323001) ``          |
| [`88a3127a`](https://github.com/NixOS/nixpkgs/commit/88a3127a6047854aa5c0bdc191cbb8129fa88083) | `` apparmor: fix invalid reference when withPython=false ``                 |
| [`cb7f76ef`](https://github.com/NixOS/nixpkgs/commit/cb7f76ef98390c6f07194d094b1f8dd76d99ecba) | `` nextcloud-client: fix description (#344196) ``                           |
| [`e7baca71`](https://github.com/NixOS/nixpkgs/commit/e7baca71a74e04b3fa9a3c1ab5b63550a9d4f585) | `` yudit: init at 3.1.0 ``                                                  |
| [`4e4b0f39`](https://github.com/NixOS/nixpkgs/commit/4e4b0f394362ab5981d0c3d46a1a41e504718e3c) | `` cosmic-icons: 1.0.0-alpha.1-unstable-2024-08-16 -> 1.0.0-alpha.2 ``      |
| [`8e7b6a0c`](https://github.com/NixOS/nixpkgs/commit/8e7b6a0ce70685324af3415c99b0d701ab4ba98e) | `` python312Packages.stookwijzer: 1.4.9 -> 1.4.10 ``                        |
| [`7edb25d2`](https://github.com/NixOS/nixpkgs/commit/7edb25d2841827688cb1d48bce44a522f5bf6711) | `` taler-{sync,challenger}: add aliases ``                                  |
| [`c6819cc3`](https://github.com/NixOS/nixpkgs/commit/c6819cc3b7f9d0db2cb4c660be37ee8dbe48ae07) | `` rye: 0.39.0 -> 0.40.0 ``                                                 |
| [`7f4dd46f`](https://github.com/NixOS/nixpkgs/commit/7f4dd46fab3a27977c6d80c278cbd3a53c9c3980) | `` cypress: add support for aarch64 on darwin ``                            |
| [`79788285`](https://github.com/NixOS/nixpkgs/commit/7978828566abbac9c442f5137136d99eac67a746) | `` closure-info: switch to stdenvNoCC ``                                    |
| [`e20f20ac`](https://github.com/NixOS/nixpkgs/commit/e20f20acaed49e8cebf6ec6a30ca9c33f15df5c3) | `` vscode-extensions.tekumara.typos-vscode: 0.1.19 -> 0.1.26 ``             |
| [`64a2b735`](https://github.com/NixOS/nixpkgs/commit/64a2b735c6bbbddf857dcd735dd999870894ec20) | `` resticprofile: use buildGo123Module ``                                   |
| [`3510b853`](https://github.com/NixOS/nixpkgs/commit/3510b853efd22fd14062785300e171cd0867b7c8) | `` oh-my-zsh: 2024-09-01 -> 2024-09-22 (#343890) ``                         |
| [`c6bf161b`](https://github.com/NixOS/nixpkgs/commit/c6bf161ba4dea5881865eb2e9be43f962767c0c8) | `` typos-lsp: 0.1.19 -> 0.1.26 ``                                           |
| [`04914842`](https://github.com/NixOS/nixpkgs/commit/04914842b9fbea26dcb2fe760a7a93060c10baee) | `` open-webui: 0.3.28 -> 0.3.29 ``                                          |
| [`7cefd841`](https://github.com/NixOS/nixpkgs/commit/7cefd8416d9cb3fb097117afb2c3a03d69d56080) | `` rainfrog: init at 0.2.4 ``                                               |
| [`8b2ec9bf`](https://github.com/NixOS/nixpkgs/commit/8b2ec9bfddde3271ad82f5e57a1e79fc0cb54d21) | `` blender: 4.2.1 -> 4.2.2 ``                                               |
| [`c107f156`](https://github.com/NixOS/nixpkgs/commit/c107f15682f162f7d23bf0ec315c973edbe48251) | `` blender: use tag as rev for assets repo ``                               |
| [`eb191b22`](https://github.com/NixOS/nixpkgs/commit/eb191b226e3344ccc1f8bc4e7e9cfb802bcc0e85) | `` fwupd: 1.9.24 -> 1.9.25 ``                                               |
| [`0daf8a71`](https://github.com/NixOS/nixpkgs/commit/0daf8a713bd5c87b04a7ce9903b1a921e2b21018) | `` dezoomify-rs: 2.12.5 -> 2.13.0 ``                                        |
| [`51c7511b`](https://github.com/NixOS/nixpkgs/commit/51c7511b183091029cf33470960f38259dbbbc67) | `` python311Packages.angr: 9.2.118 -> 9.2.119 ``                            |
| [`b1fb31ae`](https://github.com/NixOS/nixpkgs/commit/b1fb31aeb8cbb64f0c9e5908e71a18cc5a182f5b) | `` python312Packages.cle: 9.2.118 -> 9.2.119 ``                             |
| [`55860f81`](https://github.com/NixOS/nixpkgs/commit/55860f816c74231c98d50577b4144e9b52a1b47d) | `` python312Packages.claripy: 9.2.118 -> 9.2.119 ``                         |
| [`a2421d1d`](https://github.com/NixOS/nixpkgs/commit/a2421d1d5f613f21b47b6058f4140bb1b8ccb13d) | `` python312Packages.pyvex: 9.2.118 -> 9.2.119 ``                           |
| [`ec07960b`](https://github.com/NixOS/nixpkgs/commit/ec07960b821ec8d782683aefd0d288f1876efe3d) | `` python312Packages.ailment: 9.2.118 -> 9.2.119 ``                         |
| [`6374fdf5`](https://github.com/NixOS/nixpkgs/commit/6374fdf5e2bbd278f97ae9fcc6e4b6fd7411e706) | `` python312Packages.archinfo: 9.2.118 -> 9.2.119 ``                        |
| [`575c3658`](https://github.com/NixOS/nixpkgs/commit/575c3658d8b6b66ab09a04944c4518c92b8a4c9f) | `` python312Packages.angr: no support for unicorn 2.1.0 yet ``              |
| [`c65843ed`](https://github.com/NixOS/nixpkgs/commit/c65843edf452acfcc42fcfe9a3a98f2dc4fdb84e) | `` python312Packages.unicorn: remove patch ``                               |
| [`d28bcd25`](https://github.com/NixOS/nixpkgs/commit/d28bcd25ddb39437af410fb4bf2c1a37ec056329) | `` unicorn: 2.0.1.post1 -> 2.1.0 ``                                         |
| [`dd38bc27`](https://github.com/NixOS/nixpkgs/commit/dd38bc27dd485065b2d5e63a22d19cd976cc6c57) | `` pocketbase: 0.22.20 -> 0.22.21 ``                                        |
| [`1990dc11`](https://github.com/NixOS/nixpkgs/commit/1990dc11b769d806119c9f0af8a49ebf323f33a3) | `` shellhub-agent: 0.16.0 -> 0.16.2 ``                                      |
| [`2d192a06`](https://github.com/NixOS/nixpkgs/commit/2d192a061a6e8d12628edf1652581036b6a862c7) | `` php84Extensions.mongodb: 1.19.4 -> 1.20.0 ``                             |
| [`72b40575`](https://github.com/NixOS/nixpkgs/commit/72b40575d2431b090a4792a3832bff8200b7cde7) | `` python312Packages.flickrapi: patch tests ``                              |
| [`6b2f4f3d`](https://github.com/NixOS/nixpkgs/commit/6b2f4f3d0e97834a8396e649482cd8885b9dcb67) | `` python312Packages.flickrapi: refactor ``                                 |
| [`359d0354`](https://github.com/NixOS/nixpkgs/commit/359d035405c61e4487b5ed05ba852809e8200ebd) | `` rclone: 1.68.0 -> 1.68.1 ``                                              |
| [`6918e2e0`](https://github.com/NixOS/nixpkgs/commit/6918e2e0ba0486085d266dd7b13263aa0ecbb619) | `` stripe-cli: 1.21.5 -> 1.21.6 ``                                          |
| [`da5f7a87`](https://github.com/NixOS/nixpkgs/commit/da5f7a87fea1b3306bc4a063c07ec12abfcb2776) | `` pluto: 5.20.2 -> 5.20.3 ``                                               |
| [`593f7449`](https://github.com/NixOS/nixpkgs/commit/593f744926f3efe4c74764e6bf926bae207b8af7) | `` softether: format and move to new pkgs/by-name structure ``              |
| [`8a8aa978`](https://github.com/NixOS/nixpkgs/commit/8a8aa978c182c2838051adc6babd8811d4ae8167) | `` python312Packages.e3-testsuite: refactor ``                              |
| [`6ce550e2`](https://github.com/NixOS/nixpkgs/commit/6ce550e2bbf9521d2caa12f0ef935d700ce191f1) | `` python312Packages.e3-core: 22.5.0 -> 22.6.0 ``                           |
| [`5c863c35`](https://github.com/NixOS/nixpkgs/commit/5c863c35b62857876ead0f274b5a422950be9dd2) | `` anchor: run nixfmt ``                                                    |
| [`0c8a2fda`](https://github.com/NixOS/nixpkgs/commit/0c8a2fdad58f8f7d83de8e9cbd3c4ce55c080029) | `` anchor: fix build ``                                                     |
| [`3701aed3`](https://github.com/NixOS/nixpkgs/commit/3701aed36f0dd031f44c0892ce84c0e5adab4e64) | `` cargo2junit: fix build ``                                                |
| [`d53f42a5`](https://github.com/NixOS/nixpkgs/commit/d53f42a522452fd4c05d6adb540f18604d380beb) | `` cargo2junit: nixfmt; move to by-name ``                                  |