### PR TITLE
chore(flake/nix-github-actions): `e04df33f` -> `7b5f051d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729742964,
-        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
+        "lastModified": 1731952509,
+        "narHash": "sha256-p4gB3Rhw8R6Ak4eMl8pqjCPOLCZRqaehZxdZ/mbFClM=",
         "owner": "nix-community",
         "repo": "nix-github-actions",
-        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
+        "rev": "7b5f051df789b6b20d259924d349a9ba3319b226",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                         |
| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`7b5f051d`](https://github.com/nix-community/nix-github-actions/commit/7b5f051df789b6b20d259924d349a9ba3319b226) | `` replace deprecated macos-12 with macos-13 `` |