### PR TITLE
chore(flake/nixvim): `2c4e4681` -> `5f4a4b47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727557953,
-        "narHash": "sha256-xe8JQaNOPTyzWsSlLu2yC6qw4SjOMHrXk4Iq+pIgLhM=",
+        "lastModified": 1727645871,
+        "narHash": "sha256-Os3PAThU5XliKkKa+SHsFyV/EsCHogHcYONmpzb6500=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2c4e4681db658deeceb2f781136d7ba1d0009521",
+        "rev": "5f4a4b47597d3b9ac26c41ff4e8da28fa662f200",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`5f4a4b47`](https://github.com/nix-community/nixvim/commit/5f4a4b47597d3b9ac26c41ff4e8da28fa662f200) | `` plugins/earthly: add plugin ``                                 |
| [`844336ce`](https://github.com/nix-community/nixvim/commit/844336ceb2e9c3b3509dda3a0b7917bbc8f7a08e) | `` plugins/web-devicons: support custom icons and default icon `` |
| [`4e2a0221`](https://github.com/nix-community/nixvim/commit/4e2a0221653da2e541dd1197d2afdf87b1c14255) | `` lib/to-lua: fix `allowUnkeyedAttrs` option ``                  |
| [`2cda50d5`](https://github.com/nix-community/nixvim/commit/2cda50d530bdefde477a4eaf65df7f7b3054d52e) | `` plugins: remove redundant `mkRaw` `apply` functions ``         |
| [`bd6aa476`](https://github.com/nix-community/nixvim/commit/bd6aa476b81aa543a437afa347ba2b6a7eec694f) | `` lib/options: remove redundant `mkRaw` `apply` functions ``     |
| [`a9c08fb6`](https://github.com/nix-community/nixvim/commit/a9c08fb6a542137ea327659d95c4ea4a5bc5d5be) | `` lib/types: make `strLua` coerce strings to rawLua ``           |
| [`7886be87`](https://github.com/nix-community/nixvim/commit/7886be87601e7e827315df436a23e1b26a08c117) | `` lib/types: flip `maybeRaw`'s merge function ``                 |
| [`cd76b4fe`](https://github.com/nix-community/nixvim/commit/cd76b4feb87766e76ca48e31d85c7d58d5ae354a) | `` lib: remove `helpers` from internal usage ``                   |