### PR TITLE
chore(flake/nixvim): `5bc3fa69` -> `2017830a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731883908,
-        "narHash": "sha256-Yt/eVhoj+SwpsQVK0YxM8jou55ni0+dqANuQ2IvIA28=",
+        "lastModified": 1731969202,
+        "narHash": "sha256-k10MJfCQXUUzkvAQMs8b8UsCjIQQPNWEPMlBrHOoPqU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "5bc3fa6996ee37b754f2e815a165be6e4d0cfcb9",
+        "rev": "2017830a2c81a97f6b7679ea5fa0d921cd0f4535",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`2017830a`](https://github.com/nix-community/nixvim/commit/2017830a2c81a97f6b7679ea5fa0d921cd0f4535) | `` docs/ci: fix a typo when calling `mkdir -p` ``                   |
| [`85244475`](https://github.com/nix-community/nixvim/commit/852444755474998b1b24bdd2f60d332a0eb2c830) | `` docs/ci: fix docs being installed to `nixvim/nixvim/<subdir>` `` |
| [`2bc8dc86`](https://github.com/nix-community/nixvim/commit/2bc8dc86a04fbccaef9e99fde6d07ef654df36a2) | `` ci/docs: fix `env` vs `environment` error ``                     |
| [`99b066ba`](https://github.com/nix-community/nixvim/commit/99b066ba6d4dea6311b88807894324bbc6c47658) | `` docs: only set base-href in CI built docs ``                     |
| [`cdbda982`](https://github.com/nix-community/nixvim/commit/cdbda982f04bd021cfa8d549896410c5caf84fdf) | `` docs/search: refactor to use `override` ``                       |
| [`9eb07bb1`](https://github.com/nix-community/nixvim/commit/9eb07bb16fe20d6073d820c9202f72962acbbda4) | `` flake.lock: Update ``                                            |
| [`f4c910dd`](https://github.com/nix-community/nixvim/commit/f4c910dd82eb6e811ba171bc923087b7ecfb321c) | `` tests/lsp-servers: disable deprecated servers ``                 |
| [`a773b945`](https://github.com/nix-community/nixvim/commit/a773b945fb9c74897333e4cd4f097f21a1d37f51) | `` tests/lsp: ruff_lsp is deprecated, test ruff instead ``          |
| [`e1417016`](https://github.com/nix-community/nixvim/commit/e1417016dfb561ac922d561f4f00d1c9160b23d9) | `` tests/{lsp-servers,efmls-configs}: disable psalm ``              |
| [`8b77198d`](https://github.com/nix-community/nixvim/commit/8b77198d494690f947cdf548bc74c4f3bc824a7c) | `` tests/{none-ls,efmls-configs}: disable phpstan ``                |
| [`909b4f41`](https://github.com/nix-community/nixvim/commit/909b4f41d7339af3b3701cf9955376549b1c514d) | `` tests: re-enable lua-language-servers tests on all platforms ``  |
| [`1ee4915f`](https://github.com/nix-community/nixvim/commit/1ee4915f6559a5955d12ec8b802777e7272f1c70) | `` plugins/lsp: update lsp-packages.nix ``                          |
| [`00365d6d`](https://github.com/nix-community/nixvim/commit/00365d6d40737cb88841387099485dbb75c596ed) | `` generated: Updated lspconfig-servers.json ``                     |
| [`b5a999fb`](https://github.com/nix-community/nixvim/commit/b5a999fb2291abd722a3035c5ce69c373925b049) | `` flake.lock: Update ``                                            |