### PR TITLE
chore(flake/nixvim): `0ca98d02` -> `33d030d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727871072,
-        "narHash": "sha256-t+YLQwBB1soQnVjT6d7nQq4Tidaw7tpB8i6Zvpc+Zbs=",
+        "lastModified": 1728245494,
+        "narHash": "sha256-bulK/Z+SEJaHM2PPk7W/kRvO51Ag9bTebcaWai9EEJc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0ca98d02104f7f0a703787a7a080a570b7f1bedd",
+        "rev": "33d030d23c9b88bb29e300d702aade58c3734612",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`33d030d2`](https://github.com/nix-community/nixvim/commit/33d030d23c9b88bb29e300d702aade58c3734612) | `` plugins/nonels: remove with lib and helpers ``              |
| [`fb677540`](https://github.com/nix-community/nixvim/commit/fb677540e1b4bf182e744c7699e35ae14d5b3e61) | `` plugins/nonels: move to by-name ``                          |
| [`40cb7af2`](https://github.com/nix-community/nixvim/commit/40cb7af2b9eca28bff5537998c7b60031bb82816) | `` plugins/lsp-status: add undocumented options ``             |
| [`aaecda14`](https://github.com/nix-community/nixvim/commit/aaecda1471443e8278f4ec1ddc0b47a61b7af1ed) | `` docs: fix typo in standalone.md (`makeNixvimWithModule`) `` |
| [`31acdd4b`](https://github.com/nix-community/nixvim/commit/31acdd4b662e2243143d3091c4833d4a0448b424) | `` plugins/rest: move to by-name again ``                      |
| [`d42c804a`](https://github.com/nix-community/nixvim/commit/d42c804ad515f45f8addaf5a4bb0b8ce405ea140) | `` config-examples: add fred-drake ``                          |
| [`6594472f`](https://github.com/nix-community/nixvim/commit/6594472fd275f6dcf5a9fba4a83d2f7fa2cf2b8a) | `` Resolve aliases ``                                          |
| [`aeb6ae37`](https://github.com/nix-community/nixvim/commit/aeb6ae37a78db5499a78dca5dbe2e8bf2bf5fce6) | `` flake.lock: Update ``                                       |