### PR TITLE
chore(flake/git-hooks): `ff68f917` -> `3c3e88f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728778939,
-        "narHash": "sha256-WybK5E3hpGxtCYtBwpRj1E9JoiVxe+8kX83snTNaFHE=",
+        "lastModified": 1729104314,
+        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "ff68f91754be6f3427e4986d7949e6273659be1d",
+        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`92e4fb63`](https://github.com/cachix/git-hooks.nix/commit/92e4fb63b9dd1acc4e9c0198eebc6cbbc8d0ad4a) | `` docs: fix defaults ``                       |
| [`af52f533`](https://github.com/cachix/git-hooks.nix/commit/af52f533c96d6ccf706de85d47ea79c86210ec80) | `` fix(rustfmt): add cargoManifestPath back `` |
| [`7e36b4c2`](https://github.com/cachix/git-hooks.nix/commit/7e36b4c2aba327e73cddd7ec833f51874f3bf5e5) | `` fix: add golines to tools.nix ``            |
| [`1a1c7c6b`](https://github.com/cachix/git-hooks.nix/commit/1a1c7c6b618aed1602a609c184a948836b7bbc67) | `` add golines pre-commit hook ``              |