### PR TITLE
chore(flake/nixvim): `08be2027` -> `4b5364a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733574898,
-        "narHash": "sha256-8Meoqfk61EsMB3x/HQcttkgJqUm45kjtOyQGrtHP/H4=",
+        "lastModified": 1733682617,
+        "narHash": "sha256-8wGQwnWAfPXN1aiGswfofJK0oGZeI2YBSNe4vdW/rGA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "08be20270d62e31f215f4592867d53576af15001",
+        "rev": "4b5364a66bffd22536e358214b37068b34287a7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`4b5364a6`](https://github.com/nix-community/nixvim/commit/4b5364a66bffd22536e358214b37068b34287a7a) | `` plugins/persisted: init ``                     |
| [`e2f81c8e`](https://github.com/nix-community/nixvim/commit/e2f81c8e8e8baa28b100e0e43b721f16de6299d8) | `` plugins/schemastore: remove table wrapping ``  |
| [`30f3a324`](https://github.com/nix-community/nixvim/commit/30f3a3242efb223d8c67c6cbd06c19b2a4a289ab) | `` plugins/nvim-colorizer: add missing options `` |