### PR TITLE
chore(flake/nixvim): `78bfbf7b` -> `277dbeb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733220378,
-        "narHash": "sha256-tWCskBne7LigfeXRWnUFJKKTLOYmmdqiwdqom2Sml1s=",
+        "lastModified": 1733355056,
+        "narHash": "sha256-EOldkOLdgUVIa8ZJiHkqjD6yaW+AZiZwd94aBqfZERY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "78bfbf7b7eb7a1b6cf42e199547de55a55ba2cea",
+        "rev": "277dbeb607210f6a6db656ac7eee9eef3143070c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`277dbeb6`](https://github.com/nix-community/nixvim/commit/277dbeb607210f6a6db656ac7eee9eef3143070c) | `` plugins/codecompanion: init ``       |
| [`d4ae1e36`](https://github.com/nix-community/nixvim/commit/d4ae1e362fa2deed663952e31c73f4d85fef6070) | `` plugins/trouble: fix originalName `` |