### PR TITLE
chore(flake/nixvim): `be455f7f` -> `9d99d7cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731707185,
-        "narHash": "sha256-IfA3x0eL4Be/7hvdvGSnT8fgiXz7GL3PtjGw3BH68gM=",
+        "lastModified": 1731780782,
+        "narHash": "sha256-CG3rcxcZEViYEUTAXatqXrW0Gn9tQvydF+lLYH+0VPA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "be455f7f2714ce3479ae5bb662a03bd450f45793",
+        "rev": "9d99d7cfdbd7f94da9571a4d7bbb9de185241935",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`9d99d7cf`](https://github.com/nix-community/nixvim/commit/9d99d7cfdbd7f94da9571a4d7bbb9de185241935) | `` plugins/lsp: remove buf-language-server ``            |
| [`587b1cbf`](https://github.com/nix-community/nixvim/commit/587b1cbf21bb818f83580edd7444a2587e873078) | `` lib/types: allow inline-lua in `rawLua` type ``       |
| [`c8267ba3`](https://github.com/nix-community/nixvim/commit/c8267ba3955970f20031ff54e507629bf273abb8) | `` plugins/tmux-navigator: re-word usage instructions `` |
| [`a52572c0`](https://github.com/nix-community/nixvim/commit/a52572c060dd991aa9fed0683503931f6b263d0b) | `` plugins/tmux-navigator: use markdown admonition ``    |
| [`7b0df222`](https://github.com/nix-community/nixvim/commit/7b0df222fc156cf2c30dcc2da971bb857b38c801) | `` plugins/kulala: init ``                               |
| [`5c6dd20a`](https://github.com/nix-community/nixvim/commit/5c6dd20aeb7fa868836cfb20ac2ec546cc3c977a) | `` flake.lock: Update ``                                 |