### PR TITLE
chore(flake/nixvim): `029eafd7` -> `4726334e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729699620,
-        "narHash": "sha256-f6S8JX5w9bPLMbaqR5dM5koybZntdSFfKyfq/LQU7rs=",
+        "lastModified": 1729791159,
+        "narHash": "sha256-i5TKYCs9tJ2qaYTsjQh3WwExmj4O0EU+L1jq6ZBVMfM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "029eafd70d6e28919a9ec01a94a46b51c4ccff40",
+        "rev": "4726334e4413ff55f1db3768c8d08722abbf09cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                              |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`4726334e`](https://github.com/nix-community/nixvim/commit/4726334e4413ff55f1db3768c8d08722abbf09cf) | `` docs: move wrapper options to dedicated sub-pages ``              |
| [`131e74e5`](https://github.com/nix-community/nixvim/commit/131e74e5601d1619eac20e5b8daa723e951f87af) | `` docs: move `wrapper-options` to summary index page ``             |
| [`cd68b680`](https://github.com/nix-community/nixvim/commit/cd68b680cdc35a48d7972721eba7eda370b9912f) | `` docs: rename `modules` -> `platforms` ``                          |
| [`c477b786`](https://github.com/nix-community/nixvim/commit/c477b7865e8c5ec923ae42ebac14b8dd410c873d) | `` docs/mdbook: use a fileset union for source ``                    |
| [`c2dbf7ac`](https://github.com/nix-community/nixvim/commit/c2dbf7acf14a4fcf7496db04be08d69f98a6c86e) | `` docs/mdbook: clean up derivation ``                               |
| [`28bdec9c`](https://github.com/nix-community/nixvim/commit/28bdec9cf7beb3344f18a8c364d2cd4574ce9318) | `` generated: Update lspconfig-servers.json ``                       |
| [`203b419c`](https://github.com/nix-community/nixvim/commit/203b419c21373a24f8e1e3c3850cfe20f6bf1957) | `` generated: Update efmls-configs.nix ``                            |
| [`f18f4441`](https://github.com/nix-community/nixvim/commit/f18f44411689b01cfe5c143cbdf4c64fad8b288c) | `` flake.lock: Update ``                                             |
| [`46f658d9`](https://github.com/nix-community/nixvim/commit/46f658d9606278ca8ebd0220039293e30d38a706) | `` plugins/lsp: no call fn in keymaps.extra example ``               |
| [`81df7156`](https://github.com/nix-community/nixvim/commit/81df7156ae48c33ac4e0c0baecbb3c4b3bf75aeb) | `` plugins/telescope: enabledExtensions doc refer to extraPlugins `` |