### PR TITLE
chore(flake/nixvim): `4b5364a6` -> `cf7e026c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733682617,
-        "narHash": "sha256-8wGQwnWAfPXN1aiGswfofJK0oGZeI2YBSNe4vdW/rGA=",
+        "lastModified": 1733780592,
+        "narHash": "sha256-SCEjUwyt6R2+36BS7xQG+rHUrhE8HDpmRwQzKHJkimQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4b5364a66bffd22536e358214b37068b34287a7a",
+        "rev": "cf7e026c8c86c5548d270e20c04f456939591219",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`cf7e026c`](https://github.com/nix-community/nixvim/commit/cf7e026c8c86c5548d270e20c04f456939591219) | `` mkNeovimPlugin: refactor lua code generation logic ``  |
| [`f2a991ae`](https://github.com/nix-community/nixvim/commit/f2a991ae8ca430146f529357dad47d45d3548a3a) | `` plugins/colorizer: rename, switch to mkNeovimPlugin `` |