### PR TITLE
chore(flake/treefmt-nix): `879b29ae` -> `4446c7a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727431250,
-        "narHash": "sha256-uGRlRT47ecicF9iLD1G3g43jn2e+b5KaMptb59LHnvM=",
+        "lastModified": 1727984844,
+        "narHash": "sha256-xpRqITAoD8rHlXQafYZOLvUXCF6cnZkPfoq67ThN0Hc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "879b29ae9a0378904fbbefe0dadaed43c8905754",
+        "rev": "4446c7a6fc0775df028c5a3f6727945ba8400e64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                      |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`4446c7a6`](https://github.com/numtide/treefmt-nix/commit/4446c7a6fc0775df028c5a3f6727945ba8400e64) | `` zig: include .zon (#244) ``                               |
| [`861c66dd`](https://github.com/numtide/treefmt-nix/commit/861c66ddc5f45e39a831222adeda3c0325c4e1b1) | `` buildifier: include all .bazel files by default (#245) `` |
| [`a10a0cbe`](https://github.com/numtide/treefmt-nix/commit/a10a0cbe2196120aa90e4f86d459376e1d108d58) | `` wrapper: add treefmt-nix executable to output (#243) ``   |