### PR TITLE
chore(flake/nixvim): `619e2436` -> `429f2e8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728829992,
-        "narHash": "sha256-722PdOQ4uTTAOyS3Ze4H7LXDNVi9FecKbLEvj3Qu0hM=",
+        "lastModified": 1729015933,
+        "narHash": "sha256-raKxsI2SGe/vF2PvzFatd/Sl9eVUCuCUUVg7cINFVbQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "619e24366e8ad34230d65a323d26ca981bfa6927",
+        "rev": "429f2e8d1aa61181c0ec72bdafe022fbb6a092d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                 |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`429f2e8d`](https://github.com/nix-community/nixvim/commit/429f2e8d1aa61181c0ec72bdafe022fbb6a092d6) | `` plugins/lsp/efmls-configs: enable lua_format on x86 darwin ``        |
| [`296bb568`](https://github.com/nix-community/nixvim/commit/296bb568ee160657380cbca2ee34926a62ff517f) | `` plugins/lsp/efmls-configs: enable php tests again on darwin ``       |
| [`db95f9db`](https://github.com/nix-community/nixvim/commit/db95f9dbd4e693fb9157dd90b7a011808bee2d81) | `` plugins/none-ls: disable broken packages ``                          |
| [`49f7d73d`](https://github.com/nix-community/nixvim/commit/49f7d73de55c348b2446cbef5af066cc63e93ce4) | `` plugins/lsp/efmls-configs: disable dmd ``                            |
| [`bb86faf8`](https://github.com/nix-community/nixvim/commit/bb86faf8cf4e2da8aff5791915283730549b008c) | `` plugins/auto-save: fix deprecation errors ``                         |
| [`ca5ba6d5`](https://github.com/nix-community/nixvim/commit/ca5ba6d5fe8330e9e32db60f8a392338b5fa9c91) | `` generated: Update ``                                                 |
| [`6235f274`](https://github.com/nix-community/nixvim/commit/6235f2745d68258eab3a472e30e1d7f7c870f1e4) | `` flake.lock: Update ``                                                |
| [`25b8d2ab`](https://github.com/nix-community/nixvim/commit/25b8d2ab20fbc4a291e83a490382d503c999ab3a) | `` Added kickstarter.nixvim stand-alone flake in the config-examples `` |