### PR TITLE
chore(flake/nixvim): `277dbeb6` -> `6348336d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733355056,
-        "narHash": "sha256-EOldkOLdgUVIa8ZJiHkqjD6yaW+AZiZwd94aBqfZERY=",
+        "lastModified": 1733431684,
+        "narHash": "sha256-Tbdi0SEOuxABTDp0sCI7wdTnmpcnQOPzPo4jSWP0u+8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "277dbeb607210f6a6db656ac7eee9eef3143070c",
+        "rev": "6348336db0e0b17ab6d9c73bc8206db84ebf00d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`6348336d`](https://github.com/nix-community/nixvim/commit/6348336db0e0b17ab6d9c73bc8206db84ebf00d1) | `` modules/lazyload: init w/ assertion ``     |
| [`38885227`](https://github.com/nix-community/nixvim/commit/38885227461de58a712362c1c484803d6c90a8b2) | `` plugins/avante: add missing description `` |