### PR TITLE
chore(flake/git-hooks): `c2b3567b` -> `aa9f40c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734190932,
-        "narHash": "sha256-nIweyhgHbDMJSH6zlciTe2abEzDKWkW28B6/qM9UWOU=",
+        "lastModified": 1734279981,
+        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "c2b3567b03baf0999a1dd14f7e7ab34b46297d68",
+        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`3e7d7910`](https://github.com/cachix/git-hooks.nix/commit/3e7d791061be477b20a9d4e1f57872a51a392a57) | `` bugfix: remove before/after options from config json file ``                        |
| [`2c69d710`](https://github.com/cachix/git-hooks.nix/commit/2c69d710c20b8856e18d01fd4f6d265175167eec) | `` chore: add a default priority to `cabal2nix` which ensures it runs after `hpack` `` |
| [`8a8d2b81`](https://github.com/cachix/git-hooks.nix/commit/8a8d2b81f465bb693c676a285f1ba93b4d3a8931) | `` make sure that clang-tools is in the same version across all platforms ``           |