### PR TITLE
chore(flake/flake-compat): `0f9255e0` -> `4a4fe463`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1732720106,
+        "narHash": "sha256-74rRgtsneSfPhGcQYpzX8zbUz7TNJjqpymt4jJh/kz0=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "4a4fe4634a34e87e8cd094fce0a4819afa5c1997",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                            |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
| [`baa7aa7b`](https://github.com/edolstra/flake-compat/commit/baa7aa7bd0a570b3b9edd0b8da859fee3ffaa4d4) | `` Check for pure eval mode before calling `builtins.storePath` `` |
| [`b7cd5940`](https://github.com/edolstra/flake-compat/commit/b7cd594063b9118c198bbdb4c22c19ca0919822a) | `` README: fix node name look-up ``                                |