### PR TITLE
chore(flake/nixpkgs): `970e93b9` -> `ac35b104`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732837521,
-        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
+        "lastModified": 1733015953,
+        "narHash": "sha256-t4BBVpwG9B4hLgc6GUBuj3cjU7lP/PJfpTHuSqE+crk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "970e93b9f82e2a0f3675757eb0bfc73297cc6370",
+        "rev": "ac35b104800bff9028425fec3b6e8a41de2bbfff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`107d49c4`](https://github.com/NixOS/nixpkgs/commit/107d49c466073efd791e08a2d8806ade72cb09d2) | `` vimPlugins.csvview-nvim: init at 2024-11-18 ``                                           |
| [`57319498`](https://github.com/NixOS/nixpkgs/commit/5731949899a13cde82e47ca69ce4c38f69b09e70) | `` python312Packages.eq3btsmart: 1.2.0 -> 1.4.1 ``                                          |
| [`6e826b78`](https://github.com/NixOS/nixpkgs/commit/6e826b78b0f977c2a61fe2a42c8632a141f706c5) | `` php84Extensions.imagick: fix darwin build ``                                             |
| [`9b3a550e`](https://github.com/NixOS/nixpkgs/commit/9b3a550e96b95e03585b8dd15e38eb324fedbe8b) | `` gqrx: 2.17.5 -> 2.17.6 ``                                                                |
| [`4829779d`](https://github.com/NixOS/nixpkgs/commit/4829779d1c6e4f8cb56e2177d4b174de21427dbc) | `` mullvad-vpn: add versionCheckHook ``                                                     |
| [`1fdd4348`](https://github.com/NixOS/nixpkgs/commit/1fdd4348e4660d8d04ac16f5e53a5372c8989964) | `` openssh: add initrd-network-ssh nixos test to passthru.tests ``                          |
| [`b8e5253e`](https://github.com/NixOS/nixpkgs/commit/b8e5253e27391f466a4cc6ed7e816a68e5863d91) | `` evcc: 0.131.6 -> 0.131.8 ``                                                              |
| [`5289e542`](https://github.com/NixOS/nixpkgs/commit/5289e5424d00c966041dd4d47cce7a552da8c800) | `` mullvad-vpn: move to by-name ``                                                          |
| [`d6ba42ff`](https://github.com/NixOS/nixpkgs/commit/d6ba42ff017e4fa4ea5aaa99a15083589c4b6019) | `` mullvad-vpn: format ``                                                                   |
| [`0ce0839b`](https://github.com/NixOS/nixpkgs/commit/0ce0839bc2f6d94109424f4c09491ceade4243d0) | `` mullvad-vpn add darwin as badPlatform ``                                                 |
| [`da14e45b`](https://github.com/NixOS/nixpkgs/commit/da14e45b25d54d14fbcf9b9811d3bf72fedf46d0) | `` etlegacy-unwrapped: 2.82.1 -> 2.83.1 ``                                                  |
| [`a6ee73b5`](https://github.com/NixOS/nixpkgs/commit/a6ee73b5434708162ade53424ffdef6457791e4e) | `` atop: fix cross-compilation ``                                                           |
| [`b99389f0`](https://github.com/NixOS/nixpkgs/commit/b99389f02dbd5336605e6f02701bb8b66124aab5) | `` xautocfg: init at 1.2 (#335733) ``                                                       |
| [`4761b61b`](https://github.com/NixOS/nixpkgs/commit/4761b61b1efdedfb14d08f05952a08f9665b5fc2) | `` goodvibes: 0.8.0 -> 0.8.1 ``                                                             |
| [`3c352ba0`](https://github.com/NixOS/nixpkgs/commit/3c352ba05186f705a27c641d73e7a23f4583d271) | `` scx.rustscheds: drop clang from nativeBuildInputs ``                                     |
| [`23a60b09`](https://github.com/NixOS/nixpkgs/commit/23a60b0966dddc90f5b8610efc63055360ae1a94) | `` neothesia: drop clang from nativeBuildInputs ``                                          |
| [`1a827e70`](https://github.com/NixOS/nixpkgs/commit/1a827e70dc1bf6a86d63893e858a0c8a3e5ee657) | `` libkrun: drop clang from nativeBuildInputs ``                                            |
| [`f826c0aa`](https://github.com/NixOS/nixpkgs/commit/f826c0aafaea04387c9dee913149aff5801b479b) | `` fedimint: drop various darwin workarounds, use new sdk pattern ``                        |
| [`682cf788`](https://github.com/NixOS/nixpkgs/commit/682cf788e1c70474ea4e15caa87951ea367fcd69) | `` scx.rustscheds: use rustPlatform.bindgenHook ``                                          |
| [`52614866`](https://github.com/NixOS/nixpkgs/commit/52614866fd27628245f961fedcc1e963316537da) | `` servo: use rustPlatform.bindgenHook ``                                                   |
| [`bbd2561c`](https://github.com/NixOS/nixpkgs/commit/bbd2561c7fe75915afb5791acf184cd801451f8e) | `` fedimint: use rustPlatform.bindgenHook ``                                                |
| [`f9b5b1f9`](https://github.com/NixOS/nixpkgs/commit/f9b5b1f98c36b5a44a2ac0d2bf9c4df096b3a9f4) | `` caligula: use new darwin sdk pattern ``                                                  |
| [`b88f9fe2`](https://github.com/NixOS/nixpkgs/commit/b88f9fe294723f9b111c9b949d419f56a776b433) | `` caligula: use rustPlatform.bindgenHook ``                                                |
| [`c56b3749`](https://github.com/NixOS/nixpkgs/commit/c56b3749469d9e3de67307ab048c358b2de99d59) | `` libkrun: use rustPlatform.bindgenHook ``                                                 |
| [`b2078231`](https://github.com/NixOS/nixpkgs/commit/b20782310e89b55f4b11e2471b261fe7df64fdc0) | `` neothesia: use rustPlatform.bindgenHook ``                                               |
| [`0ff027e0`](https://github.com/NixOS/nixpkgs/commit/0ff027e0aebfc60db4a984dc7f2d2e760906d74d) | `` nufmt: use rustPlatform.bindgenHook ``                                                   |
| [`b5dea63a`](https://github.com/NixOS/nixpkgs/commit/b5dea63a56c863803e63fe6d10f33b170d368cd2) | `` apacheHttpd: remove support for mod_tls ``                                               |
| [`01ccbb3e`](https://github.com/NixOS/nixpkgs/commit/01ccbb3e07356ce324ada4a6af479ad96fa19e88) | `` rustls-ffi: 0.13.0 -> 0.14.1 ``                                                          |
| [`f3739b3e`](https://github.com/NixOS/nixpkgs/commit/f3739b3e231873d76a26b28f98d7a6206f6d427c) | `` opentabletdriver: remove `with lib` from meta, remove meta.description from desktop ``   |
| [`49f647ab`](https://github.com/NixOS/nixpkgs/commit/49f647ab8a1d21e3b13624281d19a6e7e3007af5) | `` opentabletdriver: fix updateScript ``                                                    |
| [`7064bc9d`](https://github.com/NixOS/nixpkgs/commit/7064bc9d991468a04935dc153fd2b3b613f1fd4b) | `` python312Packages.dbt-snowflake: 1.8.3 -> 1.8.4 ``                                       |
| [`67f3c2a2`](https://github.com/NixOS/nixpkgs/commit/67f3c2a29f5ba933882d485b97c73c96fed1ee45) | `` nchat: 5.2.11 -> 5.3.5 ``                                                                |
| [`cb923be9`](https://github.com/NixOS/nixpkgs/commit/cb923be9782f61c41f85441910f12d5e102ad182) | `` mqtt-randompub: 0.2.2 -> 0.3.0 ``                                                        |
| [`511b0843`](https://github.com/NixOS/nixpkgs/commit/511b0843c746d6aea287e16d6e2c6bd35e592998) | `` postgresqlPackages.pg-gvm: move from top-level package ``                                |
| [`d2593f01`](https://github.com/NixOS/nixpkgs/commit/d2593f01e1bf57aaf0235aec1d0ce6503a287a14) | `` runInLinuxVM: pass .attrs.sh explicitly instead of whole /build directory ``             |
| [`99c3d04c`](https://github.com/NixOS/nixpkgs/commit/99c3d04cf22966b42f90a9ae8c677988c6392723) | `` python312Packages.aiovlc: 0.6.2 -> 0.6.3 ``                                              |
| [`cd45cfe9`](https://github.com/NixOS/nixpkgs/commit/cd45cfe9c49e3ce260547b7e15c4afe44ef3226a) | `` nixosTests.vscodium: Workaround OCR tests ``                                             |
| [`58570e75`](https://github.com/NixOS/nixpkgs/commit/58570e75d9bddede2a854b0f7cb8df7f1818c541) | `` runInLinuxVM: refactor vmRunCommand ``                                                   |
| [`437e6dbb`](https://github.com/NixOS/nixpkgs/commit/437e6dbbb0f2cd8ec03da52fc2a0da0114e7c0b3) | `` runInLinuxVM: load stdenv/setup with fixed environment in stage2Init ``                  |
| [`9f6b99e1`](https://github.com/NixOS/nixpkgs/commit/9f6b99e1ef93bef085eedf961f8a5667160454e6) | `` runInLinuxVM: minimize saved-env ``                                                      |
| [`3952f870`](https://github.com/NixOS/nixpkgs/commit/3952f870fc7b7401aa06732b754c84cb94bacb61) | `` runInLinuxVM: clean up ``                                                                |
| [`0633f26e`](https://github.com/NixOS/nixpkgs/commit/0633f26e7b10c33a23e877be090375f409fd7eb0) | `` python312Packages.fastcore: 1.7.20 -> 1.7.22 ``                                          |
| [`56597456`](https://github.com/NixOS/nixpkgs/commit/56597456e194fde80d8100a5b2af5504d79fa4b7) | `` python312Packages.herepy: 3.6.4 -> 3.6.5 ``                                              |
| [`a68512db`](https://github.com/NixOS/nixpkgs/commit/a68512db54c292664bbc4a874add68002934e94c) | `` lact: mention NVIDIA ``                                                                  |
| [`0f26801e`](https://github.com/NixOS/nixpkgs/commit/0f26801e4f753c576dedfc3764a51a6a9883c98f) | `` opentabletdriver: 0.6.4.0 -> 0.6.4.0-unstable-2024-11-25 ``                              |
| [`f122659b`](https://github.com/NixOS/nixpkgs/commit/f122659b692d379e9b1c70f6e67f1b4b8b811fb1) | `` python312Packages.databricks-sdk: 0.35.0 -> 0.38.0 ``                                    |
| [`de7867c2`](https://github.com/NixOS/nixpkgs/commit/de7867c2262968f54c74a22b89e9ee0a19f3c83a) | `` runInLinuxVM: add simple structuredAttrs test ``                                         |
| [`73710fe7`](https://github.com/NixOS/nixpkgs/commit/73710fe751768edda8f5736bfb97aa8766574c4c) | `` linux_latest-libre: 19663 -> 19675 (#359464) ``                                          |
| [`dec1fc5f`](https://github.com/NixOS/nixpkgs/commit/dec1fc5f856435c85426a0d5625484d9c7ac17fb) | `` opentabletdriver: replace sed with substituteInPlace ``                                  |
| [`292bf381`](https://github.com/NixOS/nixpkgs/commit/292bf38106c2501885dd835102779dbb45bb7787) | `` opentabletdriver: format with nixfmt-rfc-style ``                                        |
| [`ad6e3db7`](https://github.com/NixOS/nixpkgs/commit/ad6e3db7c445fbe2c51fe2f0700ccabb1fc03d39) | `` opentabletdriver: move to pkgs/by-name ``                                                |
| [`ffdc0742`](https://github.com/NixOS/nixpkgs/commit/ffdc0742421f22be5e055a77118427793b4eb541) | `` linuxKernel.packages.linux_6_12.evdi: add support for kernel >= 6.12 ``                  |
| [`c18529fe`](https://github.com/NixOS/nixpkgs/commit/c18529fe1658a9891e38b0e248fa6c91d39dc25a) | `` python312Packages.kbcstorage: 0.9.1 -> 0.9.2 ``                                          |
| [`136c3ef4`](https://github.com/NixOS/nixpkgs/commit/136c3ef4a8ee22c28f93d2e14df073f61d574825) | `` apt: 2.9.8 -> 2.9.16 ``                                                                  |
| [`77a34c14`](https://github.com/NixOS/nixpkgs/commit/77a34c1488ed153aac1f89ea9bf4777fc8ae34d0) | `` ntirpc: 6.0.1 -> 6.3 ``                                                                  |
| [`f3bb835a`](https://github.com/NixOS/nixpkgs/commit/f3bb835a462a04cc9a0e90bbe2820c5797f2338f) | `` gapless: 4.0 -> 4.2 ``                                                                   |
| [`e3079539`](https://github.com/NixOS/nixpkgs/commit/e307953903351b05fe2d09cf2df89c7ee973c763) | `` rfc: 1.0.0 -> 1.0.1 ``                                                                   |
| [`1f506d83`](https://github.com/NixOS/nixpkgs/commit/1f506d83a5634f205cb7610e523d852a7914271a) | `` python312Packages.moderngl-window: 2.4.6 -> 3.0.0 ``                                     |
| [`0dd1c943`](https://github.com/NixOS/nixpkgs/commit/0dd1c943d7036bf915341148000a342f67eeccc8) | `` jwx: 2.1.1 -> 2.1.3 ``                                                                   |
| [`617a7655`](https://github.com/NixOS/nixpkgs/commit/617a7655c23cd92e26be7a0d73052059234951e6) | `` python312Packages.pystac-client: 0.8.4 -> 0.8.5 ``                                       |
| [`8a667a52`](https://github.com/NixOS/nixpkgs/commit/8a667a5213f1214b5433cc2c97b5f7fd0f871198) | `` buildFHSEnv: fix cross compilation ``                                                    |
| [`425683af`](https://github.com/NixOS/nixpkgs/commit/425683af2dc279e3eac57a0c1b6abfc77e1ab10a) | `` kubecfg: 0.35.0 -> 0.35.1 ``                                                             |
| [`397b693e`](https://github.com/NixOS/nixpkgs/commit/397b693e76632e8909d5b8c05cf626b9fe576dbf) | `` magic-wormhole-rs: 0.7.3 -> 0.7.4 ``                                                     |
| [`fb35df9f`](https://github.com/NixOS/nixpkgs/commit/fb35df9f914adc2f86c4d109f5a10e82118c6a1f) | `` julia.withPackages: expose pname/version and move things to passthru ``                  |
| [`395d59f5`](https://github.com/NixOS/nixpkgs/commit/395d59f54be1e1de061c99ea653b0e512380040a) | `` qgis-ltr: 3.34.11 -> 3.34.13 ``                                                          |
| [`9fc2250e`](https://github.com/NixOS/nixpkgs/commit/9fc2250e80ee0308d66c252bcdbc1e206b1333c8) | `` qgis-ltr: build with same pyqt version as qgis ``                                        |
| [`c989da75`](https://github.com/NixOS/nixpkgs/commit/c989da7576d55b98a70ea144bb49db60df34e2e1) | `` qgis: 3.38.3 -> 3.40.1 ``                                                                |
| [`64d83722`](https://github.com/NixOS/nixpkgs/commit/64d83722982f7726413be91706bb58bfd46ece2f) | `` python312Packages.latexrestricted: 0.6.0 -> 0.6.2 ``                                     |
| [`9cb83c2a`](https://github.com/NixOS/nixpkgs/commit/9cb83c2af476ce726adb16d8da9b589896976962) | `` nixos/tests/networking: fix GRE test ``                                                  |
| [`923e2e59`](https://github.com/NixOS/nixpkgs/commit/923e2e59ccdadfc476063689980c074fe2173f86) | `` redlib: 0.35.1-unstable-2024-11-01 -> 0.35.1-unstable-2024-11-27 ``                      |
| [`be214b4f`](https://github.com/NixOS/nixpkgs/commit/be214b4f0ef99927fc2b7fdb73ac5e3aed22f1bb) | `` mlx42: 2.4.0 -> 2.4.1 ``                                                                 |
| [`b0822b5d`](https://github.com/NixOS/nixpkgs/commit/b0822b5dcb21443b04cfecca9a6e8592a8894433) | `` tbls: 1.78.0 -> 1.79.4 ``                                                                |
| [`866939c5`](https://github.com/NixOS/nixpkgs/commit/866939c5b21cd78d400a19a63e43c8aa2f4198e5) | `` python312Packages.pyoverkiz: 1.15.0 -> 1.15.1 ``                                         |
| [`18cf9ad1`](https://github.com/NixOS/nixpkgs/commit/18cf9ad14b9592f1b8e07ee4e115a32cdfad76a9) | `` nixos/networkd: fix eval ``                                                              |
| [`8819a28d`](https://github.com/NixOS/nixpkgs/commit/8819a28de8d446ed7e05b4c0fd8a1ac267c3b42a) | `` python312Packages.opensearch-py: 2.7.1 -> 2.8.0 ``                                       |
| [`3546de54`](https://github.com/NixOS/nixpkgs/commit/3546de54ee7e00762adc40ae429e3067bfb8c980) | `` pappl: 1.4.7 -> 1.4.8 ``                                                                 |
| [`c494726b`](https://github.com/NixOS/nixpkgs/commit/c494726b98c31f34dafd0571aca743861422d391) | `` incus: fix container tests from image rename ``                                          |
| [`9ab59bb5`](https://github.com/NixOS/nixpkgs/commit/9ab59bb5fb943ad6740f64f5a79eae9642fb8211) | `` incus: format ``                                                                         |
| [`a162fd2c`](https://github.com/NixOS/nixpkgs/commit/a162fd2c8360b80907866dc03c1c8215b3396940) | `` oxipng: 9.1.2 -> 9.1.3 ``                                                                |
| [`5a32f1db`](https://github.com/NixOS/nixpkgs/commit/5a32f1dbafd45086445bc540df14128c78a87009) | `` mxt-app: 1.40 -> 1.41 ``                                                                 |
| [`8f996805`](https://github.com/NixOS/nixpkgs/commit/8f9968055f5731a8cc4440bb5d7a29f9ad65cc58) | `` nufmt: 0-unstable-2024-10-20 -> 0-unstable-2024-11-21 ``                                 |
| [`9ae3dd30`](https://github.com/NixOS/nixpkgs/commit/9ae3dd306933d94af8494cc8dae5414bb4a4d928) | `` microsoft-identity-broker: fix hash mismatch ``                                          |
| [`fe1d8695`](https://github.com/NixOS/nixpkgs/commit/fe1d869538a57c0336fa1052119ae7656d6438d4) | `` microsoft-identity-broker: format ``                                                     |
| [`cf84acca`](https://github.com/NixOS/nixpkgs/commit/cf84acca6b854fef468277a7b845d77924059278) | `` Revert "zen-browser: init at 1.0.1-a.22" ``                                              |
| [`ad356675`](https://github.com/NixOS/nixpkgs/commit/ad356675a803934c0bd3d0bf749b43bde061ac17) | `` nixos-rebuild-ng: don't repeat the keep_going argument ``                                |
| [`6bff67cf`](https://github.com/NixOS/nixpkgs/commit/6bff67cfbb52664816bc1c67e642e1c0c0ca64e5) | `` radicale3: move to aliases ``                                                            |
| [`7e813703`](https://github.com/NixOS/nixpkgs/commit/7e8137033ccb9b55120d6936025f1e35101c247c) | `` radicale2: drop ``                                                                       |
| [`c318085e`](https://github.com/NixOS/nixpkgs/commit/c318085efa8153fa8cb957d3e2ff1c63dd76413f) | `` ci/check-shell: fix `ci/**` path ``                                                      |
| [`3be17711`](https://github.com/NixOS/nixpkgs/commit/3be17711c3ff54763365e04502a7d63b3ee00e9d) | `` grpcui: 1.4.1 -> 1.4.2 ``                                                                |
| [`4d39a7b8`](https://github.com/NixOS/nixpkgs/commit/4d39a7b8e637d6d666e83ab7df01a3e540e3318c) | `` cargo-tarpaulin: 0.31.2 -> 0.31.3 ``                                                     |
| [`ea65e303`](https://github.com/NixOS/nixpkgs/commit/ea65e3038a72e0fc5700c40e45ae4b8642401c59) | `` workflows/eval: Clear unnecessary rebuild labels ``                                      |
| [`f9626364`](https://github.com/NixOS/nixpkgs/commit/f962636439680f403ef87dbcb1fb5bca8a3443be) | `` mpvScripts.mpv-image-viewer.equalizer: 0-unstable-2023-03-03 -> 0-unstable-2024-11-23 `` |
| [`6394be51`](https://github.com/NixOS/nixpkgs/commit/6394be51d20ab357bad94de01160d4a6341bcc8c) | `` maintainers: remove stnley ``                                                            |
| [`b3e8e251`](https://github.com/NixOS/nixpkgs/commit/b3e8e251f3087eaa971a087f9948bbf21ae3d14d) | `` workflows/eval: Make sure to compare against the push run ``                             |
| [`5196f6a8`](https://github.com/NixOS/nixpkgs/commit/5196f6a891ce4a3550b8685f1d3625f1caeb17d9) | `` vencord: 1.10.7 -> 1.10.8 ``                                                             |
| [`a4242293`](https://github.com/NixOS/nixpkgs/commit/a4242293ee02b75bcf0e1fc3918586d3d09d3ec5) | `` svd2rust: 0.33.5 -> 0.35.0 ``                                                            |
| [`8c4cc0b2`](https://github.com/NixOS/nixpkgs/commit/8c4cc0b2c1048d8651f1548758ee3b1f257dc698) | `` terraform-backend-git: 0.1.7 -> 0.1.8 ``                                                 |
| [`bcc5c141`](https://github.com/NixOS/nixpkgs/commit/bcc5c141bf43460909b83740e96ceeea6d0f7e12) | `` terraform-providers.vinyldns: init at 0.10.3 ``                                          |
| [`ef688ab1`](https://github.com/NixOS/nixpkgs/commit/ef688ab1caaf90e1bb05188de99a058edce1520e) | `` typstyle: 0.12.4 -> 0.12.5 ``                                                            |
| [`50d277f9`](https://github.com/NixOS/nixpkgs/commit/50d277f9e774121ce7309d2c5a51618b5e5a6c42) | `` kube-bench: 0.9.0 -> 0.9.2 ``                                                            |
| [`02e1f93c`](https://github.com/NixOS/nixpkgs/commit/02e1f93cb4e713fd56f27445be69b6a6cf12860d) | `` nixos/version: add extraOSReleaseArgs and extraLSBReleaseArgs ``                         |
| [`b4d7b9ad`](https://github.com/NixOS/nixpkgs/commit/b4d7b9ade25a49c1a2e77e94b7076ce848b61879) | `` nixos/version: use 24-bit ANSI colour code ``                                            |
| [`9ba5483e`](https://github.com/NixOS/nixpkgs/commit/9ba5483ef3060e59f672e1f758981eb11592de26) | `` webdav: 5.4.3 -> 5.4.4 ``                                                                |
| [`cb016f11`](https://github.com/NixOS/nixpkgs/commit/cb016f116bf8134bb2095cdec67cf37eae747a04) | `` ci/check-shell: only run if `shell.nix` or `./ci/**` is changed ``                       |
| [`ba5a5fac`](https://github.com/NixOS/nixpkgs/commit/ba5a5fac7bb68edfb1de329ca037ebe0d4094560) | `` flattenReferencesGraph: fix use of lib.fileset ``                                        |
| [`64de6c47`](https://github.com/NixOS/nixpkgs/commit/64de6c47ca242f3dc0b2608a28e66ba76678edf4) | `` rl-2411: `lib` release notes ``                                                          |