### PR TITLE
chore(flake/nixvim): `abc7f450` -> `eda14029`

### DIFF
--- a/config/lsp.nix
+++ b/config/lsp.nix
@@ -72,7 +72,7 @@
         bashls.enable = true;
         clangd.enable = true;
         ltex.enable = true;
-        lua-ls = {
+        lua_ls = {
           enable = true;
           settings = {
             runtime.version = "LuaJIT";
@@ -80,14 +80,14 @@
           };
         };
         marksman.enable = true;
-        nil-ls = {
+        nil_ls = {
           enable = true;
           settings.formatting.command = [ (lib.getExe pkgs.nixpkgs-fmt) ];
         };
         ruff.enable = true;
         pyright.enable = true;
         texlab.enable = true;
-        ts-ls.enable = true;
+        ts_ls.enable = true;
       };
       postConfig = ''
         require("crates").setup({

--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728336850,
-        "narHash": "sha256-2RcPY41+UopyGwrPmsAFJC6CCobuuz4sNemC5cMb5GY=",
+        "lastModified": 1728428263,
+        "narHash": "sha256-TG/ojDMLuLJI4nEo0waZawgAq4r30n7xJ8klEKpFcd0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "abc7f450adc3b12d66c451972b1876d5194644bb",
+        "rev": "eda14029813906b1ef355823de237d86fea59908",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`eda14029`](https://github.com/nix-community/nixvim/commit/eda14029813906b1ef355823de237d86fea59908) | `` plugins/auto-session: migrate to mkNeovimPlugin ``                     |
| [`7f4cfa27`](https://github.com/nix-community/nixvim/commit/7f4cfa2728aea417f7f390df19d17df396823d7c) | `` plugins/auto-session: remove with lib and helpers ``                   |
| [`28485b0e`](https://github.com/nix-community/nixvim/commit/28485b0e57aa61ee3636e7226ddc7283ce11fe4c) | `` options-search: configure title ``                                     |
| [`543f4cce`](https://github.com/nix-community/nixvim/commit/543f4ccec664e3082015bfd71f1cc2d021b1b214) | `` flake.lock: Update ``                                                  |
| [`0e59a28e`](https://github.com/nix-community/nixvim/commit/0e59a28e95ee6f14392064e9acff3104118d1e59) | `` plugins/rustaceanvim: fix deprecation ``                               |
| [`ed4958c2`](https://github.com/nix-community/nixvim/commit/ed4958c20647efd45c7c266a37b8b9976c61eff1) | `` plugin/lsp: Re-enable sourcekit ``                                     |
| [`8d1e6f5a`](https://github.com/nix-community/nixvim/commit/8d1e6f5ac402f368ef8db72c0423e8f50308072c) | `` plugins/lsp: Enable all lsp servers in tests ``                        |
| [`8e8d9afe`](https://github.com/nix-community/nixvim/commit/8e8d9afe8e54597432be29ba757c4ed607ad691e) | `` plugins/lsp: Use the auto-generated lsp plugin list ``                 |
| [`c79bfb75`](https://github.com/nix-community/nixvim/commit/c79bfb75dae149646f417e9b0d7e88fdfbc81909) | `` plugins/lsp: Add a list of all nixpkgs server packages ``              |
| [`aa24b3f9`](https://github.com/nix-community/nixvim/commit/aa24b3f9d83fc9e59890f5664fc1d313c2fc7ad0) | `` update-scripts: Extract the list of all servers from nvim-lspconfig `` |
| [`cab6b0c9`](https://github.com/nix-community/nixvim/commit/cab6b0c9febfecd96e4cda3dfe4ec8675f6d9ddb) | `` tests: Split off in a single derivation the lsp server test ``         |
| [`182ffa45`](https://github.com/nix-community/nixvim/commit/182ffa45838d22cd0d6e26718f8ac2b20dec389b) | `` plugins/nvim-ufo: migrate to mkNeovimPlugin ``                         |
| [`fc584a3a`](https://github.com/nix-community/nixvim/commit/fc584a3a41fdbecb41bc10c66b80cc8003d3cc2c) | `` plugins/nvim-ufo: remove with lib and helpers ``                       |
| [`faa96236`](https://github.com/nix-community/nixvim/commit/faa962367cfa3c95bcf20702949fb4ef52620033) | `` flake.lock: Update ``                                                  |