### PR TITLE
chore(flake/nixvim): `85759f23` -> `a81a03a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732365274,
-        "narHash": "sha256-78n1Z3+i686w1FHCWEiEimxvwJF/sgtG7Px0RyI9bLE=",
+        "lastModified": 1732478249,
+        "narHash": "sha256-ka41KXN5B5C6yxJeIpFw5ytXFjd6vXJldw/5sN6y0CA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "85759f2360faa0464da008b040217183d99fd9d9",
+        "rev": "a81a03a3f5dcdcdee5cbe831a9f2e81895e92875",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`a81a03a3`](https://github.com/nix-community/nixvim/commit/a81a03a3f5dcdcdee5cbe831a9f2e81895e92875) | `` plugins/vim-colemak: init ``                                |
| [`6b9d55f9`](https://github.com/nix-community/nixvim/commit/6b9d55f936a5df716f787df0ed172070fccbc1e9) | `` Update docs/user-guide/config-examples.md ``                |
| [`99f37733`](https://github.com/nix-community/nixvim/commit/99f377335dccdaeed895dc17b3fbae3ce92c6802) | `` docs/user-guide/config-examples: add spector700's config `` |