### PR TITLE
chore(flake/nixpkgs): `06cf0e1d` -> `bc947f54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727634051,
-        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
+        "lastModified": 1728018373,
+        "narHash": "sha256-NOiTvBbRLIOe5F6RbHaAh6++BNjsb149fGZd1T4+KBg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
+        "rev": "bc947f541ae55e999ffdb4013441347d83b00feb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`d77225b9`](https://github.com/NixOS/nixpkgs/commit/d77225b9f067feff3f2d34feffb9dd1e19f3bac4) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.0.5 -> 4.0.6 `` |
| [`65697284`](https://github.com/NixOS/nixpkgs/commit/6569728429ed9a4126e8b3a54d8d82a5a9220478) | `` superfile: 1.1.4 -> 1.1.5 ``                                                    |
| [`48b4aa8e`](https://github.com/NixOS/nixpkgs/commit/48b4aa8eae376e140698bef3c754814e716701fb) | `` openwebrx: s/alsaUtils/alsa-utils/ ``                                           |
| [`2a5cba2f`](https://github.com/NixOS/nixpkgs/commit/2a5cba2fa67d5d6e3a8a7953d3f79372ab20dfa3) | `` vimPlugins.cord-nvim: 2024-07-19 -> 0-unstable-2024-09-26 ``                    |
| [`8b3a0785`](https://github.com/NixOS/nixpkgs/commit/8b3a078501b589714b62899c2819a9a3366c0c29) | `` python312Packages.tinygrad: patch clang directly in source file ``              |
| [`e6d7bbf7`](https://github.com/NixOS/nixpkgs/commit/e6d7bbf71d946affdef7b454ae6ec0da1adecfe4) | `` nixos/prometheus-dnsmasq-exporter: use a working default leasesPath ``          |
| [`10dbb889`](https://github.com/NixOS/nixpkgs/commit/10dbb88971c852b67f0cacba27f5b574c735abba) | `` rl-notes/24.11: Add note about ZFS import being in `postResumeCommands` ``      |
| [`924ee0c2`](https://github.com/NixOS/nixpkgs/commit/924ee0c2bc8e1b7be7369a34708ded4b06a26dfc) | `` nixos/suricata: init module ``                                                  |
| [`ba727987`](https://github.com/NixOS/nixpkgs/commit/ba727987d4a88c199bf627bc543e57cfd199a187) | `` nixos/fedimintd: init services ``                                               |
| [`4935084c`](https://github.com/NixOS/nixpkgs/commit/4935084ce61f410dce4a15989ae26ae90d9d4368) | `` opentofu: 1.8.2 -> 1.8.3 ``                                                     |
| [`d042b834`](https://github.com/NixOS/nixpkgs/commit/d042b834b1f9d086d3d09cd1d7f7707764b2d26f) | `` wlink: init at 0.0.9 ``                                                         |
| [`a8b8c550`](https://github.com/NixOS/nixpkgs/commit/a8b8c550696cdeb3d6024846ae3ce7c6a2168121) | `` python312Packages.pysigma-backend-insightidr: 0.2.3 -> 0.2.4 ``                 |
| [`2b58c0b4`](https://github.com/NixOS/nixpkgs/commit/2b58c0b4b29caabe57bc18670754a9ca8419ac1e) | `` google-chrome: add rpath for libGLESv2.so as well ``                            |
| [`85ab36bb`](https://github.com/NixOS/nixpkgs/commit/85ab36bb84152ff154f5d9a0b05a8bc8b3d6c2f9) | `` valkey: 7.2.6 -> 7.2.7 ``                                                       |
| [`65043753`](https://github.com/NixOS/nixpkgs/commit/650437530270d1cf71bf5e3fe6e5385b47526661) | `` tf-summarize: 0.3.10 -> 0.3.11 ``                                               |
| [`cd0a0dac`](https://github.com/NixOS/nixpkgs/commit/cd0a0dac6867f11b046f0195b13e5c57fa13cdcb) | `` google-chrome: replace bundled libvulkan.so.1 with vulkan-loader's ``           |
| [`263e6753`](https://github.com/NixOS/nixpkgs/commit/263e67535e09fadf964bc4fcb47557d9f2f393ef) | `` python312Packages.pychromecast: 14.0.1 -> 14.0.2 ``                             |
| [`4e161960`](https://github.com/NixOS/nixpkgs/commit/4e161960552c82cefe754bef79b41e22572ac28e) | `` songrec: 0.4.2 -> 0.4.3 ``                                                      |
| [`1f52ea5b`](https://github.com/NixOS/nixpkgs/commit/1f52ea5b8da4dcafbc7e02c0dc13cffc39b5367b) | `` google-chrome: 129.0.6668.58 -> 129.0.6668.89 ``                                |
| [`3b36b87e`](https://github.com/NixOS/nixpkgs/commit/3b36b87e1a367c55dcee2ae424ff2a00df9378bb) | `` classicube: 1.3.6 -> 1.3.7 (#345753) ``                                         |
| [`2d836948`](https://github.com/NixOS/nixpkgs/commit/2d836948f67f376c82074fd381459f0762924a3e) | `` chromium,chromedriver: 129.0.6668.70 -> 129.0.6668.89 ``                        |
| [`486b1ed0`](https://github.com/NixOS/nixpkgs/commit/486b1ed071c9ca2af9eaf201b20417719e5528a7) | `` python312Packages.pathos: 0.3.2 -> 0.3.3 ``                                     |
| [`e0a0f4f1`](https://github.com/NixOS/nixpkgs/commit/e0a0f4f1f7ed5accae8b8d902b387a5d77cd5506) | `` almo: init at 0.9.5-alpha (#343864) ``                                          |
| [`421ea9e1`](https://github.com/NixOS/nixpkgs/commit/421ea9e137041af4021fbec9283f9e14a72fda7b) | `` tex-fmt: 0.4.3 -> 0.4.4 ``                                                      |
| [`825867ba`](https://github.com/NixOS/nixpkgs/commit/825867ba4b5fe5d0479f4d661ac4100fb506461d) | `` scalr-cli: 0.15.5 -> 0.16.0 ``                                                  |
| [`40d78f5d`](https://github.com/NixOS/nixpkgs/commit/40d78f5d7b6cbbdbed2221c465c3e52f45c713ca) | `` kubelogin-oidc: 1.30.0 -> 1.30.1 (#346100) ``                                   |
| [`46609270`](https://github.com/NixOS/nixpkgs/commit/466092701d53c3e641be4b156d431f9c7df733a9) | `` moosefs: apply nixfmt ``                                                        |
| [`dc279152`](https://github.com/NixOS/nixpkgs/commit/dc279152f21368d13524315be801e6d1e8689d02) | `` moosefs: remove "with lib;" in meta ``                                          |
| [`8bfd0bc8`](https://github.com/NixOS/nixpkgs/commit/8bfd0bc8e0f1fea49e44619b8f8864ba65d7b278) | `` moosefs: add markuskowa to maintainers ``                                       |
| [`ed42711c`](https://github.com/NixOS/nixpkgs/commit/ed42711c680e9f2e5b8512b246300989ffb83378) | `` python312Packages.array-api-compat: 1.8 -> 1.9 ``                               |
| [`087becfe`](https://github.com/NixOS/nixpkgs/commit/087becfe009a7619570f09ee66d138fbbf24bb62) | `` python312Packages.aiomealie: 0.9.2 -> 0.9.3 ``                                  |
| [`f62d89a2`](https://github.com/NixOS/nixpkgs/commit/f62d89a2c689b533f3d36bf8c3bedf34ee9c3e98) | `` python312Packages.aiohttp-basicauth: 1.0.0 -> 1.1.0 ``                          |
| [`15559ac2`](https://github.com/NixOS/nixpkgs/commit/15559ac221e6d4aa8cf706e44a41061ff747b29a) | `` php84.extensions.pcov: fix build ``                                             |
| [`4521df44`](https://github.com/NixOS/nixpkgs/commit/4521df44aae6f762c5dff7d74e63b3bf1b6e33b4) | `` unityhub: add unity 6 editor dependencies ``                                    |
| [`6b176627`](https://github.com/NixOS/nixpkgs/commit/6b17662793973125919e36cf077b0ba0b1b98efb) | `` maintainers: add jwillikers ``                                                  |
| [`edab40d2`](https://github.com/NixOS/nixpkgs/commit/edab40d27f5af3d8d48ad8f87343332563d71ea9) | `` marble-shell-theme: init at 46.2.3 ``                                           |
| [`ac0a31d8`](https://github.com/NixOS/nixpkgs/commit/ac0a31d8320a577680d857b5b72b4acad80cb84d) | `` faudio: change platforms to unix ``                                             |
| [`023bdebe`](https://github.com/NixOS/nixpkgs/commit/023bdebe7756c19ae46cced7ff0d4b3feee0ab3a) | `` buildGraalvm: move files in $out to $out/share ``                               |
| [`511fa806`](https://github.com/NixOS/nixpkgs/commit/511fa806d54b40c96afa7d884b8c52c960fc3db1) | `` nzbhydra2: 7.6.0 -> 7.7.0 ``                                                    |
| [`ce070434`](https://github.com/NixOS/nixpkgs/commit/ce070434fd193d750994eecc0a49da7deb186824) | `` opcr-policy: 0.2.18 -> 0.2.19 ``                                                |
| [`3516a831`](https://github.com/NixOS/nixpkgs/commit/3516a83150bbdd9c0f9d435b4da748357be458d5) | `` emacs: bump emacs2nix to handle more versions with non-digit chars ``           |
| [`6d5e7f04`](https://github.com/NixOS/nixpkgs/commit/6d5e7f0425c30730038085053400d48381f59d7e) | `` python312Packages.pycrdt: 0.9.11 -> 0.9.15 ``                                   |
| [`32b2c9d9`](https://github.com/NixOS/nixpkgs/commit/32b2c9d999dcf81d72057e70a86247ea26908d17) | `` python312Packages.sagemaker: 2.224.1 -> 2.232.1 ``                              |
| [`83bec9a6`](https://github.com/NixOS/nixpkgs/commit/83bec9a6b393993ef4182f443e9397f7f9a375dc) | `` python312Packages.sagemaker-core: init at 1.0.10 ``                             |
| [`0115bf0f`](https://github.com/NixOS/nixpkgs/commit/0115bf0f8090f1a9d09fe0faa239b580e49a00d9) | `` jbigkit: add Archlinux patch to fix heap overflow issue ``                      |
| [`7d4cd386`](https://github.com/NixOS/nixpkgs/commit/7d4cd3864d6ad39fc35a783ab125a2b225875a43) | `` proto: 0.41.1 -> 0.41.3 ``                                                      |
| [`811d1e7e`](https://github.com/NixOS/nixpkgs/commit/811d1e7e2f56be5ecaad0cd18102b44a8e525085) | `` arkade: 0.11.26 -> 0.11.27 ``                                                   |
| [`cab7a26e`](https://github.com/NixOS/nixpkgs/commit/cab7a26ec91db988599e2083b8d1ccba1eed04b1) | `` aiken: 1.1.3 -> 1.1.4 ``                                                        |
| [`f5187e3b`](https://github.com/NixOS/nixpkgs/commit/f5187e3bd37c656d5b3ba046c5a9036cb55efb19) | `` gowitness: 3.0.3 -> 3.0.4 ``                                                    |
| [`820eb4f3`](https://github.com/NixOS/nixpkgs/commit/820eb4f3a698ae7477f1338bade0536de909a58c) | `` jbigkit: add patch to fix security issue CVE-2017-9937 ``                       |
| [`9763971a`](https://github.com/NixOS/nixpkgs/commit/9763971aba22243d878ba839900dd5f224c3f131) | `` slweb: 0.9.0 -> 0.10.1 ``                                                       |
| [`d3cbba5a`](https://github.com/NixOS/nixpkgs/commit/d3cbba5a3193f48847ed079976d7fc87b07374df) | `` roon-server: 2.0-1455 -> 2.0-1462 ``                                            |
| [`99684d17`](https://github.com/NixOS/nixpkgs/commit/99684d17aec7891ee77a696e043a25e5dc794262) | `` runme: 3.0.2 -> 3.7.1 ``                                                        |
| [`5611ee64`](https://github.com/NixOS/nixpkgs/commit/5611ee6441da7ad0f0c9c045b2dac9639de90d63) | `` pritunl-ssh: 1.0.3219.78 -> 1.0.3231.6 ``                                       |
| [`f6be9740`](https://github.com/NixOS/nixpkgs/commit/f6be9740d894c97ad7cc7685031c5983ba04adb4) | `` ikos: 3.3 -> 3.4 ``                                                             |
| [`169b010d`](https://github.com/NixOS/nixpkgs/commit/169b010d52b53a88b045c89059b6b9852612885d) | `` hugo: 0.134.3 -> 0.135.0 ``                                                     |
| [`2a2b9ef2`](https://github.com/NixOS/nixpkgs/commit/2a2b9ef2dc28c94f9b57f71cec86111c164b0a7b) | `` marwaita-teal: 21 -> 22 ``                                                      |
| [`d8ff2600`](https://github.com/NixOS/nixpkgs/commit/d8ff260087eb23561d83749750036041522776e8) | `` python312Packages.pymc: update hash ``                                          |
| [`be0036b7`](https://github.com/NixOS/nixpkgs/commit/be0036b7034975f8dd0e1154ecf1852e5db8a21d) | `` python312Packages.pytensor: 2.25.4 -> 2.25.6 ``                                 |
| [`bf8c66fc`](https://github.com/NixOS/nixpkgs/commit/bf8c66fc22a5de0d5982922175d234e5edf379d2) | `` wstunnel: run the VM test on Linux only ``                                      |
| [`f3fd2a14`](https://github.com/NixOS/nixpkgs/commit/f3fd2a146ca859b3ac7bf919d739322fe6681332) | `` gql: 0.27.0 -> 0.28.0 ``                                                        |
| [`a37cee36`](https://github.com/NixOS/nixpkgs/commit/a37cee3694acb7fa55e845d6977a635d83f13958) | `` certinfo: 1.0.23 -> 1.0.24 ``                                                   |
| [`32118def`](https://github.com/NixOS/nixpkgs/commit/32118def6dd5bfd0fa96123e3a3a4ac80d98cca1) | `` bazelisk: 1.21.0 -> 1.22.0 ``                                                   |
| [`5b1d3e23`](https://github.com/NixOS/nixpkgs/commit/5b1d3e232c6928bda90d3108a70541e2b872accc) | `` gotemplate: 3.7.5 -> 3.9.1 ``                                                   |
| [`ae5064f6`](https://github.com/NixOS/nixpkgs/commit/ae5064f6cead05ca5142e723a52db25157d2db79) | `` wstunnel: 10.1.1 -> 10.1.3 ``                                                   |
| [`066b875a`](https://github.com/NixOS/nixpkgs/commit/066b875a2df1460fcac4e38af865cc393f4dac54) | `` atlas: 0.27.0 -> 0.28.0 ``                                                      |
| [`c71f5316`](https://github.com/NixOS/nixpkgs/commit/c71f5316024c1d2e26f75a26e760a105f9743f72) | `` marwaita-red: 21 -> 22 ``                                                       |
| [`2fcd0009`](https://github.com/NixOS/nixpkgs/commit/2fcd00092fc320007b5157405ba514e7543b8d78) | `` ocamlPackages.augeas: init at 0.6 ``                                            |
| [`10b646ce`](https://github.com/NixOS/nixpkgs/commit/10b646cecb2038d36914bd6a64eb9e84122077e8) | `` exo: init at 0-unstable-2024-10-03 ``                                           |
| [`f1927518`](https://github.com/NixOS/nixpkgs/commit/f1927518dd18f0a93f09a199b533ab50f64d5d91) | `` chickenPackages.chickenEggs.comparse: unbreak ``                                |
| [`5ba93894`](https://github.com/NixOS/nixpkgs/commit/5ba938945e7eb7464ca37d00df3d397c9e423a85) | `` nfs-ganesha: 6.0 -> 6.1 ``                                                      |
| [`44337891`](https://github.com/NixOS/nixpkgs/commit/44337891d6a039915f1d57a2b66ee354c685dd94) | `` fishPlugins.forgit: 24.09.0 -> 24.10.0 ``                                       |
| [`61f49a4b`](https://github.com/NixOS/nixpkgs/commit/61f49a4b5652ccdd15fb3f14d33eb472f3e88ade) | `` mbtileserver: migrate to by-name ``                                             |
| [`b35a0e8e`](https://github.com/NixOS/nixpkgs/commit/b35a0e8e939677c67d1ece02f9f90a0ccc53113a) | `` python312Packages.keras: remove tf-keras dependency ``                          |
| [`258869db`](https://github.com/NixOS/nixpkgs/commit/258869db09cb046115bbdc0f0fcd5ef5d840b1bc) | `` kodiPackages.youtube: 7.0.9.2 -> 7.1.0 ``                                       |
| [`54ee6153`](https://github.com/NixOS/nixpkgs/commit/54ee61539301b3c3e1f0b9e0e76798681a7a786f) | `` lscolors: 0.19.0 -> 0.20.0 ``                                                   |
| [`856ed550`](https://github.com/NixOS/nixpkgs/commit/856ed5506f0aae2f800338b8f915c022d48794e1) | `` waveterm: 0.8.7 -> 0.8.8 ``                                                     |
| [`33ee0f39`](https://github.com/NixOS/nixpkgs/commit/33ee0f39557704c4a4cddc3ec5ab2e8dcd1bca4b) | `` eza: 0.20.0 -> 0.20.1 ``                                                        |
| [`ce60744f`](https://github.com/NixOS/nixpkgs/commit/ce60744fdcaae79b5540ce231d94f3669996f7fa) | `` gh-dash: 4.5.4 -> 4.7.0 ``                                                      |
| [`f050aea7`](https://github.com/NixOS/nixpkgs/commit/f050aea788c0687318fa6de54188050602e13951) | `` zed-editor: 0.154.4 -> 0.155.2 ``                                               |
| [`2a13d67d`](https://github.com/NixOS/nixpkgs/commit/2a13d67dcc622a92385f731d701c81cb4169e370) | `` nixosTests.scrutiny: remove explicit wait for influxdb2 ``                      |
| [`2604e92e`](https://github.com/NixOS/nixpkgs/commit/2604e92e02bb6a1c9a8941d0ff3fc3ff7c1f7246) | `` obs-studio-plugins.obs-move-transition: 3.0.2 -> 3.1.0 ``                       |
| [`9d3aedf2`](https://github.com/NixOS/nixpkgs/commit/9d3aedf20836600003a4cbe63f825c981f52a03d) | `` cryptpad: 2024.6.1 -> 2024.9.0 ``                                               |
| [`fb3637c7`](https://github.com/NixOS/nixpkgs/commit/fb3637c7ae0ea997f165f13e4c1d9a6df8866fd2) | `` mpvScripts.modernx-zydezu: 0.3.6.6 -> 0.3.7 ``                                  |
| [`018ee148`](https://github.com/NixOS/nixpkgs/commit/018ee1482bb5f377e9e7561cf11d7f43759a3148) | `` xwayland: 24.1.2 -> 24.1.3 ``                                                   |
| [`6cf3b663`](https://github.com/NixOS/nixpkgs/commit/6cf3b66370aebfaeeb02f68dc9b35cbeadce553c) | `` gobgp: 3.29.0 -> 3.30.0 ``                                                      |
| [`a2d69162`](https://github.com/NixOS/nixpkgs/commit/a2d691621106a3b02bb638ccb385ddc462945c4f) | `` gobgpd: 3.29.0 -> 3.30.0 ``                                                     |
| [`2edfaf4d`](https://github.com/NixOS/nixpkgs/commit/2edfaf4d64bfa00d7f1a8fe6b0d8994d920ea272) | `` scarab: fix crash (#345038), don't bundle tests ``                              |
| [`718581f5`](https://github.com/NixOS/nixpkgs/commit/718581f55b637d017d3f205660b56dd96ee2242c) | `` scarab: format with nixfmt ``                                                   |
| [`21e8d2f7`](https://github.com/NixOS/nixpkgs/commit/21e8d2f7c23d037e4413357573799117f16ad535) | `` cargo-mutants: 24.7.1 -> 24.9.0 ``                                              |
| [`4ab00bbd`](https://github.com/NixOS/nixpkgs/commit/4ab00bbd10489e047c1f010bbca827b628a6c517) | `` goldwarden: 0.3.3 -> 0.3.4 ``                                                   |
| [`e1819a76`](https://github.com/NixOS/nixpkgs/commit/e1819a7650f30c465d84a0029b10b58cfcf0a69d) | `` fwup: 1.10.2 -> 1.11.0 ``                                                       |
| [`f18c3af0`](https://github.com/NixOS/nixpkgs/commit/f18c3af055dcd7a49ad40bc7223f6a85951d756c) | `` easycrypt: 2024.01 → 2024.09 ``                                                 |
| [`cdce415f`](https://github.com/NixOS/nixpkgs/commit/cdce415f9908f92f48f6b500563d99aa4fe6aded) | `` logiops: 0.3.4 -> 0.3.5 ``                                                      |
| [`c1c32966`](https://github.com/NixOS/nixpkgs/commit/c1c3296631230bc6fd6f0e625dae43d91e6ab76a) | `` ccls: 0.20240202 -> 0.20240505 ``                                               |
| [`f5870a9b`](https://github.com/NixOS/nixpkgs/commit/f5870a9b6dc0ef9f2687d6017a4d2912b5fd1a2a) | `` php84Extensions.opentelemetry: 1.1.0beta2 -> 1.1.0 ``                           |
| [`dc48fcad`](https://github.com/NixOS/nixpkgs/commit/dc48fcad0394fc812b7d380465e3a1afdb011770) | `` lxgw-wenkai-tc: 1.330 -> 1.500 ``                                               |
| [`cf291ffa`](https://github.com/NixOS/nixpkgs/commit/cf291ffa84cfa91806cda6be55b44e6cbc66dc55) | `` planus: 0.4.0 -> 1.0.0 ``                                                       |
| [`b7f2a0aa`](https://github.com/NixOS/nixpkgs/commit/b7f2a0aa48026ef006788cc24078730cfb7b593e) | `` lumafly: 3.2.0.0 -> 3.3.0.0 ``                                                  |
| [`a1223bad`](https://github.com/NixOS/nixpkgs/commit/a1223bad0c3a47decd25c2e212b852dffa2df153) | `` mbtileserver: 0.10.0 -> 0.11.0 ``                                               |
| [`21bc39e8`](https://github.com/NixOS/nixpkgs/commit/21bc39e8915f552ace90a62484e2af9e48220ea2) | `` dosage: format ``                                                               |
| [`e53c4a5c`](https://github.com/NixOS/nixpkgs/commit/e53c4a5cbd662aa4367dc3d457a2efc159a6747c) | `` dosage: 2.17 -> 3.0 ``                                                          |
| [`8019b941`](https://github.com/NixOS/nixpkgs/commit/8019b9413deaea8ab229f2a254efff1087a0ff29) | `` cope: init at 0-unstable-2024-03-27 ``                                          |
| [`acc467c1`](https://github.com/NixOS/nixpkgs/commit/acc467c1d94fc8588cc01c1eff27506b7b47616c) | `` maintainers: add deftdawg ``                                                    |
| [`d6011f00`](https://github.com/NixOS/nixpkgs/commit/d6011f008571b5d87614007bb94a6781d29a052a) | `` btor2tools: fix on darwin ``                                                    |
| [`d7c0edad`](https://github.com/NixOS/nixpkgs/commit/d7c0edad7990f072d87a52da27ed038fe9feb653) | `` gotools: add techknowlogick as maintainer ``                                    |
| [`c801f9dd`](https://github.com/NixOS/nixpkgs/commit/c801f9dd95d5f2cc62e3a862824d80c07427507d) | `` gotools: nixfmt ``                                                              |
| [`b6e2e8f2`](https://github.com/NixOS/nixpkgs/commit/b6e2e8f2fcf5983c06a7d9b8db4cb3557cc2d145) | `` gotools: move to pkgs/by-name ``                                                |
| [`2a8ed6eb`](https://github.com/NixOS/nixpkgs/commit/2a8ed6eb8bb6a8dccf910cb246cb2c7159d8cd32) | `` gotools: 0.22.0 -> 0.25.0 ``                                                    |
| [`257a6870`](https://github.com/NixOS/nixpkgs/commit/257a687043c9eee0eafd5d2da78f910d3749e0d9) | `` notcurses: 3.0.9 -> 3.0.11 ``                                                   |
| [`ce8001fb`](https://github.com/NixOS/nixpkgs/commit/ce8001fb26188254d12d5e527870a4d3ec853f42) | `` python3Packages.langchain-chroma: disable broken test ``                        |
| [`7a19953c`](https://github.com/NixOS/nixpkgs/commit/7a19953c928e55e98291216d25fbe672a5193642) | `` terraform: 1.9.6 -> 1.9.7 ``                                                    |
| [`a9b75820`](https://github.com/NixOS/nixpkgs/commit/a9b758209956e011c0ce2a47603dfa0048c5faaf) | `` actionlint: 1.7.2 -> 1.7.3 ``                                                   |
| [`ffc9bf18`](https://github.com/NixOS/nixpkgs/commit/ffc9bf1882d52ff5643fb6de2b6abbc1c5f4741c) | `` nixos/tests/acme: Better error handling ``                                      |