### PR TITLE
chore(flake/treefmt-nix): `aac86347` -> `bae131e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729613947,
-        "narHash": "sha256-XGOvuIPW1XRfPgHtGYXd5MAmJzZtOuwlfKDgxX5KT3s=",
+        "lastModified": 1730025913,
+        "narHash": "sha256-Y9NtFmP8ciLyRsopcCx1tyoaaStKeq+EndwtGCgww7I=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "aac86347fb5063960eccb19493e0cadcdb4205ca",
+        "rev": "bae131e525cc8718da22fbeb8d8c7c43c4ea502a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                                         |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`bae131e5`](https://github.com/numtide/treefmt-nix/commit/bae131e525cc8718da22fbeb8d8c7c43c4ea502a) | `` just: include .justfile (#246) ``                                                            |
| [`35b549ca`](https://github.com/numtide/treefmt-nix/commit/35b549cac94ee1fa41dbe662ba93ce9b6f458120) | `` cmake-format: init (#248) ``                                                                 |
| [`c64bc05b`](https://github.com/numtide/treefmt-nix/commit/c64bc05b8d6f719fe2f29d40f1679e6798904ba7) | `` stylua: add options: `settings`, `includes`, `excludes`; add to `meta.maintainers` (#252) `` |