### PR TITLE
chore(flake/nixvim): `060f4b4c` -> `80e49e7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733009667,
-        "narHash": "sha256-tQkfvl9oecJxW7YPu1zTagEZAQulVinTj88/LwARJpU=",
+        "lastModified": 1733010437,
+        "narHash": "sha256-xPf3jjDBDA9oMVnWU5DJ8gINCq2EPiupvF/4rD/0eEI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "060f4b4c3800367ba202440a7832cddecb7fae26",
+        "rev": "80e49e7fd3fa720b93d18e6d859d9b9e7aad4a62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`80e49e7f`](https://github.com/nix-community/nixvim/commit/80e49e7fd3fa720b93d18e6d859d9b9e7aad4a62) | `` plugins/dashboard: format ``                           |
| [`86ff391e`](https://github.com/nix-community/nixvim/commit/86ff391e9ed729914e0ab1f4893466858c225bd6) | `` plugins/dashboard: better rawLua support for header `` |