### PR TITLE
chore(flake/nixvim): `2f71c425` -> `c1271fa1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732143099,
-        "narHash": "sha256-lh2Qi8gd1SwJVGo7gJjoFvS/djS5Nimaw25j792PJjM=",
+        "lastModified": 1732315025,
+        "narHash": "sha256-vPAMWd5/akE3U3B8uXzi05X/9fUd71sZaOnfBrX4AR0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2f71c4250bef7a52fe21bd00d1e58c119f62008c",
+        "rev": "c1271fa10a54a3b35db6040dd6e779f349af52bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`c1271fa1`](https://github.com/nix-community/nixvim/commit/c1271fa10a54a3b35db6040dd6e779f349af52bf) | `` ci: fix nix-install-action versions ``                |
| [`fb49a740`](https://github.com/nix-community/nixvim/commit/fb49a740f8aa32f4452849f91da0d94839b83cf1) | `` ci: bump nix-install-action ``                        |
| [`863d7d5a`](https://github.com/nix-community/nixvim/commit/863d7d5adec45735de8e4cc873578e1f0d915dc4) | `` docs: link to all "available" versions of the docs `` |