### PR TITLE
chore(flake/nixvim): `b076f006` -> `029eafd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729602958,
-        "narHash": "sha256-eKGQKlj1oShfR6uqE1RjB4CgQ3DBrMS4VPrGPDKq1J4=",
+        "lastModified": 1729699620,
+        "narHash": "sha256-f6S8JX5w9bPLMbaqR5dM5koybZntdSFfKyfq/LQU7rs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b076f006c6b0cc6644a651bd21d4449cc3e7e56d",
+        "rev": "029eafd70d6e28919a9ec01a94a46b51c4ccff40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`029eafd7`](https://github.com/nix-community/nixvim/commit/029eafd70d6e28919a9ec01a94a46b51c4ccff40) | `` plugins/deprecation: add rust-tools ``             |
| [`876ca324`](https://github.com/nix-community/nixvim/commit/876ca324513a0bd61d16e718de192fdd19d94de4) | `` plugins/rust-tools: remove with lib and helpers `` |
| [`32969847`](https://github.com/nix-community/nixvim/commit/32969847d3267117e00ebd70f4efab5a2f894fa1) | `` plugins/lsp-format: migrate to mkNeovimPlugin ``   |
| [`fb1943a6`](https://github.com/nix-community/nixvim/commit/fb1943a673ea78db68e194c89bbb82b150bf74c4) | `` plugins/lsp-format: remove with lib and helpers `` |