### PR TITLE
chore(flake/nixvim): `80e49e7f` -> `e680b367`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733010437,
-        "narHash": "sha256-xPf3jjDBDA9oMVnWU5DJ8gINCq2EPiupvF/4rD/0eEI=",
+        "lastModified": 1733132296,
+        "narHash": "sha256-fYEf0IgsNJp/hcb+C3FKtJvVabPDQs64hdL0izNBwXc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "80e49e7fd3fa720b93d18e6d859d9b9e7aad4a62",
+        "rev": "e680b367c726e2ae37d541328fe81f8daaf49a6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`e680b367`](https://github.com/nix-community/nixvim/commit/e680b367c726e2ae37d541328fe81f8daaf49a6c) | `` treewide: format with latest nixfmt ``               |
| [`d55ca74c`](https://github.com/nix-community/nixvim/commit/d55ca74c054a98a38d1056f82008151c5a75b477) | `` flake.lock: Update ``                                |
| [`3c6dd42f`](https://github.com/nix-community/nixvim/commit/3c6dd42ff8ef739f1a9c231c5669798c56070ac6) | `` plugin/lsp: simplify automatic keymap description `` |
| [`d867aaea`](https://github.com/nix-community/nixvim/commit/d867aaea43a7efcfc2cd19a6e0fc89783e15838e) | `` plugin/lsp: automatic keymap description ``          |
| [`838829c8`](https://github.com/nix-community/nixvim/commit/838829c8f9cb238a915fe3d6ac36df1a3f040d2c) | `` lsp/keymaps: cosmetic implem changes ``              |