### PR TITLE
chore(flake/nixvim): `036e1166` -> `c4ad4d0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729281122,
-        "narHash": "sha256-fcV0T+Spw5/vF1Rgt/UiH4gKIDbb5NiIGagmBIULFyA=",
+        "lastModified": 1729368702,
+        "narHash": "sha256-KW+NFU0woUYpiVsdbXO5YAKCnKZ743BJlnG4ZEflvfs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "036e11665f819ebf1dddf493ba212c1ec441eaad",
+        "rev": "c4ad4d0b2e7de04fa9ae0652b006807f42062080",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`c4ad4d0b`](https://github.com/nix-community/nixvim/commit/c4ad4d0b2e7de04fa9ae0652b006807f42062080) | `` modules/nixpkgs: add `overlays` option ``                          |
| [`b9d17d5e`](https://github.com/nix-community/nixvim/commit/b9d17d5e6c981911f33270e0eefdcb978559d990) | `` modules/nixpkgs: restructure `nixpkgs.pkgs.isDefined` assertion `` |
| [`e3239b4d`](https://github.com/nix-community/nixvim/commit/e3239b4d328efaaf090892fbca71a1008dbc5a59) | `` plugins/cmp: add cmp-nixpkgs-maintainers source ``                 |
| [`6a8124ca`](https://github.com/nix-community/nixvim/commit/6a8124ca7bc97e753f89da43b82bbc83d1125a32) | `` tests/efmls-configs: add unpackaged ``                             |
| [`b5ead146`](https://github.com/nix-community/nixvim/commit/b5ead146c84919d5413e4325326199db53946e6d) | `` lsp/efmls-configs-pkgs: add new efmls packages ``                  |
| [`92eec760`](https://github.com/nix-community/nixvim/commit/92eec7603ff1ca49b9ccbdd92fdb28ca7468d86b) | `` generated: Update ``                                               |
| [`db27a881`](https://github.com/nix-community/nixvim/commit/db27a881469cc859dd9dc98ecd3c178d7ce226d1) | `` flake.lock: Update ``                                              |