### PR TITLE
chore(flake/nixvim): `5f4a4b47` -> `0ca98d02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727645871,
-        "narHash": "sha256-Os3PAThU5XliKkKa+SHsFyV/EsCHogHcYONmpzb6500=",
+        "lastModified": 1727871072,
+        "narHash": "sha256-t+YLQwBB1soQnVjT6d7nQq4Tidaw7tpB8i6Zvpc+Zbs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "5f4a4b47597d3b9ac26c41ff4e8da28fa662f200",
+        "rev": "0ca98d02104f7f0a703787a7a080a570b7f1bedd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`0ca98d02`](https://github.com/nix-community/nixvim/commit/0ca98d02104f7f0a703787a7a080a570b7f1bedd) | `` plugins/wrapping: Add more options ``     |
| [`846e1a32`](https://github.com/nix-community/nixvim/commit/846e1a321a0735416316d50baf2957ef260a3a46) | `` config-examples: add zainkergaye ``       |
| [`dfbd2721`](https://github.com/nix-community/nixvim/commit/dfbd272170805486383433114a5ed66ec9e9f040) | `` tests/neorg: re-enable finally ``         |
| [`90a4e3d8`](https://github.com/nix-community/nixvim/commit/90a4e3d88b45275e13d6ab782c9ea2abaf94147d) | `` tests/lsp/efmls: re-enable cpplint ``     |
| [`52984eaa`](https://github.com/nix-community/nixvim/commit/52984eaa0faafe9b0ae539f846a4af37c10a1565) | `` tests/lsp/efmls: disable php on darwin `` |
| [`675c5f27`](https://github.com/nix-community/nixvim/commit/675c5f27fc400a6b1e730fca6973a2e09c4c993c) | `` flake.lock: Update ``                     |