### PR TITLE
chore(flake/nix-github-actions): `622f829f` -> `e04df33f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720066371,
-        "narHash": "sha256-uPlLYH2S0ACj0IcgaK9Lsf4spmJoGejR9DotXiXSBZQ=",
+        "lastModified": 1729742964,
+        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
         "owner": "nix-community",
         "repo": "nix-github-actions",
-        "rev": "622f829f5fe69310a866c8a6cd07e747c44ef820",
+        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`e04df33f`](https://github.com/nix-community/nix-github-actions/commit/e04df33f62cdcf93d73e9a04142464753a16db67) | `` Update cachix/install-nix-action action to v30 ``   |
| [`8e43da7e`](https://github.com/nix-community/nix-github-actions/commit/8e43da7ea5da0a28c376617831b5d3e96d8cc22c) | `` .github: Set a nicer name for each attribute job `` |
| [`0448a8e9`](https://github.com/nix-community/nix-github-actions/commit/0448a8e9a8c885d8b6e895d3f519bf68a834b44f) | `` Add name and system attributes to matrix output ``  |
| [`e9aac168`](https://github.com/nix-community/nix-github-actions/commit/e9aac168d1d128f835a351e0010d7f962f48c001) | `` .github: Run workflows on push to all branches ``   |