### PR TITLE
chore(flake/nixvim): `2e1b3b7d` -> `619e2436`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728736326,
-        "narHash": "sha256-JYy050VI7AQyDPHjZ/48rdNFfVvdbR0wPtsRA/4nc7E=",
+        "lastModified": 1728829992,
+        "narHash": "sha256-722PdOQ4uTTAOyS3Ze4H7LXDNVi9FecKbLEvj3Qu0hM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2e1b3b7d43f485866573f70411a4797ce38e27bb",
+        "rev": "619e24366e8ad34230d65a323d26ca981bfa6927",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`619e2436`](https://github.com/nix-community/nixvim/commit/619e24366e8ad34230d65a323d26ca981bfa6927) | `` plugins/lsp/hls: handle automatic installation of required GHC ``        |
| [`767eb62f`](https://github.com/nix-community/nixvim/commit/767eb62f48c0818e9f4392dc3eb61572cc8bd11d) | `` modules/output: obtain plugin configs from wrapped neovim ``             |
| [`ba77e887`](https://github.com/nix-community/nixvim/commit/ba77e88740a66c6e8e37297321960deb5d24162e) | `` modules/output: remove unused binding ``                                 |
| [`21f7ed6e`](https://github.com/nix-community/nixvim/commit/21f7ed6eb617089f9ea7251303a2567e8ab43e29) | `` tests/modules/output: test that init.lua contains all config sections `` |
| [`48b62ac2`](https://github.com/nix-community/nixvim/commit/48b62ac2e607fb0c5332ba2a2455e9cf3184832a) | `` plugins/trouble: update to v3 ``                                         |
| [`066ee7d0`](https://github.com/nix-community/nixvim/commit/066ee7d0a94f292d851361ea33d870905e741982) | `` plugins/trouble: remove with lib and helpers ``                          |
| [`df515c65`](https://github.com/nix-community/nixvim/commit/df515c651e4b9d6983cdfa2eaaa285085066a6f9) | `` tests/trouble: add more examples ``                                      |