### PR TITLE
chore(flake/nixvim): `f11a877b` -> `ccae4350`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731527733,
-        "narHash": "sha256-12OpSgbLDiKmxvBXwVracIfGI9FpjFyHpa1r0Ho+NFA=",
+        "lastModified": 1731537511,
+        "narHash": "sha256-MV0J2A+UM+oOQDfcrz9yLWH5Poo7K0ya+FE3uF8wV2U=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "f11a877bcc1d66cc8bd7990c704f91c1e99c7d08",
+        "rev": "ccae4350d0657e45a0203c16b1121a72285984f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`ccae4350`](https://github.com/nix-community/nixvim/commit/ccae4350d0657e45a0203c16b1121a72285984f2) | `` options: add defaultNullOpts.mkRaw `` |