### PR TITLE
chore(flake/nixvim): `05331006` -> `060f4b4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732838896,
-        "narHash": "sha256-9YfEyCU2wB/aSbtpZ+OHb++xS2Km970Ja33H13oEaWM=",
+        "lastModified": 1733009667,
+        "narHash": "sha256-tQkfvl9oecJxW7YPu1zTagEZAQulVinTj88/LwARJpU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "05331006a42846d6e55129b642485f45f90c9efc",
+        "rev": "060f4b4c3800367ba202440a7832cddecb7fae26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`060f4b4c`](https://github.com/nix-community/nixvim/commit/060f4b4c3800367ba202440a7832cddecb7fae26) | `` plugins/aerial: init ``                                                   |
| [`09dfa035`](https://github.com/nix-community/nixvim/commit/09dfa035b65db88ca32df11507c891530f3258ef) | `` plugins/gitlab: init ``                                                   |
| [`880a5705`](https://github.com/nix-community/nixvim/commit/880a57058862752aed6d0215697718c4f646f299) | `` ci: add support for new stable nixos-24.11 branch ``                      |
| [`a35f923d`](https://github.com/nix-community/nixvim/commit/a35f923d6aa05eede3cf694608ce0dde6ba28d54) | `` treewide: replace mentions of 24.05 with 24.11 ``                         |
| [`0c89a669`](https://github.com/nix-community/nixvim/commit/0c89a669f6f8508784c187c9cf9d381592146e92) | `` readme: fix `stable` -> `24.05` in docs URL ``                            |
| [`98bedb5e`](https://github.com/nix-community/nixvim/commit/98bedb5eebc92ec3a170c7f7844d4dbd944ac334) | `` ci/docs: `stable` -> `24.05` in docs path ``                              |
| [`72762c8e`](https://github.com/nix-community/nixvim/commit/72762c8ef1e33604d4338b4254a3a45829fa59f8) | `` ci/docs: remove on 24.05 branch ``                                        |
| [`bb5b0a26`](https://github.com/nix-community/nixvim/commit/bb5b0a26556017f1f3a4c07f8bd20dee88f6ffb0) | `` tests/modules-performance: add nvim-cmp to extraPlugins when necessary `` |
| [`a4e5f694`](https://github.com/nix-community/nixvim/commit/a4e5f694355777c5f4e24bb9398316fbe33084d4) | `` tests/codeium-nvim: fix and update tests ``                               |
| [`cb0e3a7e`](https://github.com/nix-community/nixvim/commit/cb0e3a7e4049f774e7cbd34c57eeeee17bb1ed2a) | `` plugins/efmls-configs: add new formatter kdlfmt to unpackaged ``          |
| [`c39ecbb0`](https://github.com/nix-community/nixvim/commit/c39ecbb055597edade9b936905314eade3e5ca96) | `` tests/lsp-servers: disable servers relying on EOL dotnet-core-combined `` |
| [`41657913`](https://github.com/nix-community/nixvim/commit/41657913df2cb1577620b9609a41ba2201c05218) | `` generated: Update ``                                                      |
| [`4d0b66b9`](https://github.com/nix-community/nixvim/commit/4d0b66b9d7c9d56e9a1e99bc0a7f3d215a66c06c) | `` flake.lock: Update ``                                                     |