### PR TITLE
chore(flake/nixvim): `2ef948ed` -> `a20fbbc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729945956,
-        "narHash": "sha256-nWRynowHjpRsDK6uf+VE6fz7/Wk80uRiAV2NQssGBH8=",
+        "lastModified": 1730058276,
+        "narHash": "sha256-t4fyRWIiDBJiDBnqqnxnk9nfT1SDTZN+koJLiuKkIT8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2ef948ed8ccf3c93f8caafa93cddca85df5783e9",
+        "rev": "a20fbbc4b9665ec215e7bea061a1d64f6fd652ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`a20fbbc4`](https://github.com/nix-community/nixvim/commit/a20fbbc4b9665ec215e7bea061a1d64f6fd652ce) | `` CONTRIBUTING: update doc about test.runNvim ``           |
| [`bc5fc9a8`](https://github.com/nix-community/nixvim/commit/bc5fc9a89685a3e266a3e6baa5fa57b32af607a7) | `` plugins/notebook-navigator: init ``                      |
| [`38abcfe8`](https://github.com/nix-community/nixvim/commit/38abcfe89adb4e56b046c4fc429139bde9405f5b) | `` flake.lock: Update ``                                    |
| [`bb0e3892`](https://github.com/nix-community/nixvim/commit/bb0e3892a27efdc6f9c1771927f513577cb1c671) | `` plugins/typescript-tools: migrate to mkNeovimPlugin ``   |
| [`2a40d081`](https://github.com/nix-community/nixvim/commit/2a40d081d72258c7d3ef4a01eed7aeabbb376ef1) | `` plugins/typescript-tools: remove with lib and helpers `` |