### PR TITLE
chore(flake/nixvim): `929bb0cd` -> `2f71c425`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732035679,
-        "narHash": "sha256-J03v1XnxvsrrvHmzKVBZiwik8678IXfkH1/ZR954ujk=",
+        "lastModified": 1732143099,
+        "narHash": "sha256-lh2Qi8gd1SwJVGo7gJjoFvS/djS5Nimaw25j792PJjM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "929bb0cd1cffb9917ab14be9cdb3f27efd6f505f",
+        "rev": "2f71c4250bef7a52fe21bd00d1e58c119f62008c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`2f71c425`](https://github.com/nix-community/nixvim/commit/2f71c4250bef7a52fe21bd00d1e58c119f62008c) | `` tests/avante: remove deprecated model option `local` ``                   |
| [`5f0b3371`](https://github.com/nix-community/nixvim/commit/5f0b33710ab1eb0657081e015031c4b9b1eb9b2c) | `` tests/{efmls-configs,none-ls}: re-enable phpstan test ``                  |
| [`7defce38`](https://github.com/nix-community/nixvim/commit/7defce38637187b334afbd58515ec18ad30d4f4b) | `` tests/{efmls-configs,lsp-servers}: re-enable psalm test ``                |
| [`fd41c5af`](https://github.com/nix-community/nixvim/commit/fd41c5afee9882dfce17f9dee33355fcfa383058) | `` generated: Updated rust-analyzer.nix ``                                   |
| [`2a94d1de`](https://github.com/nix-community/nixvim/commit/2a94d1de6ecf80d022c998d41290834c93f1e7ea) | `` flake.lock: Update ``                                                     |
| [`7b94afce`](https://github.com/nix-community/nixvim/commit/7b94afceaf616d64d43d33340dddf64f57c7a5b2) | `` plugins: cleanup most `extraConfig` args ``                               |
| [`63cfc84a`](https://github.com/nix-community/nixvim/commit/63cfc84abeec5f8995945098e30e2d8101133d18) | `` lib/modules: add `applyExtraConfig` ``                                    |
| [`c7b7b648`](https://github.com/nix-community/nixvim/commit/c7b7b6481b129d31b5357b4529c28e2cc341b96e) | `` docs: no longer using `master` but `main` ``                              |
| [`9416bc90`](https://github.com/nix-community/nixvim/commit/9416bc9018cca37b3f24eef290e2113edff25960) | `` docs/ci: use `nix build --argstr` to safely supply input ``               |
| [`ed30fd85`](https://github.com/nix-community/nixvim/commit/ed30fd858848be9b0f13d48cfa9ae6fd00df21d6) | `` modules/opts: fix code generation condition to prevent false positives `` |