### PR TITLE
chore(flake/nixpkgs): `5e4fbfb6` -> `23e89b7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731676054,
-        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
+        "lastModified": 1732014248,
+        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
+        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`d5808aee`](https://github.com/NixOS/nixpkgs/commit/d5808aee19c06e9e6b2603d0b600de34ed890de8) | `` handheld-daemon-ui: init at 3.2.3 (#305027) ``                                      |
| [`46cc4292`](https://github.com/NixOS/nixpkgs/commit/46cc4292da55da3aadf5b7d306b1f00aa91d2b0c) | `` libretro.mame2003-plus: unstable-2024-10-05 -> unstable-2024-11-19 ``               |
| [`3521da58`](https://github.com/NixOS/nixpkgs/commit/3521da588146697b05aebf4d3064e6845d26ac88) | `` vimPlugins: add missing dependencies ``                                             |
| [`3afde341`](https://github.com/NixOS/nixpkgs/commit/3afde341d147da3f0887d762169e0383b689c8ad) | `` libretro.ppsspp: unstable-2024-10-03 -> unstable-2024-11-15 ``                      |
| [`e848cf7d`](https://github.com/NixOS/nixpkgs/commit/e848cf7d8322b0197c9b89e0a029d5199b6e2f77) | `` libretro.smsplus-gx: unstable-2024-08-07 -> unstable-2024-10-21 ``                  |
| [`0705964c`](https://github.com/NixOS/nixpkgs/commit/0705964c881cea8896474610188905ba41b59b08) | `` nixStatic: mark as broken on darwin (#357185) ``                                    |
| [`74012c66`](https://github.com/NixOS/nixpkgs/commit/74012c66d41fec05108608888d276fa292634e26) | `` libretro.handy: unstable-2024-06-28 -> unstable-2024-10-21 ``                       |
| [`3c19b680`](https://github.com/NixOS/nixpkgs/commit/3c19b680f9bc923c39801972d39b1149ad190389) | `` icestudio: init at 0-unstable-2024-11-18 (#356775) ``                               |
| [`89069b15`](https://github.com/NixOS/nixpkgs/commit/89069b15aab072d4bb1da2b7f249c7cee67727d3) | `` libretro.mame2003: unstable-2024-09-04 -> unstable-2024-11-10 ``                    |
| [`55bba10a`](https://github.com/NixOS/nixpkgs/commit/55bba10a01e69a3834e79dab3610ee50d60962b0) | `` libretro.beetle-supergrafx: unstable-2024-09-06 -> unstable-2024-11-15 ``           |
| [`8960ca88`](https://github.com/NixOS/nixpkgs/commit/8960ca882abbb7cee1115a6b4d1925036aa8839d) | `` vimPlugins.nvim-treesitter: update grammars ``                                      |
| [`67a7b574`](https://github.com/NixOS/nixpkgs/commit/67a7b574bdc0816776cf8a5ab37eaacea78c0830) | `` vimPlugins: update on 2024-11-19 ``                                                 |
| [`3c375611`](https://github.com/NixOS/nixpkgs/commit/3c37561119ff039db7bab7049f5910c2c9629f34) | `` luaPackages: update on 2024-11-18 ``                                                |
| [`af8279fe`](https://github.com/NixOS/nixpkgs/commit/af8279fe38a2b7957563d253a83156be922b5265) | `` nixos/systemd-stage-1: nixos-find-nixos-closure before initrd.target ``             |
| [`0347a0b7`](https://github.com/NixOS/nixpkgs/commit/0347a0b7bad3bcb9df955636b6e7460dc2678906) | `` libretro.beetle-saturn: unstable-2024-10-01 -> unstable-2024-10-21 ``               |
| [`d9bf9170`](https://github.com/NixOS/nixpkgs/commit/d9bf91700e617512efc2f62202117f442f1ad3c4) | `` nixos/acme: make address families in systemd service less restrictive ``            |
| [`5cda6592`](https://github.com/NixOS/nixpkgs/commit/5cda65923e85c2cc1b21db9d3ad9b4c939203239) | `` libretro.vba-m: unstable-2024-06-28 -> unstable-2024-10-21 ``                       |
| [`5f677709`](https://github.com/NixOS/nixpkgs/commit/5f677709c99a47a7392269115868b6a160001846) | `` libretro.gw: unstable-2024-06-28 -> unstable-2024-10-21 ``                          |
| [`9405feaa`](https://github.com/NixOS/nixpkgs/commit/9405feaad98edf238ecfe49ba41314b4c6f63024) | `` smart-copy-paste-2: init at 0-unstable-2023-11-25 ``                                |
| [`ed15cbbf`](https://github.com/NixOS/nixpkgs/commit/ed15cbbff9b20fb49636c8598ea80ae28cd01b56) | `` mpvScripts.mpv-subtitle-lines: init at 0-unstable-2024-05-19 ``                     |
| [`52340241`](https://github.com/NixOS/nixpkgs/commit/52340241464d18db91499cf792f36951fa47d5f8) | `` libretro.desmume: unstable-2024-01-11 -> unstable-2024-10-21 ``                     |
| [`c5c832d8`](https://github.com/NixOS/nixpkgs/commit/c5c832d89066a13792d851fbd629a81cd79eda86) | `` libretro.mesen-s: unstable-2022-07-25 -> unstable-2024-10-21 ``                     |
| [`f7114a17`](https://github.com/NixOS/nixpkgs/commit/f7114a17d75684343194441b98761f92d94baf0d) | `` libretro.beetle-pce: unstable-2024-10-01 -> unstable-2024-11-15 ``                  |
| [`5a87f753`](https://github.com/NixOS/nixpkgs/commit/5a87f75375eee8a7a236f1698e402ec53ef2ac79) | `` libretro.beetle-pce-fast: unstable-2024-09-20 -> unstable-2024-11-15 ``             |
| [`a74d23ff`](https://github.com/NixOS/nixpkgs/commit/a74d23ffb771c691403768f648bfd8a1feab4c12) | `` python3Packages.scikit-learn: Remove unused environment variable in build script `` |
| [`5e1144c5`](https://github.com/NixOS/nixpkgs/commit/5e1144c572a133b129d004275e3afde53e248fce) | `` git-annex: work around corrupted store paths of dependencies ``                     |
| [`4c6d20c6`](https://github.com/NixOS/nixpkgs/commit/4c6d20c64896bf4d9eabfdbf7703a8afdc9b200c) | `` nix-update: 1.6.0 -> 1.7.0 ``                                                       |
| [`952d277b`](https://github.com/NixOS/nixpkgs/commit/952d277bb28339874508b1457b28be31c4e4f518) | `` libretro.np2kai: unstable-2024-01-10 -> unstable-2024-11-03 ``                      |
| [`6867e4bb`](https://github.com/NixOS/nixpkgs/commit/6867e4bb3206d3100091d68e7dff1209b97ceb39) | `` libretro.stella: unstable-2024-10-04 -> unstable-2024-11-17 ``                      |
| [`3901e068`](https://github.com/NixOS/nixpkgs/commit/3901e0689b6226ebb1bcdb4b6dea7988f0e8d2c2) | `` libretro.pcsx-rearmed: unstable-2024-10-06 -> unstable-2024-11-17 ``                |
| [`5f71753c`](https://github.com/NixOS/nixpkgs/commit/5f71753ce4f482b8f16ff33c37931f9cec40d301) | `` libretro.snes9x: unstable-2024-10-03 -> unstable-2024-10-28 ``                      |
| [`8a95027e`](https://github.com/NixOS/nixpkgs/commit/8a95027e71a3c6a63d96d8caac27f8d5ce85a079) | `` mautrix-whatsapp: 0.11.0 -> 0.11.1 ``                                               |
| [`7a424b4a`](https://github.com/NixOS/nixpkgs/commit/7a424b4a0125f55b337feb0d21d03ce15c6c95ee) | `` libretro.prosystem: unstable-2024-06-28 -> unstable-2024-10-21 ``                   |
| [`f9f5c70e`](https://github.com/NixOS/nixpkgs/commit/f9f5c70ea9932202739f008f707b0d8e580901dc) | `` libretro.beetle-psx-hw: unstable-2024-09-16 -> unstable-2024-11-15 ``               |
| [`fccca859`](https://github.com/NixOS/nixpkgs/commit/fccca859895e91380fe76c8bdcc580909f9981e2) | `` libretro.eightyone: unstable-2024-06-28 -> unstable-2024-10-21 ``                   |
| [`5d171bb6`](https://github.com/NixOS/nixpkgs/commit/5d171bb64731a9bf7e25452e776c77902ccce37e) | `` openapi-generator-cli: 7.9.0 -> 7.10.0 ``                                           |
| [`9afde02c`](https://github.com/NixOS/nixpkgs/commit/9afde02c5a1a5d46fcefe7d35a839da20caf13bb) | `` cardinal: use suffix instead of prefix in wrapProgram ``                            |
| [`02cc2a7b`](https://github.com/NixOS/nixpkgs/commit/02cc2a7b0370097a36db783509eed21387843d77) | `` legcord: 1.0.2 -> 1.0.4 ``                                                          |
| [`3066d8b9`](https://github.com/NixOS/nixpkgs/commit/3066d8b9830bf1ab1df95a44011ad9e58097ef43) | `` vscode-extensions.visualjj.visualjj: 0.12.3 -> 0.12.5 ``                            |
| [`5aa3f165`](https://github.com/NixOS/nixpkgs/commit/5aa3f1650c2ec6ee96f2962d1e271ff9e13c8ce7) | `` python312Packages.pyro5: disable failing tests ``                                   |
| [`b4d622fd`](https://github.com/NixOS/nixpkgs/commit/b4d622fd7acd3842ad6dc9b0580cc8299c98bf8c) | `` nixos/{arp-scan,iftop,tcpdump,traceroute}: format ``                                |
| [`a6ee554a`](https://github.com/NixOS/nixpkgs/commit/a6ee554a67d563c96134fd7b3797552c72113b68) | `` nixos/traceroute: use lib.getExe ``                                                 |
| [`4fae2896`](https://github.com/NixOS/nixpkgs/commit/4fae28967bbc2c04a48066891c01bfb1c798fc98) | `` nixos/iftop: improve description, use lib.getExe ``                                 |
| [`eb42ef0c`](https://github.com/NixOS/nixpkgs/commit/eb42ef0c24564082056a5ae54cdf52902bda58fd) | `` nixos/tcpdump: init ``                                                              |
| [`b00728da`](https://github.com/NixOS/nixpkgs/commit/b00728da1090ce0dc8a3586f7d86f1a04122e605) | `` electron-cash: remove absolute path in desktop entry ``                             |
| [`fb74ff8d`](https://github.com/NixOS/nixpkgs/commit/fb74ff8dd0d91eeb7e9c9251e03812a25ec5aeb9) | `` tilix: remove absolute path in desktop entry ``                                     |
| [`824cbe99`](https://github.com/NixOS/nixpkgs/commit/824cbe992255b202ac4d2005a0d4b739e14a7973) | `` gamepad-tool: remove absolute icon path ``                                          |
| [`f278e7f4`](https://github.com/NixOS/nixpkgs/commit/f278e7f42c94fcd3944295699cea8307d5413f63) | `` python3Packages.hikari: fix build ``                                                |
| [`28291813`](https://github.com/NixOS/nixpkgs/commit/28291813168bbcad28f5f695c84b9d3ae470c69d) | `` nixos/arp-scan: init ``                                                             |
| [`859c76c5`](https://github.com/NixOS/nixpkgs/commit/859c76c505a4f2b80c32c64a22e51e139b6d68fa) | `` nixos/tools: add enable options to manual ``                                        |
| [`9a2d0bf1`](https://github.com/NixOS/nixpkgs/commit/9a2d0bf15f9a6ce5be79b4fe19f347cff7b01931) | `` libretro.beetle-vb: unstable-2024-06-28 -> unstable-2024-10-21 ``                   |
| [`0f1b3297`](https://github.com/NixOS/nixpkgs/commit/0f1b3297c9a0cd68262108cd940c2d4bb27939f2) | `` libretro.melonds: unstable-2023-04-13 -> unstable-2024-10-21 ``                     |
| [`6b53949b`](https://github.com/NixOS/nixpkgs/commit/6b53949b0cbe3f6dadf4ea730558ac5f4eb56793) | `` formats.ini: expose INI atom from all ini formats ``                                |
| [`48a8c0b2`](https://github.com/NixOS/nixpkgs/commit/48a8c0b281f4d9e0691d817fd1646eb560f2fae6) | `` mblaze: 1.2 -> 1.3 ``                                                               |
| [`ba0d80db`](https://github.com/NixOS/nixpkgs/commit/ba0d80db843c06d1c4247296516f4c60532ce47b) | `` ip2unix: fix cross compilation ``                                                   |
| [`ebdcc360`](https://github.com/NixOS/nixpkgs/commit/ebdcc360f527e3807e9a291434e3fdfaa1da6bce) | `` stm8flash: fix cross compilation ``                                                 |
| [`3226e139`](https://github.com/NixOS/nixpkgs/commit/3226e1398841841400ca83bda480940b0c1127bf) | `` libretro.tgbdual: unstable-2024-07-01 -> unstable-2024-10-21 ``                     |
| [`2b410eeb`](https://github.com/NixOS/nixpkgs/commit/2b410eeb15f043a1290a9c24b07e94cfc5d2c09e) | `` nix-init: fix build on x86_64-darwin ``                                             |
| [`4ba778e0`](https://github.com/NixOS/nixpkgs/commit/4ba778e088686cef915676c30aad104fbe16c054) | `` libretro.nestopia: unstable-2024-06-28 -> unstable-2024-10-17 ``                    |
| [`e772508f`](https://github.com/NixOS/nixpkgs/commit/e772508fc9fe8bc3c28d3fe30b615a5ea5b0c2c2) | `` libretro.beetle-pcfx: unstable-2024-08-07 -> unstable-2024-10-21 ``                 |
| [`d6e26c4e`](https://github.com/NixOS/nixpkgs/commit/d6e26c4e7d7847dc448365bd92f22aac9c84b5d1) | `` libretro.neocd: unstable-2024-06-22 -> unstable-2024-10-21 ``                       |
| [`06f50f4a`](https://github.com/NixOS/nixpkgs/commit/06f50f4adf5f96efc6926681ee7143c038e2abbc) | `` nixos/networkd: warn about naively replacing IPForward ``                           |
| [`08d2f9c6`](https://github.com/NixOS/nixpkgs/commit/08d2f9c665416cb5a4779eacf692fa5a6937a841) | `` path-of-building.data: 2.48.2 -> 2.49.0 ``                                          |
| [`f2ca8f1d`](https://github.com/NixOS/nixpkgs/commit/f2ca8f1d7a23607c615286d1e56a640b4c0219a8) | `` libretro.picodrive: unstable-2024-10-01 -> unstable-2024-10-19 ``                   |
| [`58c785ae`](https://github.com/NixOS/nixpkgs/commit/58c785ae21b0f807850f75ac3fb001b8e7d14526) | `` libretro.yabause: unstable-2023-01-03 -> unstable-2024-10-21 ``                     |
| [`efeab004`](https://github.com/NixOS/nixpkgs/commit/efeab00416ff61997379d42fdfdda84de1dfd926) | `` libretro.beetle-gba: unstable-2021-09-18 -> unstable-2024-10-21 ``                  |
| [`13097e3a`](https://github.com/NixOS/nixpkgs/commit/13097e3a4b125c82cabcc0477a676a5f8dae9263) | `` libretro.bsnes-mercury-balanced: unstable-2023-11-01 -> unstable-2024-10-21 ``      |
| [`81d54c13`](https://github.com/NixOS/nixpkgs/commit/81d54c130da1562af75534e8d3abb75df9bd7669) | `` vaultwarden: 1.32.4 -> 1.32.5 ``                                                    |
| [`bd9c7d02`](https://github.com/NixOS/nixpkgs/commit/bd9c7d0272597fa4475ad4485dc776acc6038b22) | `` python312Packages.experiment-utilities: 0.3.6 -> 0.3.8 ``                           |
| [`9dd1da74`](https://github.com/NixOS/nixpkgs/commit/9dd1da7475146cdc8937038b9341e8e19bcf5278) | `` linuxManualConfig: don't leak rust-lib-src paths into the final binary ``           |
| [`57fb63c9`](https://github.com/NixOS/nixpkgs/commit/57fb63c9314cf30e4c2b0abe5b0096fd73364007) | `` cynthion: init at 0.1.7 ``                                                          |
| [`93b0565d`](https://github.com/NixOS/nixpkgs/commit/93b0565dd2230219f71b191334d5765ebc182680) | `` python312Packages.cynthion: init at 0.1.7 ``                                        |
| [`ded0edc6`](https://github.com/NixOS/nixpkgs/commit/ded0edc6d918e711fcf131e3bc646e51a6ba98af) | `` python312Packages.luna-soc: init at 0.2.0 ``                                        |
| [`393495aa`](https://github.com/NixOS/nixpkgs/commit/393495aa442c8712876096a2ba5595b64f196802) | `` python312Packages.luna-usb: init at 0.1.2 ``                                        |
| [`de6f807a`](https://github.com/NixOS/nixpkgs/commit/de6f807a09eec88ac89861d66fc924aa94862a7a) | `` python312Packages.apollo-fpga: init at 1.1.0 ``                                     |
| [`e0f9d195`](https://github.com/NixOS/nixpkgs/commit/e0f9d1953abf7648eeb37d989e1ea94211a1e0f7) | `` python312Packages.usb-protocol: init at 0.9.1 ``                                    |
| [`ec24d96a`](https://github.com/NixOS/nixpkgs/commit/ec24d96ad57a80ff9bc8d5f8a1d7d4ac0da271ec) | `` libretro.mupen64plus: unstable-2024-08-21 -> unstable-2024-10-29 ``                 |
| [`ed5098fd`](https://github.com/NixOS/nixpkgs/commit/ed5098fd7da20c419baaecee5a1fd465604dece3) | `` libretro.beetle-lynx: unstable-2024-06-28 -> unstable-2024-10-21 ``                 |
| [`95d07692`](https://github.com/NixOS/nixpkgs/commit/95d076927b34737991eefb7464adfc4351e09a55) | `` fastfetch: 2.29.0 -> 2.30.1 ``                                                      |
| [`7b1fc75b`](https://github.com/NixOS/nixpkgs/commit/7b1fc75bce56f5e8f2de62c10aaede4594db01ba) | `` libretro.prboom: unstable-2024-09-07 -> unstable-2024-10-21 ``                      |
| [`ecbe02d8`](https://github.com/NixOS/nixpkgs/commit/ecbe02d89665d5760470746c0077ea356a5a3a5e) | `` tcllib: 1.21 -> 2.0 ``                                                              |
| [`d023b182`](https://github.com/NixOS/nixpkgs/commit/d023b182b389699adba6c94987fc47bdb60d8d31) | `` critcl: 3.2 -> 3.3.1 ``                                                             |
| [`ac35e924`](https://github.com/NixOS/nixpkgs/commit/ac35e924ac31ff9bac96f54e486fbb0967fc5268) | `` libretro.opera: unstable-2024-05-06 -> unstable-2024-10-17 ``                       |
| [`5d56253d`](https://github.com/NixOS/nixpkgs/commit/5d56253de0ce091003e5f1d26ba3c82ce49ef20a) | `` google-cloud-sdk: 494.0.0 -> 501.0.0 ``                                             |
| [`5ebcfc74`](https://github.com/NixOS/nixpkgs/commit/5ebcfc742d00e0dfbc529f3427648ba9da78e588) | `` space-cadet-pinball: improve packaging ``                                           |
| [`eadef8f4`](https://github.com/NixOS/nixpkgs/commit/eadef8f4860c9eff7d45a5f87031bc1c416d759a) | `` space-cadet-pinball: migrate to by-name ``                                          |
| [`3246cfb7`](https://github.com/NixOS/nixpkgs/commit/3246cfb7bf3f9b6c48f40855ae8e79a90eae8a56) | `` space-cadet-pinball: format with nixfmt-rfc-style ``                                |
| [`4a68949c`](https://github.com/NixOS/nixpkgs/commit/4a68949c7e080ad50010c3a56bd98c1f6b86b7d2) | `` maintainers: add nadiaholmquist ``                                                  |
| [`8dd8ed68`](https://github.com/NixOS/nixpkgs/commit/8dd8ed68a1685a373361cc87a41beb1837b4d297) | `` verifpal: 0.27.0 -> 0.27.4 ``                                                       |
| [`80aefca4`](https://github.com/NixOS/nixpkgs/commit/80aefca49cf274460e1ab582b933a41e5fe7a1ad) | `` libretro.snes9x2005: unstable-2024-06-28 -> unstable-2024-10-21 ``                  |