### PR TITLE
chore(flake/nixvim): `ccae4350` -> `be455f7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731537511,
-        "narHash": "sha256-MV0J2A+UM+oOQDfcrz9yLWH5Poo7K0ya+FE3uF8wV2U=",
+        "lastModified": 1731707185,
+        "narHash": "sha256-IfA3x0eL4Be/7hvdvGSnT8fgiXz7GL3PtjGw3BH68gM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ccae4350d0657e45a0203c16b1121a72285984f2",
+        "rev": "be455f7f2714ce3479ae5bb662a03bd450f45793",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`be455f7f`](https://github.com/nix-community/nixvim/commit/be455f7f2714ce3479ae5bb662a03bd450f45793) | `` lib/options: use `literalLua` for `defaultNullOpts.mkRaw` ``       |
| [`da6e3499`](https://github.com/nix-community/nixvim/commit/da6e3499d4dbf0d0c69480f619e8f5e2de2c9f8f) | `` lib/utils: add `nestedLiteral` and `nestedLiteralLua` ``           |
| [`eb76e62a`](https://github.com/nix-community/nixvim/commit/eb76e62a9b00e841cd1eb35989bcbca140224cb0) | `` lib/utils: add `literalLua` for use in option docs ``              |
| [`de99f293`](https://github.com/nix-community/nixvim/commit/de99f2938feefc990854363897623a19c077478e) | `` lib/{vim,neovim}-plugin: `installPackage` -> `packageDecorator` `` |
| [`1d78aee7`](https://github.com/nix-community/nixvim/commit/1d78aee791ac3e97134f93af79f00e6e01ed1e86) | `` tests/modules/clipboard: add raw lua code test ``                  |
| [`ef8d57ab`](https://github.com/nix-community/nixvim/commit/ef8d57aba0a4b436632730b558d3996019b3a698) | `` modules/clipboard: allow raw lua code in register option ``        |
| [`5095066d`](https://github.com/nix-community/nixvim/commit/5095066df62f3159ad8ffd950fce7eb4f8521528) | `` docs: improve mk(Neovim/Vim)Plugin function documentation ``       |
| [`46e574d4`](https://github.com/nix-community/nixvim/commit/46e574d4ea1642dd87a6bfb162053c52b2e4878b) | `` plugins/snacks: init ``                                            |
| [`54f56716`](https://github.com/nix-community/nixvim/commit/54f567166dd7a92d860d7ce8ca8b4a7a7a2a0246) | `` plugins/vim-dadbod-completion: init ``                             |
| [`5dfc9526`](https://github.com/nix-community/nixvim/commit/5dfc9526ef13a8fe87c3db314616ba2c76648041) | `` plugins/vim-dadbod-ui: init ``                                     |
| [`d408ffd6`](https://github.com/nix-community/nixvim/commit/d408ffd6b477facbcf3f7a23a0636875f4448cc3) | `` plugins/vim-dadbod: init ``                                        |
| [`f2259372`](https://github.com/nix-community/nixvim/commit/f2259372fbb7c084027747e8238f268f648342b6) | `` plugins/neoconf: init ``                                           |
| [`f8b3f165`](https://github.com/nix-community/nixvim/commit/f8b3f16556ed399e84277d41e0658fcea95d41f1) | `` maintainers: add BoneyPatel ``                                     |
| [`24fe0dd2`](https://github.com/nix-community/nixvim/commit/24fe0dd2478643fcd4dd57c9570b4614fac80144) | `` flake.lock: Update ``                                              |