### PR TITLE
chore(flake/git-hooks): `3c3e88f0` -> `af8a16fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729104314,
-        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
+        "lastModified": 1730302582,
+        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
+        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`b3ff86fc`](https://github.com/cachix/git-hooks.nix/commit/b3ff86fcd0a1cd990dbec5b9efff5578e6202967) | `` fix: avoid use of deprecated stage names `` |
| [`f187f18b`](https://github.com/cachix/git-hooks.nix/commit/f187f18bec64d13a0cac592fa2d8c6a579f1ac3d) | `` Spelling: Check *.org files ``              |