### PR TITLE
chore(flake/treefmt-nix): `5f5c2787` -> `62003fda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732013921,
-        "narHash": "sha256-grEEN4LjL4DTDZUyZjVcj9dXRykH/SKnpOIADN0q5w8=",
+        "lastModified": 1732111664,
+        "narHash": "sha256-XWHuPWcP59QnHEewdZJXBX1TA2lAP78Vz4daG6tfIr4=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5f5c2787576f3e39bbc2ebdbf8521b3177c5c19c",
+        "rev": "62003fdad7a5ab7b6af3ea9bd7290e4c220277d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                             |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`62003fda`](https://github.com/numtide/treefmt-nix/commit/62003fdad7a5ab7b6af3ea9bd7290e4c220277d0) | `` feat: sqlfluff support (#258) `` |