### PR TITLE
chore(flake/nixpkgs): `22c3f2cf` -> `a73246e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733581040,
-        "narHash": "sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY=",
+        "lastModified": 1733759999,
+        "narHash": "sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "22c3f2cf41a0e70184334a958e6b124fb0ce3e01",
+        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
| [`1d6a2c28`](https://github.com/NixOS/nixpkgs/commit/1d6a2c28a49865a1b81199eb44c06e70668297ea) | `` lib.types: add release notes ``                                                                     |
| [`2341e4fb`](https://github.com/NixOS/nixpkgs/commit/2341e4fb60dea97840bcbd7d112774672915bc9f) | `` vimPlugins.nvim-lspconfig: 2024-12-02 -> 2024-12-08 ``                                              |
| [`d504a1e6`](https://github.com/NixOS/nixpkgs/commit/d504a1e68085dbe27bd32978130ff9006af8067f) | `` lib.types.attrsWith: add placeholder parameter ``                                                   |
| [`1008102c`](https://github.com/NixOS/nixpkgs/commit/1008102caf6fc3aa7e9219c16a38209a5afa97f8) | `` super-slicer: fix build with GCC 14 (#362194) ``                                                    |
| [`1b52efe8`](https://github.com/NixOS/nixpkgs/commit/1b52efe8c2f1f106d4224fbc9f4cca8ed36f52a2) | `` nix-prefetch-scripts: add bash to inputs ``                                                         |
| [`5720f42c`](https://github.com/NixOS/nixpkgs/commit/5720f42c329d990dd7c7b6012ab163af6ce6409f) | `` nix-prefetch-docker: provide `hash` in SRI format ``                                                |
| [`d0e6b0e1`](https://github.com/NixOS/nixpkgs/commit/d0e6b0e170391f072f0b2b45b536e48edaa387fb) | `` dockerTools.pullImage: accept `hash` parameter ``                                                   |
| [`e81df5bb`](https://github.com/NixOS/nixpkgs/commit/e81df5bb2d85efff392c8d2aca5aa77019bb8865) | `` terraform-providers.auth0: 1.7.3 -> 1.8.0 ``                                                        |
| [`f407f6f5`](https://github.com/NixOS/nixpkgs/commit/f407f6f57ec12cfe1c5bf2de531cd8c3d601332d) | `` lib.types: chore use consistent payload form ``                                                     |
| [`d304322e`](https://github.com/NixOS/nixpkgs/commit/d304322e373503e3ae2ee6da55fce0f2098d5a0d) | `` android-studio: 2024.2.1.9 -> 2024.2.1.12 ``                                                        |
| [`1a9dbc6e`](https://github.com/NixOS/nixpkgs/commit/1a9dbc6e2fa9c671d26299cc382e25ac2a29578b) | `` terraform-providers.vault: 4.4.0 -> 4.5.0 ``                                                        |
| [`bfa12bde`](https://github.com/NixOS/nixpkgs/commit/bfa12bdee5b5f58724c4477299ac87865fa033ab) | `` snac2: 2.63 -> 2.65 ``                                                                              |
| [`504c7ce2`](https://github.com/NixOS/nixpkgs/commit/504c7ce21239280cba64797d1ae14f12b23131d5) | `` terraform-providers.launchdarkly: 2.21.0 -> 2.21.2 ``                                               |
| [`7961132c`](https://github.com/NixOS/nixpkgs/commit/7961132c80eb7dc2f7d6fb50de81bd36827bb13d) | `` terraform-providers.ovh: 1.0.0 -> 1.1.0 ``                                                          |
| [`5c26d676`](https://github.com/NixOS/nixpkgs/commit/5c26d67667b7a80aa7eef602a8cd650beb55caff) | `` python3Packages.python-apt: 2.8.0 -> 2.9.2 ``                                                       |
| [`66bd38db`](https://github.com/NixOS/nixpkgs/commit/66bd38db4d0734aaee60417c805f3a2c72fdcbfc) | `` llama-cpp: 4154 -> 4293 ``                                                                          |
| [`ff6fe6ec`](https://github.com/NixOS/nixpkgs/commit/ff6fe6ec6d0214c4ffe5fe511e1926da6b1ce55b) | `` dooit: 3.0.4 -> 3.1.0 ``                                                                            |
| [`cc094113`](https://github.com/NixOS/nixpkgs/commit/cc0941133bb27566c97a53032bc5803bc2fac6c8) | `` tippecanoe: 2.70.0 -> 2.72.0 ``                                                                     |
| [`e876e2ff`](https://github.com/NixOS/nixpkgs/commit/e876e2ff03ac48b3d3abb45e2a4ca3a9bf631809) | `` typos: 1.28.1 -> 1.28.2 ``                                                                          |
| [`7996ffc5`](https://github.com/NixOS/nixpkgs/commit/7996ffc5cf0c790480ae0ae6f69ac18c8a2a324f) | `` git-workspace: remove passthru.tests.version ``                                                     |
| [`a3cb2042`](https://github.com/NixOS/nixpkgs/commit/a3cb20422a21ab2c17b3e783aaa0da554285f476) | `` python312Packages.bidsschematools: 0.11.3.post3 -> 1.0.0 (#363258) ``                               |
| [`98ebb7e0`](https://github.com/NixOS/nixpkgs/commit/98ebb7e0b2b598196f83c355292b9db4e801bd99) | `` janet: 1.36.0 -> 1.37.1 ``                                                                          |
| [`463f9342`](https://github.com/NixOS/nixpkgs/commit/463f9342eb6bc887d4b2991655a4b0404d65120f) | `` yq-go: 4.44.5 -> 4.44.6 ``                                                                          |
| [`d163a0ea`](https://github.com/NixOS/nixpkgs/commit/d163a0ea76f7fecd3f72b3746487823d61d208dc) | `` cedar: init at 4.2.2 (#360328) ``                                                                   |
| [`67004e9b`](https://github.com/NixOS/nixpkgs/commit/67004e9b81d111d7c31bc634d7932e130aad26f0) | `` python312Packages.execnb: 0.1.8 -> 0.1.11 ``                                                        |
| [`617f0f1f`](https://github.com/NixOS/nixpkgs/commit/617f0f1ff28b1573cda08ac0f901e22e0213d000) | `` yazi, yazi-unwrapped: 0.3.3 -> 0.4.0 (#363326) ``                                                   |
| [`bd4edc04`](https://github.com/NixOS/nixpkgs/commit/bd4edc04bb1f1076613c6fa99a6faccddc1f8b93) | `` keymapper: 4.9.0 -> 4.9.1 ``                                                                        |
| [`749ef603`](https://github.com/NixOS/nixpkgs/commit/749ef6034057f1612ca5c25c966f39d5df37a7e6) | `` git-workspace: 1.7.0 -> 1.8.0 ``                                                                    |
| [`ed65a899`](https://github.com/NixOS/nixpkgs/commit/ed65a89903db2c520f973028021ee683405bc8a8) | `` obs-studio-plugins.obs-3d-effect: 0.1.1 -> 0.1.2 ``                                                 |
| [`b251e978`](https://github.com/NixOS/nixpkgs/commit/b251e9782380974b7ba32926d72b290106c83abd) | `` minio-client: 2024-10-02T08-27-28Z -> 2024-11-17T19-35-25Z ``                                       |
| [`a8c5dc11`](https://github.com/NixOS/nixpkgs/commit/a8c5dc11d9823cec286cf37b7c54020fdca2dcc0) | `` box86: 0.3.6 -> 0.3.8 ``                                                                            |
| [`889fb165`](https://github.com/NixOS/nixpkgs/commit/889fb165d6f4e598bc939bf632744afe4379956a) | `` libvirt: 10.9.0 -> 10.10.0 ``                                                                       |
| [`9451bb51`](https://github.com/NixOS/nixpkgs/commit/9451bb51c25b61fe8955189178b93a2e0e62e0a9) | `` nixos/zapret: remove maintainer ``                                                                  |
| [`16d0a9cb`](https://github.com/NixOS/nixpkgs/commit/16d0a9cbd1e671539e20a6377a257e40f2c9f0d1) | `` kubectl-explore: 0.10.0 -> 0.11.0 ``                                                                |
| [`943626e7`](https://github.com/NixOS/nixpkgs/commit/943626e75a75b1e53cd99140467d99e84c952b1b) | `` terraform-providers.mailgun: 0.7.6 -> 0.7.7 ``                                                      |
| [`c72d33fe`](https://github.com/NixOS/nixpkgs/commit/c72d33fea7289c25618d6b367ceb8e0835463a30) | `` python312Packages.fastcore: 1.7.23 -> 1.7.25 ``                                                     |
| [`2e98ec0e`](https://github.com/NixOS/nixpkgs/commit/2e98ec0e0eb30615a75242233b3ba1d92cd20631) | `` nixos/networking-interfaces-scripted: use read -r ``                                                |
| [`2b73f72f`](https://github.com/NixOS/nixpkgs/commit/2b73f72f4a89569eb2f973d37a7e0e5b4fe30c97) | `` python312Packages.pymc: 5.18.2 -> 5.19.1 ``                                                         |
| [`b644a1b9`](https://github.com/NixOS/nixpkgs/commit/b644a1b90a3867383fe2cef8f184508a7cc64644) | `` cargo-deny: 0.16.2 -> 0.16.3 ``                                                                     |
| [`753dacd7`](https://github.com/NixOS/nixpkgs/commit/753dacd78399042dbe031f2796fd85173fa3a92e) | `` snpguest: 0.7.1 -> 0.8.0 ``                                                                         |
| [`9e866bbd`](https://github.com/NixOS/nixpkgs/commit/9e866bbdbf438379f537b1b0395cbde482337412) | `` terraform-providers.linode: 2.29.1 -> 2.31.1 ``                                                     |
| [`9e32ef89`](https://github.com/NixOS/nixpkgs/commit/9e32ef890f47671a5d6d0bc492f23af5166417b8) | `` terraform-providers.bitwarden: 0.12.0 -> 0.12.1 ``                                                  |
| [`fdc1fed9`](https://github.com/NixOS/nixpkgs/commit/fdc1fed984d5057381740d96372393199d9741c9) | `` terraform-providers.newrelic: 3.52.1 -> 3.53.0 ``                                                   |
| [`c05f640e`](https://github.com/NixOS/nixpkgs/commit/c05f640eac9d0fd58b993d909333e27d37a278a0) | `` terraform-providers.temporalcloud: 0.0.14 -> 0.0.15 ``                                              |
| [`ab45bc5c`](https://github.com/NixOS/nixpkgs/commit/ab45bc5c01732c45eaf9a0788036c0c836e2001c) | `` toot: 0.47.0 -> 0.47.1 ``                                                                           |
| [`73b7d880`](https://github.com/NixOS/nixpkgs/commit/73b7d880f14c87a54ad49f25cf41c218163b1c68) | `` prometheus-cpp: 1.1.0 -> 1.3.0 ``                                                                   |
| [`4e3ef907`](https://github.com/NixOS/nixpkgs/commit/4e3ef907e4636cfc3e183b1937fb1647cd7c36a1) | `` nixpacks: 1.29.1 -> 1.30.0 ``                                                                       |
| [`0f9c9444`](https://github.com/NixOS/nixpkgs/commit/0f9c9444be62f29227d2d284ac5efe029408b245) | `` quark-engine: 24.11.1 -> 24.12.1 ``                                                                 |
| [`12561754`](https://github.com/NixOS/nixpkgs/commit/125617542b23e8b7882e6ba65f34e55c717d98bf) | `` smbclient-ng: 2.1.6 -> 2.1.7 ``                                                                     |
| [`2ee01474`](https://github.com/NixOS/nixpkgs/commit/2ee01474dac2a13944c1b66d55f41292bba54389) | `` ngtcp2-gnutls: 1.8.0 -> 1.9.1 ``                                                                    |
| [`a3b773a4`](https://github.com/NixOS/nixpkgs/commit/a3b773a440f6e776a65347fa8cb55a4223a355be) | `` hyprlauncher: 0.2.7 -> 0.2.8 ``                                                                     |
| [`4e97bcd8`](https://github.com/NixOS/nixpkgs/commit/4e97bcd8d3128405505d81376794fb20492df088) | `` maa-assistant-arknights: 5.9.0 -> 5.10.2 ``                                                         |
| [`db46aae5`](https://github.com/NixOS/nixpkgs/commit/db46aae5a194e106d9224b21dfd14fbcdd8b7199) | `` python312Packages.craft-application: 4.4.0 -> 4.5.0 ``                                              |
| [`0ef44a48`](https://github.com/NixOS/nixpkgs/commit/0ef44a488f3d9e14a4335260ae1b834365133bb8) | `` oversteer: 0.8.1 -> 0.8.3 (#362937) ``                                                              |
| [`239a55c5`](https://github.com/NixOS/nixpkgs/commit/239a55c50ac48b22175722b62a7f79e211cf5fd3) | `` wasmer: 5.0.2 -> 5.0.3 (#362987) ``                                                                 |
| [`363c2503`](https://github.com/NixOS/nixpkgs/commit/363c25038f6adba791e88f9d3f319c7ab5db5689) | `` docify: 1.0.0 -> 1.1.0 (#363067) ``                                                                 |
| [`7cedac46`](https://github.com/NixOS/nixpkgs/commit/7cedac469e616585f1aca913231b0a303ce02e51) | `` jotdown: 0.6.0 -> 0.7.0 ``                                                                          |
| [`53bd25e9`](https://github.com/NixOS/nixpkgs/commit/53bd25e9e250a57d56ad147f4d8ed404932bfb61) | `` kanboard: init at 1.2.42 (#357229) ``                                                               |
| [`a4762bf3`](https://github.com/NixOS/nixpkgs/commit/a4762bf346e6754e6e57099ac8a3b90323229684) | `` csvlens: 0.10.1 -> 0.11.0 ``                                                                        |
| [`a963fa59`](https://github.com/NixOS/nixpkgs/commit/a963fa59d02641caff49b320e1685eb3ad23d940) | `` butane: 0.22.0 -> 0.23.0 ``                                                                         |
| [`621e924e`](https://github.com/NixOS/nixpkgs/commit/621e924eb3d95342ddd7c4a1e9fc0a78dd670d76) | `` puncia: 0.24 -> 0.25 ``                                                                             |
| [`bdeec57e`](https://github.com/NixOS/nixpkgs/commit/bdeec57ec9b28982db111c8b1c79347301dd1de4) | `` kubeshark: 52.3.89 -> 52.3.91 ``                                                                    |
| [`9aadd04e`](https://github.com/NixOS/nixpkgs/commit/9aadd04e27f7af0f140b85e276aa0167299992c6) | `` python312Packages.rich-click: 1.8.4 -> 1.8.5 ``                                                     |
| [`8dc553b7`](https://github.com/NixOS/nixpkgs/commit/8dc553b70802225ed2ddd1fc896fa43355912142) | `` immich: 1.122.1 -> 1.122.2 ``                                                                       |
| [`6c3cb218`](https://github.com/NixOS/nixpkgs/commit/6c3cb218ab70788ecd8ef54f9c83f1d51f3ac7e0) | `` home-assistant-custom-lovelace-modules.mushroom: 4.2.0 -> 4.2.1 ``                                  |
| [`b4fe70ac`](https://github.com/NixOS/nixpkgs/commit/b4fe70ac92bbc087eb541d31dc94bf7846d3a29a) | `` mystmd: 1.3.17 -> 1.3.18 ``                                                                         |
| [`b6dbf6de`](https://github.com/NixOS/nixpkgs/commit/b6dbf6deed81ee4e2bb75d355ec480f9adb5240a) | `` nixos/filesystems: assert that the device and label options are consistent ``                       |
| [`a1819670`](https://github.com/NixOS/nixpkgs/commit/a181967099dfbc714420c6c78db43d8c39166fed) | `` nodePackages.create-react-native-app: drop (#363374) ``                                             |
| [`f304ede4`](https://github.com/NixOS/nixpkgs/commit/f304ede4f4dc1fcbaa3acded568ec70bb8585f84) | `` terraform-providers.google-beta: 6.9.0 -> 6.12.0 ``                                                 |
| [`ae2356ff`](https://github.com/NixOS/nixpkgs/commit/ae2356ff4553f2fafb19f6e0eac02e36395e39a9) | `` terraform-providers.signalfx: 9.1.6 -> 9.5.0 ``                                                     |
| [`00199954`](https://github.com/NixOS/nixpkgs/commit/0019995430d20a30ba2e6668c8ca3e06eee7034d) | `` terraform-providers.datadog: 3.46.0 -> 3.49.0 ``                                                    |
| [`3231455e`](https://github.com/NixOS/nixpkgs/commit/3231455e5383f51113f2599e3b95d53e745e7467) | `` terraform-providers.opentelekomcloud: 1.36.23 -> 1.36.26 ``                                         |
| [`0f4b6469`](https://github.com/NixOS/nixpkgs/commit/0f4b646923ad8d478c46386620453b2affaab6c7) | `` terraform-providers.migadu: 2024.10.10 -> 2024.11.28 ``                                             |
| [`700d34f0`](https://github.com/NixOS/nixpkgs/commit/700d34f0038d2f55d3b53ad32d065366e133b7cc) | `` terraform-providers.huaweicloud: 1.69.1 -> 1.71.0 ``                                                |
| [`8e10d955`](https://github.com/NixOS/nixpkgs/commit/8e10d955b875f0ad52eaee80a66e259915381913) | `` terraform-providers.sentry: 0.14.0 -> 0.14.1 ``                                                     |
| [`a45fb10b`](https://github.com/NixOS/nixpkgs/commit/a45fb10b4384c851ed6e826f8543b0efb5d45b01) | `` terraform-providers.artifactory: 12.3.1 -> 12.5.1 ``                                                |
| [`28b89ed4`](https://github.com/NixOS/nixpkgs/commit/28b89ed40af4395f7bb2ce447996b58c0c1bd362) | `` terraform-providers.grafana: 3.10.0 -> 3.14.1 ``                                                    |
| [`6e2beb51`](https://github.com/NixOS/nixpkgs/commit/6e2beb51f708dd3a77b434de36fa3fd6c059f7ee) | `` terraform-providers.aiven: 4.28.0 -> 4.30.0 ``                                                      |
| [`25fe86df`](https://github.com/NixOS/nixpkgs/commit/25fe86dff71eb20ecb175b3112b8c86c9367a37a) | `` nodePackages.expo-cli: drop (#361284) ``                                                            |
| [`afc324d9`](https://github.com/NixOS/nixpkgs/commit/afc324d90d98ccf5cb2a36a6f61157ade6b4c328) | `` opentofu: fix passhthru test ``                                                                     |
| [`22a2f067`](https://github.com/NixOS/nixpkgs/commit/22a2f067415f180478b1fc838e2aa8a4227e8bbd) | `` synchrony: init at 2.4.5 (#352833) ``                                                               |
| [`f5e46f66`](https://github.com/NixOS/nixpkgs/commit/f5e46f66856e14906c319851b1c5014cf4cd7086) | `` kubectl-node-shell: 1.10.2 -> 1.11.0 ``                                                             |
| [`78cfe2d7`](https://github.com/NixOS/nixpkgs/commit/78cfe2d72362f5c080901b8bc1a99398c5d531eb) | `` cargo-outdated: 0.15.0 -> 0.16.0 ``                                                                 |
| [`80f9a6b1`](https://github.com/NixOS/nixpkgs/commit/80f9a6b175505bfe25febb9daf7ee74d92b7a89c) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.2.0 -> 4.2.1 (#363351) ``           |
| [`b928ad00`](https://github.com/NixOS/nixpkgs/commit/b928ad0093c9b6c1c2081162653092fc4a73839b) | `` nixos-rebuild-ng: only show the error message if the user forget to use --ask-sudo-password flag `` |
| [`69d9c352`](https://github.com/NixOS/nixpkgs/commit/69d9c3529d13ad7fbc776207356cfc5c0e62128b) | `` nixos-rebuild-ng: fix repl command ``                                                               |
| [`f6a5be36`](https://github.com/NixOS/nixpkgs/commit/f6a5be36f3b040e6ee05352963779d590fd8c011) | `` dart.fvp: use FindMDK.cmake ``                                                                      |
| [`0afd5fbf`](https://github.com/NixOS/nixpkgs/commit/0afd5fbf4018d0ed4ea85a44a1499cf8eb242c12) | `` mdk-sdk: 0.30.0 -> 0.30.1 ``                                                                        |
| [`f968abfc`](https://github.com/NixOS/nixpkgs/commit/f968abfcfa185cfacb7439baa87cf8c446cb571f) | `` mdk-sdk: format ``                                                                                  |
| [`e857cfa8`](https://github.com/NixOS/nixpkgs/commit/e857cfa8a1941680366b9ee9e4d6b67e395f0692) | `` nixos/seafile: fix systemd option capitalization for RandomizedDelaySec (#363324) ``                |
| [`6d8f27f3`](https://github.com/NixOS/nixpkgs/commit/6d8f27f3bb43944070351df0099ffa65f2e59d8f) | `` python312Packages.gftools: 0.9.74 -> 0.9.76 ``                                                      |
| [`c45b460d`](https://github.com/NixOS/nixpkgs/commit/c45b460d606f8ed56555a9fecfc9eae600f52f95) | `` openvpn3: 23 -> 24 ``                                                                               |
| [`339a3006`](https://github.com/NixOS/nixpkgs/commit/339a3006ecd6bee1abc41dbe9aca28151b616794) | `` gdbuspp: 2 -> 3 ``                                                                                  |
| [`61dfad04`](https://github.com/NixOS/nixpkgs/commit/61dfad04c48226d78f00e2c3a12ff32a7423b39c) | `` maintainers: add second key to progrm_jarvis ``                                                     |