### PR TITLE
chore(flake/git-hooks): `af8a16fe` -> `cd1af27a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730302582,
-        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`b87ed055`](https://github.com/cachix/git-hooks.nix/commit/b87ed055fb24db57ab528319d1e2026a6b8907d7) | `` feat(treefmt): add options to settings and disable cache by default `` |
| [`26f0d52b`](https://github.com/cachix/git-hooks.nix/commit/26f0d52b005bce294591c120585d6993c62cb8cb) | `` chore(deps): lock file maintenance ``                                  |
| [`04db8c18`](https://github.com/cachix/git-hooks.nix/commit/04db8c18ca4667986514ef81dc93d88998e9438d) | `` fix: poetry option is not defined ``                                   |
| [`92495abe`](https://github.com/cachix/git-hooks.nix/commit/92495abe55afe79f1f7b23a0b304d8dc3fa29740) | `` fix: poetry option is not defined ``                                   |