### PR TITLE
chore(flake/nixvim): `6fcf389a` -> `c1810144`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734046322,
-        "narHash": "sha256-e5THGHwIhK/BwXigHQ93ulUnc4zorjANT4NDGLt9K9Y=",
+        "lastModified": 1734103614,
+        "narHash": "sha256-H5JN0fajkKZLir/GN6QHmLsR3cW+/EIOR+W/VmwHKfI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6fcf389a8de53c535e724abd2581a09afd46d5ba",
+        "rev": "c181014422fa9261db06fc9b5ecbf67f42c30ec3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`c1810144`](https://github.com/nix-community/nixvim/commit/c181014422fa9261db06fc9b5ecbf67f42c30ec3) | `` colorschemes/dracula: switch to mkVimPlugin ``          |
| [`2b5a4a38`](https://github.com/nix-community/nixvim/commit/2b5a4a3896219078eabc32cb3fc3556cb59d31e6) | `` plugins/neorg: switch to mkNeovimPlugin ``              |
| [`c0550513`](https://github.com/nix-community/nixvim/commit/c0550513b3277954f2362c54c0d0f1a0da3d161d) | `` plugins/treesitter: extraConfiguLua -> luaConfig ``     |
| [`e60af136`](https://github.com/nix-community/nixvim/commit/e60af13695cbbe2e0013ff26f3b3fa1150518aaa) | `` plugins/lightline: extraConfiguLua -> luaConfig ``      |
| [`455c5bff`](https://github.com/nix-community/nixvim/commit/455c5bff3e551b5bb46778135fc048d5154f2167) | `` plugins/nvim-autopairs: extraConfiguLua -> luaConfig `` |
| [`8012fbd9`](https://github.com/nix-community/nixvim/commit/8012fbd998466dde1a2831173531972e8a284110) | `` plugins/lz-n: move to extraConfigLuaPre ``              |
| [`d99bc6eb`](https://github.com/nix-community/nixvim/commit/d99bc6ebadce99dcb8b294c31fac96329b3bdf2e) | `` plugins/netman: migrate to mkNeovimPlugin ``            |
| [`1d0404ff`](https://github.com/nix-community/nixvim/commit/1d0404ff43a4b64335b224bbe43161cb7ce52bf5) | `` plugins/netman: remove with lib; and helpers ``         |