### PR TITLE
chore(flake/treefmt-nix): `746901bb` -> `675d4a7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730321837,
-        "narHash": "sha256-vK+a09qq19QNu2MlLcvN4qcRctJbqWkX7ahgPZ/+maI=",
+        "lastModified": 1731959974,
+        "narHash": "sha256-AsuUJfILHGteNuQgCuiWPzWOVgzBsbetUHRAVwW7FCw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "746901bb8dba96d154b66492a29f5db0693dbfcc",
+        "rev": "675d4a7fc531799ae8dfca1986b79be7660559e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                       |
| ---------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`675d4a7f`](https://github.com/numtide/treefmt-nix/commit/675d4a7fc531799ae8dfca1986b79be7660559e2) | `` dnscontrol: init (#262) `` |
| [`579b9a2f`](https://github.com/numtide/treefmt-nix/commit/579b9a2fd0020cd9cd81a4ef4eab2dca4d20c94c) | `` typstyle: init (#261) ``   |