### PR TITLE
chore(flake/nixvim): `33d030d2` -> `abc7f450`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728245494,
-        "narHash": "sha256-bulK/Z+SEJaHM2PPk7W/kRvO51Ag9bTebcaWai9EEJc=",
+        "lastModified": 1728336850,
+        "narHash": "sha256-2RcPY41+UopyGwrPmsAFJC6CCobuuz4sNemC5cMb5GY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "33d030d23c9b88bb29e300d702aade58c3734612",
+        "rev": "abc7f450adc3b12d66c451972b1876d5194644bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`abc7f450`](https://github.com/nix-community/nixvim/commit/abc7f450adc3b12d66c451972b1876d5194644bb) | `` flake.lock: Update ``                            |
| [`cb3c1bfc`](https://github.com/nix-community/nixvim/commit/cb3c1bfcaf44fd6f0043d916f3a14f666c3364a4) | `` plugins/lsp-status: fix update_interval type ``  |
| [`a3dd64b3`](https://github.com/nix-community/nixvim/commit/a3dd64b30c1016342f8c96ef04806b49dc4339f3) | `` plugins/airline: remove with lib; and helpers `` |
| [`08cac4a5`](https://github.com/nix-community/nixvim/commit/08cac4a5c04081149cd0cc7e1325e578c117b587) | `` plugins/cmp: remove helpers ``                   |
| [`62b87e5b`](https://github.com/nix-community/nixvim/commit/62b87e5b5672650727aff6a6bda61cee598715ac) | `` plugins/cmp: remove with lib; ``                 |
| [`d71cfaaa`](https://github.com/nix-community/nixvim/commit/d71cfaaae8353b4102169a9858422ce3738cd43b) | `` plugins/none-ls: add gersemi package ``          |