### PR TITLE
chore(flake/nixvim): `61ec3976` -> `af650ba9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728485062,
-        "narHash": "sha256-+2e9hAM2GVDF3gywdQI/OA7s4f0Z9rvFuiVxePI41QM=",
+        "lastModified": 1728593423,
+        "narHash": "sha256-xM3+7mvWwM5i+RXD97wQ/fSoQDFidVxNszIfKIv9msE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "61ec39764fbe1e4f21cf801ea7b9209d527c8135",
+        "rev": "af650ba9401501352d6eaaced192bbb4abfaec87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`af650ba9`](https://github.com/nix-community/nixvim/commit/af650ba9401501352d6eaaced192bbb4abfaec87) | `` tests/lsp-servers: de-couple from grouped tests ``                        |
| [`88302aa1`](https://github.com/nix-community/nixvim/commit/88302aa17aa9693bc683d626f34263b0247ce052) | `` plugins/lsp: use a no-default option when there is no default provided `` |
| [`0d2751b5`](https://github.com/nix-community/nixvim/commit/0d2751b53c6c69a3c4ef43b0d3a8fb773899f09c) | `` tests/generated: validate declared lsp packages ``                        |
| [`7916df22`](https://github.com/nix-community/nixvim/commit/7916df22d2dde3d9db37047ce78bbf13e1129794) | `` plugins/lsp: sort unpackaged ``                                           |
| [`d9dd5739`](https://github.com/nix-community/nixvim/commit/d9dd57390314a279f96912d6c0814029211dd7af) | `` generated/lspconfig-servers.json: update ``                               |
| [`b4f71a93`](https://github.com/nix-community/nixvim/commit/b4f71a933003eb3ff386eb91ddbf959cef771e82) | `` flake-modules/dev: exclude generated files from typos hook ``             |
| [`849c33c2`](https://github.com/nix-community/nixvim/commit/849c33c2839a55d52a9ee6ae1d522bdf5bf28e07) | `` update-scripts/nvim-lspconfig: server_configurations -> configs ``        |
| [`684df4d9`](https://github.com/nix-community/nixvim/commit/684df4d93dabf81ebfe8d01709121fc68bf32a3e) | `` tests/lua-ls: disable on x86_64-darwin ``                                 |
| [`75ae1057`](https://github.com/nix-community/nixvim/commit/75ae10571da39dbaaf13e2520d8d27715549630d) | `` tests/byte-compile-lua: server_configurations -> configs ``               |
| [`c7fc3812`](https://github.com/nix-community/nixvim/commit/c7fc381247c068c7f869b6b21fa1b2015ffa0aa5) | `` tests/magma-nvim: only run on linux ``                                    |
| [`f830aada`](https://github.com/nix-community/nixvim/commit/f830aada6f815e892f022466e173f10f1cb670a7) | `` flake.lock: Update ``                                                     |