### PR TITLE
chore(flake/nixvim): `0562e519` -> `b076f006`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729532160,
-        "narHash": "sha256-Nxpp4vrnMw9R43iWTfsId8vadk7vQk33duanvIQ3V9w=",
+        "lastModified": 1729602958,
+        "narHash": "sha256-eKGQKlj1oShfR6uqE1RjB4CgQ3DBrMS4VPrGPDKq1J4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0562e519ec0e69125c5edc917d41bccb54a534fd",
+        "rev": "b076f006c6b0cc6644a651bd21d4449cc3e7e56d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b076f006`](https://github.com/nix-community/nixvim/commit/b076f006c6b0cc6644a651bd21d4449cc3e7e56d) | `` wrappers: add `meta.wrappers` options to wrappers `` |
| [`574ae92a`](https://github.com/nix-community/nixvim/commit/574ae92a43206717f61f105bfb5bebc937800ed9) | `` wrappers/modules: move `enable` to `shared.nix` ``   |
| [`c693500a`](https://github.com/nix-community/nixvim/commit/c693500a72fcceb559a3c8cc58962d482cb6aade) | `` docs: simplify `mdbook.nixvimOptions` impl ``        |