### PR TITLE
chore(flake/nixvim): `7d882356` -> `42ea1626`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730214386,
-        "narHash": "sha256-FNXiFunXR2DnNrjmA0ofLznTTHcEDJjNWvCQtQExtL0=",
+        "lastModified": 1730368298,
+        "narHash": "sha256-5z4pDqRSSovXPPtN1BNEJOkGoCd/XSYuCWh8AsvoTio=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7d882356a486cf44b7fab842ac26885ecd985af3",
+        "rev": "42ea1626cb002fa759a6b1e2841bfc80a4e59615",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`42ea1626`](https://github.com/nix-community/nixvim/commit/42ea1626cb002fa759a6b1e2841bfc80a4e59615) | `` plugins/lsp: update unpackaged lsp list ``   |
| [`483fb755`](https://github.com/nix-community/nixvim/commit/483fb75564756237bb8c8556d97529294622273a) | `` plugins/magma-nvim: update package name ``   |
| [`f809a034`](https://github.com/nix-community/nixvim/commit/f809a0345bd12b62199d8d512cd487dfa02dca3a) | `` generated: Updated lspconfig-servers.json `` |
| [`bc4305e9`](https://github.com/nix-community/nixvim/commit/bc4305e96bb60cd038857c20a08f926729b5467a) | `` flake.lock: Update ``                        |