### PR TITLE
chore(flake/git-hooks): `3308484d` -> `6f4e2a21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732021966,
-        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
+        "lastModified": 1733318908,
+        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`f8333004`](https://github.com/cachix/git-hooks.nix/commit/f83330040d0530f1ddbbc1b0b1a1c707bd85a2de) | `` feat: make git package configurable and default to gitMinimal `` |