### PR TITLE
chore(flake/nixvim): `b5c19b6a` -> `2c4e4681`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727471696,
-        "narHash": "sha256-3r/VNQp5aJK9Gj8hKdfSYqeXcc0kqpfFYhEg8ioWttE=",
+        "lastModified": 1727557953,
+        "narHash": "sha256-xe8JQaNOPTyzWsSlLu2yC6qw4SjOMHrXk4Iq+pIgLhM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b5c19b6abb0fb0156b1cb76793b363e430e2cb47",
+        "rev": "2c4e4681db658deeceb2f781136d7ba1d0009521",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`2c4e4681`](https://github.com/nix-community/nixvim/commit/2c4e4681db658deeceb2f781136d7ba1d0009521) | `` plugins/avante: init ``          |
| [`c06d5983`](https://github.com/nix-community/nixvim/commit/c06d598315a2f90e59f10a27350b8d1475aa93ee) | `` maintainers: add wadsaek ``      |
| [`c32a43a8`](https://github.com/nix-community/nixvim/commit/c32a43a862000f693ef6d7a56b23d4e5878312b3) | `` plugins/lsp-signature: init ``   |
| [`13564727`](https://github.com/nix-community/nixvim/commit/13564727c59831ff36a9d091024fa79aeca86839) | `` plugins/render-markdown: init `` |
| [`f9dcd86c`](https://github.com/nix-community/nixvim/commit/f9dcd86caefab831dc0c0612305772d31694a93e) | `` flake.lock: Update ``            |