### PR TITLE
chore(flake/treefmt-nix): `9ef337e4` -> `746901bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730120726,
-        "narHash": "sha256-LqHYIxMrl/1p3/kvm2ir925tZ8DkI0KA10djk8wecSk=",
+        "lastModified": 1730321837,
+        "narHash": "sha256-vK+a09qq19QNu2MlLcvN4qcRctJbqWkX7ahgPZ/+maI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "9ef337e492a5555d8e17a51c911ff1f02635be15",
+        "rev": "746901bb8dba96d154b66492a29f5db0693dbfcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                         |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`746901bb`](https://github.com/numtide/treefmt-nix/commit/746901bb8dba96d154b66492a29f5db0693dbfcc) | `` nixpkgs-fmt: add `includes` and `excludes` options (#254) `` |