### PR TITLE
chore(flake/flake-compat): `4a4fe463` -> `9ed2ac15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1732720106,
-        "narHash": "sha256-74rRgtsneSfPhGcQYpzX8zbUz7TNJjqpymt4jJh/kz0=",
+        "lastModified": 1732722421,
+        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "4a4fe4634a34e87e8cd094fce0a4819afa5c1997",
+        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                        |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
| [`a1b45cd4`](https://github.com/edolstra/flake-compat/commit/a1b45cd4a224023888702a60d6830bc0ab40c038) | `` Return all outputs ``                       |
| [`3980b5e4`](https://github.com/edolstra/flake-compat/commit/3980b5e441bac46246f9f11c77085ed5a2c73912) | `` Expose revCount attribute for git inputs `` |
| [`520e73f6`](https://github.com/edolstra/flake-compat/commit/520e73f623ca5e1f61ee4b5f07a9a700e67c0e95) | `` Use builtins.fetchTree if available ``      |