### PR TITLE
chore(flake/nixvim): `c1810144` -> `c351af10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734103614,
-        "narHash": "sha256-H5JN0fajkKZLir/GN6QHmLsR3cW+/EIOR+W/VmwHKfI=",
+        "lastModified": 1734219356,
+        "narHash": "sha256-1D0Jn/y4rIaUDlqtVS6Cm+48wSHsNgdMUN7+9Q6XraQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c181014422fa9261db06fc9b5ecbf67f42c30ec3",
+        "rev": "c351af103f7a5a4228ab9f31bc1e3646c1987a98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`c351af10`](https://github.com/nix-community/nixvim/commit/c351af103f7a5a4228ab9f31bc1e3646c1987a98) | `` tests/efmls-configs: fix eval error ``                                     |
| [`fd279c89`](https://github.com/nix-community/nixvim/commit/fd279c892d0fe72d1c2e9d2eeb0a5ce732239989) | `` tests/lsp-servers: disable typst_lsp ``                                    |
| [`25a3dc7c`](https://github.com/nix-community/nixvim/commit/25a3dc7cb58af9958e95d867ba91b7f45f8778c3) | `` plugins/efmls-configs: add gleam_format to unpackaged ``                   |
| [`99a2827f`](https://github.com/nix-community/nixvim/commit/99a2827f7ce3c25cc23a84961efed0e06359a517) | `` plugins/lsp: add ltex_plus to unpackaged ``                                |
| [`4463eccb`](https://github.com/nix-community/nixvim/commit/4463eccbd27e6f957a29c4245f5488ae4bd0b609) | `` generated: Update ``                                                       |
| [`b3318925`](https://github.com/nix-community/nixvim/commit/b33189256bbe3d777ca9960fa64cc11e13013a72) | `` flake.lock: Update ``                                                      |
| [`e6018ac1`](https://github.com/nix-community/nixvim/commit/e6018ac19521082a86477da18f35488cd453d60d) | `` plugins/lsp: modernize implem of language-servers ``                       |
| [`57464f22`](https://github.com/nix-community/nixvim/commit/57464f22bb13689856d6db246fa5beaf23611648) | `` config-examples: add NikolayGalkin ``                                      |
| [`94535b24`](https://github.com/nix-community/nixvim/commit/94535b24a2193d7e31cf79efca63bfb001a31e4b) | `` plugins/lsp: fix tinymist implementation and update options ``             |
| [`95361fda`](https://github.com/nix-community/nixvim/commit/95361fda3c020f64f9331aaa09e76c2dcb662ac0) | `` treewide: apply deadnix suggestions ``                                     |
| [`c7a261db`](https://github.com/nix-community/nixvim/commit/c7a261db2ceb9ddf6f8e59c8d82431bf9c73b688) | `` flake-modules/dev: add deadnix ``                                          |
| [`09daa2cb`](https://github.com/nix-community/nixvim/commit/09daa2cb8377de50d1afc1e769edaefd90ae7bc0) | `` plugins/efmls-configs: move from lsp to by-name ``                         |
| [`f13bdfec`](https://github.com/nix-community/nixvim/commit/f13bdfec8f2c5786362a78f555ff3577c2a59591) | `` plugins/TEMPLATE: add moduleName ``                                        |
| [`63c81b17`](https://github.com/nix-community/nixvim/commit/63c81b1778b778c83043980c672f4bd2605b2240) | `` lib/options: mkLazyLoadOption: packPathName -> name ``                     |
| [`c37031d7`](https://github.com/nix-community/nixvim/commit/c37031d71ffc6b4cad88871899cb15a40d2e8016) | `` treewide: luaName -> moduleName ``                                         |
| [`a7012e78`](https://github.com/nix-community/nixvim/commit/a7012e7864bde5c5fceadd466d6aee909d2b682c) | `` treewide: originalName -> packPathName ``                                  |
| [`e8e39655`](https://github.com/nix-community/nixvim/commit/e8e396558b52be4319d93b995da91b16fd9793b7) | `` docs/user-guide: add lazy-loading.md ``                                    |
| [`6a192a86`](https://github.com/nix-community/nixvim/commit/6a192a86045c4f0b7fa345ee8950abab468456c1) | `` lib/neovim-plugin: allow `configLocation` to be wrapped using `mkOrder` `` |