### PR TITLE
chore(flake/nixvim): `47b563d4` -> `0562e519`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729438888,
-        "narHash": "sha256-TGTDOX2/5OIoSzlcRReVn4BbbfL6Ami/eassiPPGqNA=",
+        "lastModified": 1729532160,
+        "narHash": "sha256-Nxpp4vrnMw9R43iWTfsId8vadk7vQk33duanvIQ3V9w=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "47b563d4e1410bff6a9481b3dd8b01b1e5ed70d2",
+        "rev": "0562e519ec0e69125c5edc917d41bccb54a534fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`0562e519`](https://github.com/nix-community/nixvim/commit/0562e519ec0e69125c5edc917d41bccb54a534fd) | `` docs: refactor wrapper-options docs ``  |
| [`5992a228`](https://github.com/nix-community/nixvim/commit/5992a2282193d0d9ef35a63610cd2ee4353dcc2d) | `` docs: introduce a dedicated homepage `` |