### PR TITLE
chore(flake/nixvim): `c351af10` -> `ec24d496`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734219356,
-        "narHash": "sha256-1D0Jn/y4rIaUDlqtVS6Cm+48wSHsNgdMUN7+9Q6XraQ=",
+        "lastModified": 1734299751,
+        "narHash": "sha256-PFJ/Wwk57XzmRkU0pJLnz4tJX81ln2OaFeqcOQqp7G0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c351af103f7a5a4228ab9f31bc1e3646c1987a98",
+        "rev": "ec24d496d52c2620b5ce3d237a2a1029a197b412",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`ec24d496`](https://github.com/nix-community/nixvim/commit/ec24d496d52c2620b5ce3d237a2a1029a197b412) | `` treewide (cleaning): helpers.toLuaObject -> lib.nixvim.toLuaObject ``        |
| [`78e295fa`](https://github.com/nix-community/nixvim/commit/78e295fa419801efb56a384e37987c25a618f21f) | `` treewide (cleaning): helpers.vim-plugin -> lib.nixvim.vim-plugin ``          |
| [`e54833d2`](https://github.com/nix-community/nixvim/commit/e54833d2f7378d9759d70a213b647e4515f15145) | `` treewide (cleaning): helpers.neovim-plugin -> lib.nixvim.neovim-plugin ``    |
| [`1e690618`](https://github.com/nix-community/nixvim/commit/1e690618d92234e59a34f41c3a78004b57cab5ab) | `` tests: use our extended lib in tests ``                                      |
| [`ea26af3e`](https://github.com/nix-community/nixvim/commit/ea26af3ee98f6f6c0c4c61534d2174ceb6ade767) | `` dev/list-plugins: cleanup migrated plugins ``                                |
| [`85b99028`](https://github.com/nix-community/nixvim/commit/85b990286d391cce9a41d72cf4303637a7b43a10) | `` flake-modules/new-plugin: find project root ``                               |
| [`35b6d9bc`](https://github.com/nix-community/nixvim/commit/35b6d9bc9d576725dd374f81cff46539307b84ff) | `` flake-modules/new-plugin: init ``                                            |
| [`a9578bca`](https://github.com/nix-community/nixvim/commit/a9578bcae59224a63e02effb7c27f28602fa5128) | `` plugins/lsp: Add some LSP servers ``                                         |
| [`dc7bca6d`](https://github.com/nix-community/nixvim/commit/dc7bca6d8c5ca0a56cec0c42a74819b8caca3b25) | `` update-scripts: Add a script to search for nvim-lspconfig server packages `` |
| [`bef9feb4`](https://github.com/nix-community/nixvim/commit/bef9feb446a9203a1343a5026970396bcae60f6f) | `` lib/modules: pass `inputs.nixpkgs` into `evalNixvim` ``                      |
| [`e16d2448`](https://github.com/nix-community/nixvim/commit/e16d2448650f6ae3841198996bb795b0f4e28b79) | `` plugins/tiny-devicons-auto-colors: init ``                                   |
| [`d0040391`](https://github.com/nix-community/nixvim/commit/d0040391e82343ba2d4e3ca5b9485bd8e49a1896) | `` plugins/mini: configLocation mkBefore ``                                     |
| [`cef7414b`](https://github.com/nix-community/nixvim/commit/cef7414b034f2ac9278e5e8eeb400f8794588558) | `` plugins/web-devicons: configLocation mkBefore ``                             |
| [`32027965`](https://github.com/nix-community/nixvim/commit/32027965d8ca7da03ac6215be588cc4884f4b129) | `` lib: remove dependency on `pkgs` ``                                          |
| [`9e6b2074`](https://github.com/nix-community/nixvim/commit/9e6b20740192f447116951924b64649ef13d690c) | `` flake.lock: Update ``                                                        |
| [`cb61e12b`](https://github.com/nix-community/nixvim/commit/cb61e12bbac08fc7fd2c672974ccf2d12cdcf236) | `` plugins/easyescape: switch to mkVimPlugin and add options ``                 |
| [`a658e81d`](https://github.com/nix-community/nixvim/commit/a658e81d7124987742228575234048d438548584) | `` docs/config-examples: generate dynamically from a toml list ``               |
| [`8eeea073`](https://github.com/nix-community/nixvim/commit/8eeea073fcc4feec2cb62f293f53c884bcc626f0) | `` tests: call using `callPackages` ``                                          |
| [`452c30f7`](https://github.com/nix-community/nixvim/commit/452c30f747b52d798d31deaa07f14b9833a8527f) | `` plugins/commentary: switch to mkVimPlugin ``                                 |
| [`64681ae8`](https://github.com/nix-community/nixvim/commit/64681ae84cb6f67ab62003f52c5f1e6e9fe2068a) | `` dev/list-plugins: add markdown formatting ``                                 |
| [`3726dbed`](https://github.com/nix-community/nixvim/commit/3726dbed68e769acdef11e1eed3ceb1b5611bd01) | `` dev/list-plugins: deprecate Kind.UNKNOWN completely ``                       |
| [`a7afed6b`](https://github.com/nix-community/nixvim/commit/a7afed6b45e5c5eb7d9bdc36b754bd11340587bf) | `` dev/list-plugins: update EXCLUDES and KNOWN_PATHS variables ``               |
| [`bcebe05a`](https://github.com/nix-community/nixvim/commit/bcebe05a5141dcaa3dec892c31a4e7c720af0f92) | `` dev/list-plugins: add symbol for 'MISC' type plugins ``                      |
| [`ece37219`](https://github.com/nix-community/nixvim/commit/ece372190a51ff13e0a3af2b5797ee41ab831aab) | `` plugins/conjure: switch to mkVimPlugin ``                                    |
| [`58d2a5ac`](https://github.com/nix-community/nixvim/commit/58d2a5ac9cc4ff987e6edb77f2b55d1dec05ce50) | `` plugins/dap-lldb: init ``                                                    |