### PR TITLE
chore(flake/nixvim): `c7b109f5` -> `6fcf389a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733953545,
-        "narHash": "sha256-1UsUuIfq0ywIxmYBJdIi6tFFmpR/RtOBQVijARaaX68=",
+        "lastModified": 1734046322,
+        "narHash": "sha256-e5THGHwIhK/BwXigHQ93ulUnc4zorjANT4NDGLt9K9Y=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c7b109f5af93f8e59148a1a4838f3472f8ae403d",
+        "rev": "6fcf389a8de53c535e724abd2581a09afd46d5ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`6fcf389a`](https://github.com/nix-community/nixvim/commit/6fcf389a8de53c535e724abd2581a09afd46d5ba) | `` colorschemes/catppuccin: add originalName `` |
| [`2844c316`](https://github.com/nix-community/nixvim/commit/2844c31655e4e710fac1733c8f4456b92d506e8d) | `` plugins/grug-far: init ``                    |
| [`54b1d912`](https://github.com/nix-community/nixvim/commit/54b1d912992e4d3e76dadd98f300b28f083ca7bc) | `` plugins/remote-nvim: init ``                 |