### PR TITLE
chore(flake/nixvim): `cf7e026c` -> `b7526066`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733780592,
-        "narHash": "sha256-SCEjUwyt6R2+36BS7xQG+rHUrhE8HDpmRwQzKHJkimQ=",
+        "lastModified": 1733847310,
+        "narHash": "sha256-VHzWuZYK/m5OFXzAczrjnI7vH6knj0sfLnziRVDqgFE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "cf7e026c8c86c5548d270e20c04f456939591219",
+        "rev": "b752606681ded3f69e99ed568c7075b3578dce48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`b7526066`](https://github.com/nix-community/nixvim/commit/b752606681ded3f69e99ed568c7075b3578dce48) | `` tests/lazyloading/lz-n: runNvim false ``                     |
| [`26f1daa4`](https://github.com/nix-community/nixvim/commit/26f1daa47e0ca89ebea09efe1d6db99fada04caf) | `` tests/lazyloading/lz-n: reduce repetition ``                 |
| [`76b567b4`](https://github.com/nix-community/nixvim/commit/76b567b43c9d1587f25884d745d08f5034b2c541) | `` modules/lazyload: warn enabling a lazy loading provider ``   |
| [`0997b371`](https://github.com/nix-community/nixvim/commit/0997b371c784e9f623c8666ec006e8970ed76166) | `` lib/neovim-plugin: freeform lazy settings ``                 |
| [`d24dd313`](https://github.com/nix-community/nixvim/commit/d24dd313cfb5212aaec9e8cb15c273d869bf6e4b) | `` tests/lazyloading: lazy-load -> lz-n ``                      |
| [`277b2658`](https://github.com/nix-community/nixvim/commit/277b2658a9e7ab82f948be8f7b73aee1d9f0a4c0) | `` plugins/typescript-tools: todo about lazy loading ``         |
| [`c3f9cb72`](https://github.com/nix-community/nixvim/commit/c3f9cb721c7d920c281139b90254732870679401) | `` lib/neovim-plugin: refactor mkLazyLoadOption ``              |
| [`3cfde155`](https://github.com/nix-community/nixvim/commit/3cfde1554c3aff3a3652a2779fec0170cf3c6f34) | `` lib/neovim-plugin: support lz-n lazy config ``               |
| [`da30527d`](https://github.com/nix-community/nixvim/commit/da30527de18ea14971d176e81eb4e39037035838) | `` lib/neovim-plugin: use mkLazyLoadOption ``                   |
| [`6ed719db`](https://github.com/nix-community/nixvim/commit/6ed719dba8a5ed821ae525311669e7195422cf6f) | `` lib/options: added mkLazyLoadOption ``                       |
| [`301868d3`](https://github.com/nix-community/nixvim/commit/301868d380d267a313a4a7aa6344e03ab8f16074) | `` lib/neovim-plugin: support lazy loading luaConfig.content `` |
| [`2e30f482`](https://github.com/nix-community/nixvim/commit/2e30f4828d2f0c669a3f28a4a32148d02b7a92b4) | `` plugins/cmp/sources: add cmp-vimtex ``                       |
| [`39adaa0b`](https://github.com/nix-community/nixvim/commit/39adaa0b7af4c7a1ea97bfce985787c656cac551) | `` plugins/cmp/sources: sort list ``                            |
| [`8dfa5fa8`](https://github.com/nix-community/nixvim/commit/8dfa5fa8a204f0dc14654c07619bb3df132099e0) | `` flake-modules/dev: cosmetic refactor ``                      |
| [`99cb3fb8`](https://github.com/nix-community/nixvim/commit/99cb3fb8fc7fc073d695e7c029d9c93e95e2520c) | `` plugins/dotnet: init ``                                      |