### PR TITLE
chore(flake/nixvim): `b7526066` -> `c7b109f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733847310,
-        "narHash": "sha256-VHzWuZYK/m5OFXzAczrjnI7vH6knj0sfLnziRVDqgFE=",
+        "lastModified": 1733953545,
+        "narHash": "sha256-1UsUuIfq0ywIxmYBJdIi6tFFmpR/RtOBQVijARaaX68=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b752606681ded3f69e99ed568c7075b3578dce48",
+        "rev": "c7b109f5af93f8e59148a1a4838f3472f8ae403d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`c7b109f5`](https://github.com/nix-community/nixvim/commit/c7b109f5af93f8e59148a1a4838f3472f8ae403d) | `` plugins/otter: fix treesitter warning ``   |
| [`22063281`](https://github.com/nix-community/nixvim/commit/220632813768aa8bcc49dd95c7312dc287062877) | `` plugins/neotest: fix adapter warning ``    |
| [`c169e6df`](https://github.com/nix-community/nixvim/commit/c169e6df1fb8473e35d2189ff0b2e2d6d5bdb031) | `` plugins/hmts: migrate to mkNeovimPlugin `` |
| [`1040d597`](https://github.com/nix-community/nixvim/commit/1040d597b2b45f77a1a2818c9831c7100d4eb961) | `` plugins/hmts: remove with lib; ``          |
| [`58a1f4a3`](https://github.com/nix-community/nixvim/commit/58a1f4a399dcd0a0dde4c4e791fa9d07cc09bc43) | `` plugins/hmts: fix warning ``               |