### PR TITLE
chore(flake/nixvim): `6f210158` -> `f11a877b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730569492,
-        "narHash": "sha256-NByr7l7JetL9kIrdCOcRqBu+lAkruYXETp1DMiDHNQs=",
+        "lastModified": 1731527733,
+        "narHash": "sha256-12OpSgbLDiKmxvBXwVracIfGI9FpjFyHpa1r0Ho+NFA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6f210158b03b01a1fd44bf3968165e6da80635ce",
+        "rev": "f11a877bcc1d66cc8bd7990c704f91c1e99c7d08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`f11a877b`](https://github.com/nix-community/nixvim/commit/f11a877bcc1d66cc8bd7990c704f91c1e99c7d08) | `` tests/modules/output: add tests for providers ``                                          |
| [`d100a4e9`](https://github.com/nix-community/nixvim/commit/d100a4e9943420b7a4ccb900964034171fcc29fb) | `` modules/output: expose `withPython3` ``                                                   |
| [`590153d4`](https://github.com/nix-community/nixvim/commit/590153d40354f6c12f3060f2b74eef98bb59a663) | `` modules/output: expose `withPerl` ``                                                      |
| [`e552c984`](https://github.com/nix-community/nixvim/commit/e552c984a24c88017f8bfe6807527b7a9c77e22c) | `` plugins/nonels/prettier: use priority instead of null for prettier disableTsFormatting `` |
| [`d593b824`](https://github.com/nix-community/nixvim/commit/d593b82436e55471b19ee19186aed60cc0a10a81) | `` plugins/nonels/prettierd: add disableTsServerFormatting option to prettierd ``            |
| [`7dc65b2d`](https://github.com/nix-community/nixvim/commit/7dc65b2d9873b6bbb6ef90234b3db6546e4ed9af) | `` docs/contributing: update documentation for running single tests ``                       |
| [`c892aa20`](https://github.com/nix-community/nixvim/commit/c892aa20732f982d4cc2b3ef2e2276a2a9a4d45b) | `` docs/user-guide/config-examples: remove trailing whitespace ``                            |
| [`3415e104`](https://github.com/nix-community/nixvim/commit/3415e10419fa898210e844864d74b27474d58ef9) | `` docs/user-guide/config-examples: add bkp5190 ``                                           |
| [`a92339d8`](https://github.com/nix-community/nixvim/commit/a92339d83bdc47f6d42998a5ac96020f9dd7c2d6) | `` docs: specify `site-url` ``                                                               |
| [`4ea34656`](https://github.com/nix-community/nixvim/commit/4ea34656c234855a0c70b09f760d658f4efc9641) | `` plugins/lsp: enable angularls ``                                                          |
| [`de2a7944`](https://github.com/nix-community/nixvim/commit/de2a7944d0f2b87a1836a671f8eab372039e70f7) | `` plugins/muren: init ``                                                                    |
| [`57068f53`](https://github.com/nix-community/nixvim/commit/57068f532d5d42601fd74e2b531204fe1cd3a8f2) | `` plugins/helm: add recommended autocmd for proper LSP behavior ``                          |
| [`432af78f`](https://github.com/nix-community/nixvim/commit/432af78ffd792257e601430f2f604c0d3e60cf8c) | `` tests/lsp-servers: disable lua-language-server on aarch64-darwin ``                       |
| [`daaf281e`](https://github.com/nix-community/nixvim/commit/daaf281e155680ccac3e1ee31e36f3598c5d3ef0) | `` flake.lock: Update ``                                                                     |
| [`31364af1`](https://github.com/nix-community/nixvim/commit/31364af1990067d5529846a2ebf17a42c5ab22ff) | `` flake.lock: Update ``                                                                     |
| [`93ffac63`](https://github.com/nix-community/nixvim/commit/93ffac6346eab42a6fac879d2559f7e2698e4e61) | `` Add global python3Dependencies ``                                                         |
| [`c0742ca4`](https://github.com/nix-community/nixvim/commit/c0742ca466dbb36dfdd67f5cbd55aa4df64e4307) | `` Add jupytext python3Dependency to jupytext plugin ``                                      |
| [`aabbd606`](https://github.com/nix-community/nixvim/commit/aabbd60633947baba11db44df84f402edc241440) | `` plugins/lsp: enable auto-installing rustfmt ``                                            |
| [`b0ebcaa1`](https://github.com/nix-community/nixvim/commit/b0ebcaa17789089b28c44f7610b1ed5f0ee4ae4d) | `` plugins/helm: switch to mkVimPlugin ``                                                    |
| [`77b49580`](https://github.com/nix-community/nixvim/commit/77b495801c2c6c33e126ef1d7e84e684fd020ecd) | `` plugins/blink-cmp: update configuration ``                                                |
| [`898246c9`](https://github.com/nix-community/nixvim/commit/898246c943ba545a79d585093e97476ceb31f872) | `` Revert "tests/lsp-servers: disable typescript-language-server on darwin" ``               |
| [`fefb588c`](https://github.com/nix-community/nixvim/commit/fefb588c7fb042328de61a9509d1037a05a0eb54) | `` Revert "tests/lsp-servers: disable tests impacted by broken _7zz on x86_64-linux" ``      |
| [`e5e109a1`](https://github.com/nix-community/nixvim/commit/e5e109a1c2ed517119b154cbebf707f41e92dba5) | `` flake.lock: Update ``                                                                     |
| [`3d24cb72`](https://github.com/nix-community/nixvim/commit/3d24cb72618738130e6af9c644c81fe42aa34ebc) | `` plugins/fastaction: init ``                                                               |
| [`aa06b176`](https://github.com/nix-community/nixvim/commit/aa06b176e78c9ae9e779e605cab61c9d8681a54e) | `` plugins/luasnip: fix example ``                                                           |
| [`38dd5b07`](https://github.com/nix-community/nixvim/commit/38dd5b07a00331fffe60236970d914bd0eeaf7da) | `` tests/lsp-servers: disable tests impacted by broken _7zz on x86_64-linux ``               |
| [`e3733a2f`](https://github.com/nix-community/nixvim/commit/e3733a2f27e1842f5842d2d4fdd182a707fe682c) | `` tests: disable tests impacted by clj-kondo being broken on x86_64-darwin ``               |
| [`f98e11b5`](https://github.com/nix-community/nixvim/commit/f98e11b5c3c35c64f0840ae7fb94a2eaaa8ec14e) | `` tests/efmls-configs: sql-formatter has been moved to top-level ``                         |
| [`98e8fcdd`](https://github.com/nix-community/nixvim/commit/98e8fcdded314bbdc50a5ebae16c6903979e4b7c) | `` tests/lsp-servers: disable typescript-language-server on darwin ``                        |
| [`454f328b`](https://github.com/nix-community/nixvim/commit/454f328b9a09c6fd7aec68bbe230a14fa5364fc0) | `` flake.lock: Update ``                                                                     |