### PR TITLE
chore(flake/nixvim): `a81a03a3` -> `8b19d154`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732478249,
-        "narHash": "sha256-ka41KXN5B5C6yxJeIpFw5ytXFjd6vXJldw/5sN6y0CA=",
+        "lastModified": 1732629460,
+        "narHash": "sha256-Cr8EyxEFPbVmX6p8LsslFBjDEuVlFNPILrWlwbBNnNA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a81a03a3f5dcdcdee5cbe831a9f2e81895e92875",
+        "rev": "8b19d154823619af7ced464185e8d13ec80a758b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`8b19d154`](https://github.com/nix-community/nixvim/commit/8b19d154823619af7ced464185e8d13ec80a758b) | `` plugins/lsp: fix `enabledServers.extraOptions` type merging `` |
| [`a1c352af`](https://github.com/nix-community/nixvim/commit/a1c352affcd40ad28ac7c77e10e3313d8a8fa628) | `` plugins/vim-be-good: init ``                                   |
| [`8507b01e`](https://github.com/nix-community/nixvim/commit/8507b01e0ccd0d0b42939b9e249553c220388249) | `` lib/maintainers: add 347Online ``                              |