### PR TITLE
chore(flake/nixpkgs): `5d67ea6b` -> `3566ab72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733940404,
-        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
+        "lastModified": 1734119587,
+        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`56456210`](https://github.com/NixOS/nixpkgs/commit/56456210e9bfc57dbc3f33846e40770bc2c8498f) | `` blender: 4.3.0 -> 4.3.1 (#364446) ``                                         |
| [`bef38c59`](https://github.com/NixOS/nixpkgs/commit/bef38c59f3f4f14ba7cdce2dd85aefe607139a7d) | `` melonDS: 1.0rc-unstable-2024-11-27 -> 1.0rc-unstable-2024-12-05 (#364697) `` |
| [`5c941d44`](https://github.com/NixOS/nixpkgs/commit/5c941d4463d46b982fb9ae1a465a203f75750905) | `` organicmaps: 2024.11.12-7 -> 2024.11.27-12 ``                                |
| [`c5caab6a`](https://github.com/NixOS/nixpkgs/commit/c5caab6aed24a8eda10c63508a9542d1bd8f75ad) | `` ps3-disc-dumper: 3.2.3 -> 4.2.5 ``                                           |
| [`22cf4c09`](https://github.com/NixOS/nixpkgs/commit/22cf4c09490ede7989a8b4e6ac1f8bbfdfd51a31) | `` ps3-disc-dumper: .NET 6 -> .NET 9 ``                                         |
| [`3206fca3`](https://github.com/NixOS/nixpkgs/commit/3206fca3295b9ae9aebd52e06248fb288c7e04e1) | `` ps3-disc-dumper: add maintainer gepbird ``                                   |
| [`6b996d66`](https://github.com/NixOS/nixpkgs/commit/6b996d6693faade32f989274e538b16cefe5ba89) | `` ps3-disc-dumper: `fetchFromGitHub` refactor ``                               |
| [`57804c3f`](https://github.com/NixOS/nixpkgs/commit/57804c3fbbe111aaa8de09cc0a888a3aac0d88fd) | `` ps3-disc-dumper: remove `with lib;`, order `meta` attrs ``                   |
| [`540c7a13`](https://github.com/NixOS/nixpkgs/commit/540c7a13c20bb94e0a7479d95890f4ae95413954) | `` ps3-disc-dumper: add update script ``                                        |
| [`8b4a96dd`](https://github.com/NixOS/nixpkgs/commit/8b4a96dd8039a6a8456f01a16cce410ba438e4f3) | `` gitea: 1.22.5 -> 1.22.6 ``                                                   |
| [`1cf12db2`](https://github.com/NixOS/nixpkgs/commit/1cf12db2eec6e4be80715344a5788a2b8a12f7ee) | `` yggdrasil: 0.5.10 -> 0.5.11 ``                                               |
| [`0ba0da04`](https://github.com/NixOS/nixpkgs/commit/0ba0da04c100781e238789103af2e8dc5cb6a181) | `` usql: 0.19.12 -> 0.19.14 ``                                                  |
| [`831af1be`](https://github.com/NixOS/nixpkgs/commit/831af1be93542826aeb200ef1e78a925893b1308) | `` numix-icon-theme-square: 24.10.22 -> 24.12.12 ``                             |
| [`1780cbb3`](https://github.com/NixOS/nixpkgs/commit/1780cbb35167e444dfffae613d1397e898780f6f) | `` python312Packages.llm-gguf: init at 0.2 ``                                   |
| [`a64b0895`](https://github.com/NixOS/nixpkgs/commit/a64b0895ebcf0ee7f3d45d45616f0e789c807ef2) | `` tailscale: build derpprobe ``                                                |
| [`36ecdfd2`](https://github.com/NixOS/nixpkgs/commit/36ecdfd28cb1b5dc24c4c57a5d88fc179b21a333) | `` libfmvoice: 0-unstable-2024-11-08 -> 0-unstable-2024-12-11 ``                |
| [`d099ad0a`](https://github.com/NixOS/nixpkgs/commit/d099ad0a0ecdf28e6a6eb677c7a18416eed99a3c) | `` spotify-qt: 3.11 -> 3.12 ``                                                  |
| [`63147ee2`](https://github.com/NixOS/nixpkgs/commit/63147ee264d9e2f90fb6e8be0386b426e7898eb7) | `` disko: 1.9.0 -> 1.10.0 ``                                                    |
| [`b048953c`](https://github.com/NixOS/nixpkgs/commit/b048953c5f1ba806b7be93dc9018bd87b5cf27d3) | `` dnscontrol: 4.14.3 -> 4.15.0 ``                                              |
| [`df1f21fd`](https://github.com/NixOS/nixpkgs/commit/df1f21fd1a9f33fb1adc0ad453e88a395c8111af) | `` gopls: 0.16.2 -> 0.17.0 ``                                                   |
| [`4e85178c`](https://github.com/NixOS/nixpkgs/commit/4e85178c7e6dc8ad46dde83f063ee538ca910039) | `` nimble: 0.16.2 -> 0.16.3 ``                                                  |
| [`1cfdf7eb`](https://github.com/NixOS/nixpkgs/commit/1cfdf7ebbba2e31c6e196369afa3ba55344727b4) | `` python312Packages.pyvicare: 2.37.0 -> 2.38.0 ``                              |
| [`c0159d6b`](https://github.com/NixOS/nixpkgs/commit/c0159d6be7ab1b508b56c829bea125240ea66997) | `` shopware-cli: 0.4.60 -> 0.4.61 ``                                            |
| [`7d8f9ce5`](https://github.com/NixOS/nixpkgs/commit/7d8f9ce5fc357b2618a3cdfab55bd0d3e460b124) | `` yaralyzer: 0.9.4 -> 0.9.5 ``                                                 |
| [`aed10d73`](https://github.com/NixOS/nixpkgs/commit/aed10d7310a8c220c203e6c74467a998c0fb1a5b) | `` gnucash: add libsecret to support db password storage in keychain ``         |
| [`629830c8`](https://github.com/NixOS/nixpkgs/commit/629830c8ffc7d1b34533a6ebebde0eaec0c5c941) | `` Add coqPackages.stdlib ``                                                    |
| [`0fb1b7d8`](https://github.com/NixOS/nixpkgs/commit/0fb1b7d80c3ba638429f0da98928080073092dd0) | `` Rename coq-stdlib into rocq-core ``                                          |
| [`9fb82dcd`](https://github.com/NixOS/nixpkgs/commit/9fb82dcd802c15322aa274311a11cc630b9e5c2d) | `` mongodb-ce: 8.0.3 -> 8.0.4 ``                                                |
| [`e6cb5a82`](https://github.com/NixOS/nixpkgs/commit/e6cb5a82e1cd8057d5c38207c1e6e30829a49956) | `` mydumper: 0.16.9-1 -> 0.17.0-1 ``                                            |
| [`29968df3`](https://github.com/NixOS/nixpkgs/commit/29968df363358418afa5169b4449a0ba37911385) | `` mergiraf: fix use vendored Cargo.lock ``                                     |
| [`ef3402f2`](https://github.com/NixOS/nixpkgs/commit/ef3402f28b1c6747a34d88bbb30fa5105efac6e2) | `` terraform-providers.kafka: 0.8.1 -> 0.8.3 ``                                 |
| [`9372cd96`](https://github.com/NixOS/nixpkgs/commit/9372cd96fe554a8ee68c023eaa534d4c6ea2b942) | `` mergiraf: 0.3.0 -> 0.4.0 ``                                                  |
| [`4901bb7d`](https://github.com/NixOS/nixpkgs/commit/4901bb7d4bec8d4466f89ba413a6c0824621e839) | `` terraform-providers.vcd: 3.14.0 -> 3.14.1 ``                                 |
| [`e51d950d`](https://github.com/NixOS/nixpkgs/commit/e51d950dd8c9774c637c406279356bd79ea2a7d4) | `` tmuxPlugins.weather: set correct rtpFilePath (#285909) ``                    |
| [`41a76e2c`](https://github.com/NixOS/nixpkgs/commit/41a76e2c7b7dd2ddf5c8c2acba678c25fe357e3a) | `` mailpit: 1.21.5 -> 1.21.6 ``                                                 |
| [`f4cd916d`](https://github.com/NixOS/nixpkgs/commit/f4cd916d2f96c079c55f7e8ccaace48ed5544fa0) | `` eksctl: 0.197.0 -> 0.198.0 ``                                                |
| [`61372e47`](https://github.com/NixOS/nixpkgs/commit/61372e47f8be0169a911c089d4215f361f9bb1ac) | `` argocd: 2.13.1 -> 2.13.2 ``                                                  |
| [`22405c23`](https://github.com/NixOS/nixpkgs/commit/22405c23fc746cec69f3f69e5e7ff890b6d7a5fd) | `` misconfig-mapper: 1.12.3 -> 1.12.4 ``                                        |
| [`210fc874`](https://github.com/NixOS/nixpkgs/commit/210fc874b2d8718f7c19600bfd3fc7a67f9bf432) | `` spacectl: 1.7.1 -> 1.8.0 ``                                                  |
| [`a082997c`](https://github.com/NixOS/nixpkgs/commit/a082997c9614ec8cf77f90f6cae3a08d82e470f7) | `` simdutf: 5.6.3 -> 5.6.4 ``                                                   |
| [`ec7c864e`](https://github.com/NixOS/nixpkgs/commit/ec7c864e35d7188decf8a2ee54ccc88ffde1da76) | `` helmfile: 0.169.1 -> 0.169.2 ``                                              |
| [`ded42bbe`](https://github.com/NixOS/nixpkgs/commit/ded42bbe5c636264be7421fc1484024423fa8600) | `` ocamlPackages.ocplib-simplex: 0.5 → 0.5.1 ``                                 |
| [`dbb9c52b`](https://github.com/NixOS/nixpkgs/commit/dbb9c52bd3c464a9e2769514405017429d75ae69) | `` terraform-ls: 0.36.0 -> 0.36.2 ``                                            |
| [`3428e4dc`](https://github.com/NixOS/nixpkgs/commit/3428e4dcac32286771f6f15d8e0dee3fa8601cd8) | `` novops: 0.18.0 -> 0.19.0 ``                                                  |
| [`89b854db`](https://github.com/NixOS/nixpkgs/commit/89b854db13888955aa547845d8af70580f7e3940) | `` ddns-go: 6.7.6 -> 6.7.7 ``                                                   |
| [`013994f9`](https://github.com/NixOS/nixpkgs/commit/013994f91f0cde0deb4fedc9ca7bc74d882505c5) | `` pet: 1.0.0 -> 1.0.1 ``                                                       |
| [`b0de57dd`](https://github.com/NixOS/nixpkgs/commit/b0de57ddb8a877c1cccdea974644b047378bc1cc) | `` netscanner: 0.6.1 -> 0.6.2 ``                                                |
| [`3068057d`](https://github.com/NixOS/nixpkgs/commit/3068057dbbac9b12772425c34e9237c42a1825eb) | `` kubefetch: 0.8.0 -> 0.8.1 ``                                                 |
| [`2796a3fe`](https://github.com/NixOS/nixpkgs/commit/2796a3fe3d55e8c787a65830ac8a46d736886906) | `` pyflyby: 1.9.8 -> 1.9.10 ``                                                  |
| [`5d82b80c`](https://github.com/NixOS/nixpkgs/commit/5d82b80c0d2fd120045c817b6c42ef4e6d72897e) | `` vault-ssh-plus: 0.7.5 -> 0.7.6 ``                                            |
| [`e534b7d6`](https://github.com/NixOS/nixpkgs/commit/e534b7d60bde4f840c76b4eda12d88228a78e52e) | `` terraform-providers.doppler: 1.12.0 -> 1.13.0 ``                             |
| [`84ff5e70`](https://github.com/NixOS/nixpkgs/commit/84ff5e7026b6eaffdfdcacd9a0859e11e6a92d4f) | `` terraform-providers.tfe: 0.60.1 -> 0.61.0 ``                                 |
| [`9b99a985`](https://github.com/NixOS/nixpkgs/commit/9b99a9851e779143b811235274a3856b43d2e891) | `` govc: 0.46.2 -> 0.46.3 ``                                                    |
| [`3995d89e`](https://github.com/NixOS/nixpkgs/commit/3995d89ed45aae4c90b7bd22a1b1de7c6c754b7c) | `` goose: 3.23.0 -> 3.23.1 ``                                                   |
| [`f486c572`](https://github.com/NixOS/nixpkgs/commit/f486c572dad0d639c98269f988710db8eb3f534f) | `` patch2pr: 0.29.0 -> 0.30.0 ``                                                |
| [`cdc114ef`](https://github.com/NixOS/nixpkgs/commit/cdc114ef3384af75fd60c60adf3bc3772590e93a) | `` muparser: 2.3.4 -> 2.3.5 ``                                                  |
| [`de23a891`](https://github.com/NixOS/nixpkgs/commit/de23a891ac9aa4a692f7832dc39e62c0fa13bca4) | ``  python312Packages.plyara: init at 2.1.1 (#362909) ``                        |
| [`7f632a70`](https://github.com/NixOS/nixpkgs/commit/7f632a70b8a09bbb3aede079a5e0c7627fd2ddde) | `` nixos/bookstack: add package option (#364347) ``                             |
| [`c99ef045`](https://github.com/NixOS/nixpkgs/commit/c99ef045eb3e4fd67eefaeb4d3fb7c54f6941f05) | `` mktxp: init at 1.2.9 (#359136) ``                                            |
| [`a16ff38b`](https://github.com/NixOS/nixpkgs/commit/a16ff38b6cd04b04786f7649e5f95ff6712b85fd) | `` kmon: 1.6.5 -> 1.7.0 ``                                                      |
| [`8072a6b1`](https://github.com/NixOS/nixpkgs/commit/8072a6b11acc278e098cf5357964189c2c45d779) | `` kompose: 1.34.0 -> 1.35.0 ``                                                 |
| [`f3df1326`](https://github.com/NixOS/nixpkgs/commit/f3df13265bdfba76d9963a566ae9dc7840a83de4) | `` nextcloud28: 28.0.12 -> 28.0.14 ``                                           |
| [`3f89fb0e`](https://github.com/NixOS/nixpkgs/commit/3f89fb0eace4b9c6214ac29e96268278c0929e27) | `` lumafly: use dotnet sdk 9 as sdk 7 has been marked insecure ``               |
| [`067e2bba`](https://github.com/NixOS/nixpkgs/commit/067e2bba11075c6f07be911a6cb8aced82f0c2cc) | `` caligula: 0.4.7 -> 0.4.8 ``                                                  |
| [`4ee9e32d`](https://github.com/NixOS/nixpkgs/commit/4ee9e32df3e7405f4a2f97f3255171355221a604) | `` snipaste: 2.10.2 -> 2.10.3 ``                                                |
| [`e7e35ef8`](https://github.com/NixOS/nixpkgs/commit/e7e35ef8b4b9756b54785ebae831c7687c14f020) | `` python312Packages.morecantile: 6.0.0 -> 6.1.0 ``                             |
| [`6a71b413`](https://github.com/NixOS/nixpkgs/commit/6a71b413b37e49c7f1ab45f744c59664bcd9dfa1) | `` python312Packages.shiv: 1.0.7 -> 1.0.8 ``                                    |
| [`37318073`](https://github.com/NixOS/nixpkgs/commit/3731807312f36c344929059a049cd6d0d685d2bc) | `` python312Packages.pyoverkiz: 1.15.1 -> 1.15.2 ``                             |
| [`72feaf31`](https://github.com/NixOS/nixpkgs/commit/72feaf314508272d9bd656049aef55d18bd65665) | `` kube-bench: 0.9.2 -> 0.9.3 ``                                                |
| [`c609f1e3`](https://github.com/NixOS/nixpkgs/commit/c609f1e3713402ff6026ecbdd964318c65116227) | `` ttaenc: init at 3.4.1 ``                                                     |
| [`6cc45447`](https://github.com/NixOS/nixpkgs/commit/6cc454478df780595e9022abf553ab12ea6a5926) | `` nixos/inputmodule: init module ``                                            |
| [`bcab2a12`](https://github.com/NixOS/nixpkgs/commit/bcab2a1246c53d95270601068378d2e5f2eb379c) | `` inputmodule-control: init at v0.2.0 ``                                       |
| [`71eb26ef`](https://github.com/NixOS/nixpkgs/commit/71eb26ef20ad2d6acc4579ce67983e991901ae9a) | `` maintainers: add Kitt3120 ``                                                 |
| [`caebc410`](https://github.com/NixOS/nixpkgs/commit/caebc4109281a57f69e897cf3ff01fdf87a2d393) | `` vpp: 24.06 -> 24.10 ``                                                       |
| [`106a6a10`](https://github.com/NixOS/nixpkgs/commit/106a6a108d5780a68bfd7a7cca4ead16b21a3819) | `` nb: 7.14.6 -> 7.15.0 ``                                                      |
| [`1d0c19c9`](https://github.com/NixOS/nixpkgs/commit/1d0c19c9e75ccedb8d3f317b66012e3497472219) | `` vscode-extensions.github.copilot-chat: 0.23.2024102903 -> 0.24.2024121201 `` |
| [`33642e3a`](https://github.com/NixOS/nixpkgs/commit/33642e3a4532df6f4b5cd07f231788eed9ca6e2f) | `` vscode-extensions.github.copilot: 1.246.1233 -> 1.251.0 ``                   |