### PR TITLE
chore(flake/git-hooks): `06bb5971` -> `eb74e0be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728651332,
-        "narHash": "sha256-lm+asqDSTj0m6j1dtEte1/XG+uzZbwxS3tn7JLaBw84=",
+        "lastModified": 1728727368,
+        "narHash": "sha256-7FMyNISP7K6XDSIt1NJxkXZnEdV3HZUXvFoBaJ/qdOg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "06bb5971c139959d9a951f34e4264d32f5d998e7",
+        "rev": "eb74e0be24a11a1531b5b8659535580554d30b28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message    |
| ----------------------------------------------------------------------------------------------------- | ---------- |
| [`eb74e0be`](https://github.com/cachix/git-hooks.nix/commit/eb74e0be24a11a1531b5b8659535580554d30b28) | `` typo `` |