### PR TITLE
chore(flake/nixvim): `6348336d` -> `ae78face`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733431684,
-        "narHash": "sha256-Tbdi0SEOuxABTDp0sCI7wdTnmpcnQOPzPo4jSWP0u+8=",
+        "lastModified": 1733498727,
+        "narHash": "sha256-R+n4JfXjGrJG2gbhJPsZPTwdDsHoJvwxxpWcRY4KjyQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6348336db0e0b17ab6d9c73bc8206db84ebf00d1",
+        "rev": "ae78face8d6a09abe2504d41c035b6460c15a17b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`ae78face`](https://github.com/nix-community/nixvim/commit/ae78face8d6a09abe2504d41c035b6460c15a17b) | `` treewide: format with latest nixfmt ``   |
| [`c6080c20`](https://github.com/nix-community/nixvim/commit/c6080c206e994b65b69940d456d503f12f8b7b44) | `` plugins/copilot-chat: update mappings `` |
| [`bca825e5`](https://github.com/nix-community/nixvim/commit/bca825e5184a2d9d9c74f0c97a372532b86f0b37) | `` plugins/none-ls: update packages ``      |
| [`c6e8f4dd`](https://github.com/nix-community/nixvim/commit/c6e8f4dd5268e0384fe23ba87a4b40612cf19d29) | `` generated: Update ``                     |
| [`4502cf3c`](https://github.com/nix-community/nixvim/commit/4502cf3c0b333690734b7f415daa213893f56969) | `` flake.lock: Update ``                    |