### PR TITLE
chore(flake/git-hooks): `d8c02f0f` -> `c2b3567b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733665616,
-        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
+        "lastModified": 1734190932,
+        "narHash": "sha256-nIweyhgHbDMJSH6zlciTe2abEzDKWkW28B6/qM9UWOU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
+        "rev": "c2b3567b03baf0999a1dd14f7e7ab34b46297d68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`06d077bf`](https://github.com/cachix/git-hooks.nix/commit/06d077bf86c056451418ac209ec7819f6a2a2cfb) | `` feat(hook order): add before, after options to specify hooks order `` |
| [`ac756a3a`](https://github.com/cachix/git-hooks.nix/commit/ac756a3a8208a18e764f87016a04fc8212dcc275) | `` feat: add priority to hooks. ``                                       |