### PR TITLE
chore(flake/nixvim): `ec24d496` -> `450cccf4`

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -104,7 +104,7 @@
     };
     vim-matchup = {
       enable = true;
-      enableSurround = true;
+      settings.surround_enabled = 1;
     };
     vim-suda.enable = true;
     web-devicons.enable = true;

--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734299751,
-        "narHash": "sha256-PFJ/Wwk57XzmRkU0pJLnz4tJX81ln2OaFeqcOQqp7G0=",
+        "lastModified": 1734880727,
+        "narHash": "sha256-bQfaaYoH8kSdw2UWb8RLZoa/2jPvDjaw87nvj+pO5lE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ec24d496d52c2620b5ce3d237a2a1029a197b412",
+        "rev": "450cccf472f40ae8e3b92eec9e5f4b071693ac85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| [`450cccf4`](https://github.com/nix-community/nixvim/commit/450cccf472f40ae8e3b92eec9e5f4b071693ac85) | `` flake.lock: Update ``                                                                                                 |
| [`214731d3`](https://github.com/nix-community/nixvim/commit/214731d35564896397ca4fb7590fb544331a3294) | `` lib/plugins: deprecate `neovim-plugin` & `vim-plugin` aliases ``                                                      |
| [`43a3171d`](https://github.com/nix-community/nixvim/commit/43a3171dec22d079252f4397605f318adf6c6fd5) | `` treewide: `vim-plugin` -> `plugins` ``                                                                                |
| [`5e9a6c00`](https://github.com/nix-community/nixvim/commit/5e9a6c00a95ed842467270246ccc2c0f0863e53c) | `` treewide: `neovim-plugin` -> `plugins` ``                                                                             |
| [`787844cf`](https://github.com/nix-community/nixvim/commit/787844cfe496577db468adbfcaa5dd2f7dd2032d) | `` lib/plugins: call sub-components with relevant args ``                                                                |
| [`690fc895`](https://github.com/nix-community/nixvim/commit/690fc895b57965a261f00ac5542d91dac4f5fb3d) | `` lib/plugins: extract common logic for `package` options ``                                                            |
| [`896f6be6`](https://github.com/nix-community/nixvim/commit/896f6be694cabe6f8d7256f6430c964a3f2af881) | `` lib/plugins: take ownership of `modules` utils ``                                                                     |
| [`ec97297f`](https://github.com/nix-community/nixvim/commit/ec97297fd5c828aed869ceba85a577bab7fb343d) | `` lib/plugins: separate main factory functions ``                                                                       |
| [`88a1c1b4`](https://github.com/nix-community/nixvim/commit/88a1c1b46a38c18427e8a5cc6d2b10b66317e14e) | `` lib/plugins: organise plugin-factory functions in a subdir ``                                                         |
| [`6a4b4221`](https://github.com/nix-community/nixvim/commit/6a4b4221c4ebf1140f73f8df769e97f1828d90fa) | `` dev/new-plugin: originalName -> packPathName ``                                                                       |
| [`d39a09d0`](https://github.com/nix-community/nixvim/commit/d39a09d05dd4649ea8bf8520296aeef0740276df) | `` flake: warn when `lib.<system>.helpers` is used ``                                                                    |
| [`4b3b67fb`](https://github.com/nix-community/nixvim/commit/4b3b67fb6f618726aecea1f07b35c57e4963ea8c) | `` lib: make overrideable & access via flake ``                                                                          |
| [`e2ef15a6`](https://github.com/nix-community/nixvim/commit/e2ef15a665cbd05b33bdeb6f7b8b3c5fe0c9bde1) | `` lib: add `extend` function ``                                                                                         |
| [`937c9b4a`](https://github.com/nix-community/nixvim/commit/937c9b4acf653ce8b25ccc640dff99dcec7cf273) | `` flake.lock: Update ``                                                                                                 |
| [`9f32e25f`](https://github.com/nix-community/nixvim/commit/9f32e25f3f2b029b76e79ef7c1f48cd3596938d8) | `` plugins/treesitter: update docs for custom grammar installation ``                                                    |
| [`354fc0f2`](https://github.com/nix-community/nixvim/commit/354fc0f288e045594e2e30da7ff95189d3545a9a) | `` plugins/todo-comments: add TodoFzfLua ``                                                                              |
| [`6830c55d`](https://github.com/nix-community/nixvim/commit/6830c55d0945036ad9e15f068836dab346862ca3) | `` fix(docs): typo in install.md ``                                                                                      |
| [`f3ef2721`](https://github.com/nix-community/nixvim/commit/f3ef2721abf6e7f4f9ab8346cb1efebb0ecb9769) | `` modules/keymap: quickfix, use "keep" rather than "error" ``                                                           |
| [`37608b46`](https://github.com/nix-community/nixvim/commit/37608b462772e35220e02bfbd9045d0946564436) | `` Revert "plugins/cmp/sources: use mkNeovimPlugin instead of mkVimPlugin for source plugins" ``                         |
| [`2b7f17b6`](https://github.com/nix-community/nixvim/commit/2b7f17b6de578b63b7dc0e4155e36538042bc968) | `` plugins/crates: rename from crates-nvim to crates, move to by-name, migrate to mkNeovimPlugin ``                      |
| [`5d6e83d8`](https://github.com/nix-community/nixvim/commit/5d6e83d8ab5f5df325a2f1a6a870d8c592ad62b0) | `` plugins/copilot-cmp: move to by-name, migrate to mkNeovimPlugin ``                                                    |
| [`7aed1c4b`](https://github.com/nix-community/nixvim/commit/7aed1c4b577b227fc4c892d15a77fb015a7f693e) | `` plugins/cmp-tabnine: move to by-name ``                                                                               |
| [`79a637d1`](https://github.com/nix-community/nixvim/commit/79a637d1962e725218ff46f5234cb3d5617ed36b) | `` modules/keymap: include buffer when registering `keymapsOnEvents` ``                                                  |
| [`520c2868`](https://github.com/nix-community/nixvim/commit/520c2868eb8047942abd58902bb3b6110c6529e2) | `` plugins/cmp-git: move to by-name ``                                                                                   |
| [`a61193ab`](https://github.com/nix-community/nixvim/commit/a61193abcc00f54a1313c6a218123afc5871ce65) | `` plugins/cmp-ai: move to by-name ``                                                                                    |
| [`f1addaad`](https://github.com/nix-community/nixvim/commit/f1addaaddff58d8619d326d313b0468e801c327d) | `` lib/{neovim,vim}-plugin: remove redundant parens ``                                                                   |
| [`6019ce78`](https://github.com/nix-community/nixvim/commit/6019ce784c1a0558a817402e080c0941274928d7) | `` lib/{neovim,vim}-plugin: use `loc` throughout ``                                                                      |
| [`eaa20846`](https://github.com/nix-community/nixvim/commit/eaa20846279654fa038427ce078d4cd9609e5f2f) | `` plugins/cmp-fish: move extra option to the sources list ``                                                            |
| [`5abe382c`](https://github.com/nix-community/nixvim/commit/5abe382c54eff3cd3977733e9d268ab8994f397b) | `` plugins/cmp-tabby: move to by-name ``                                                                                 |
| [`6e52e32d`](https://github.com/nix-community/nixvim/commit/6e52e32d4026076c7ef6d1a72eaa9ac1d82c72ac) | `` dev/list-plugins: trivial refactor ``                                                                                 |
| [`6a9d8403`](https://github.com/nix-community/nixvim/commit/6a9d840370647abb0c980ff1bb8e47edd1255789) | `` plugins/cmp/sources: use mkNeovimPlugin instead of mkVimPlugin for source plugins ``                                  |
| [`11e8a5db`](https://github.com/nix-community/nixvim/commit/11e8a5dbc6ce83444d9de8d247271cc70d812b32) | `` flake.lock: Update ``                                                                                                 |
| [`4f1fe403`](https://github.com/nix-community/nixvim/commit/4f1fe403b18c45614d6b81423038a34cff371244) | `` plugins/openscad: migrate to mkVimPlugin ``                                                                           |
| [`17905dec`](https://github.com/nix-community/nixvim/commit/17905dec3d08062dc8358b86a95058be4c71cc35) | `` modules: let extraPlugins accept null values ``                                                                       |
| [`167167e4`](https://github.com/nix-community/nixvim/commit/167167e4b371a07e4388fb4a2dc71fdcd72731ad) | `` lib/vim-plugin: expose new helpers `settingsOptionDescription` and `processPrefixedGlobals` and `mkSettingsOption` `` |
| [`1d50fa4f`](https://github.com/nix-community/nixvim/commit/1d50fa4f63e27c30d44fa2ceab6ec4ce7d7d6df8) | `` lib: add applyPrefixToAttrs ``                                                                                        |
| [`e24e40e5`](https://github.com/nix-community/nixvim/commit/e24e40e5f1ad9773fa9f7ca9e12de7db494d7468) | `` plugins/obsidian: add missing word in description ``                                                                  |
| [`092e5ed5`](https://github.com/nix-community/nixvim/commit/092e5ed56ae0fdffdc0cfaea9dbebb8f5fa9d1e1) | `` plugins/luasnip: migrate to mkNeovimPlugin ``                                                                         |
| [`aaf0fb16`](https://github.com/nix-community/nixvim/commit/aaf0fb166331dd5f469bd7e63bd993bbb6f4d524) | `` dev/list-plugins: conditionally create devshell only if devshell input is present ``                                  |
| [`f4b7fd46`](https://github.com/nix-community/nixvim/commit/f4b7fd46f6caf984fdfc41281792eac7b7ab8f24) | `` plugins/palette: fix minor typo; (#2696) ``                                                                           |
| [`c803fd73`](https://github.com/nix-community/nixvim/commit/c803fd738f52b177e7d6961acb62a9d1d7c21e7f) | `` dev/list-plugins: derivation cosmetic refactor ``                                                                     |
| [`3461f890`](https://github.com/nix-community/nixvim/commit/3461f890fa34a5048e71b1c9fb1d4aded4acf2c7) | `` plugins/vim-matchup: migrate to mkVimPlugin ``                                                                        |
| [`30895485`](https://github.com/nix-community/nixvim/commit/30895485c3a31bb16ace513def4f3a36bfeb68c6) | `` user-configs: add HeitorAugustoLN's configuration ``                                                                  |
| [`bfb08c1a`](https://github.com/nix-community/nixvim/commit/bfb08c1ab71252ff4e7c86fa4a8565a909f81aa5) | `` plugins/nix-develop: migrate to mkNeovimPlugin ``                                                                     |
| [`6c30476a`](https://github.com/nix-community/nixvim/commit/6c30476a4d5f761149945a65e74179f4492b1ea6) | `` plugins/plantuml-syntax: migrate to mkVimPlugin ``                                                                    |
| [`471f68d9`](https://github.com/nix-community/nixvim/commit/471f68d9bb9e00e7cbc352c452e7e314dced17bb) | `` plugins/vim-bbye: migrate to mkVimPlugin ``                                                                           |
| [`a24ec741`](https://github.com/nix-community/nixvim/commit/a24ec7412ed0b120e49f8f8dd421d5ff1e3171cc) | `` plugins/intellitab: migrate to mkVimPlugin ``                                                                         |
| [`9062a66e`](https://github.com/nix-community/nixvim/commit/9062a66ee9a7c65f65c64920a91963268e66fd93) | `` plugins/gitmessenger: migrate to mkVimPlugin ``                                                                       |
| [`ad87ec83`](https://github.com/nix-community/nixvim/commit/ad87ec831b5d8df6fa5a8846a7b126e378570f6a) | `` dev/list-plugins: add flake check ``                                                                                  |
| [`12db5eaf`](https://github.com/nix-community/nixvim/commit/12db5eaf8ab1abd49307586a6aee488f67fb048c) | `` dev/list-plugins: add --root-path argument ``                                                                         |
| [`bc3b99c4`](https://github.com/nix-community/nixvim/commit/bc3b99c4d90b08726dd919d94eb03563c949d08a) | `` dev/list-plugins: make it a proper package ``                                                                         |
| [`0fb43cbf`](https://github.com/nix-community/nixvim/commit/0fb43cbfb62a46cdfcea7487c397d9f232ac469e) | `` dev/list-plugins: properly error out when parsing is unsuccessfull ``                                                 |
| [`0edc061a`](https://github.com/nix-community/nixvim/commit/0edc061a6c9fcf0d46f30568da31ae325c1f51b6) | `` plugins/gitgutter: migrate to mkVimPlugin ``                                                                          |
| [`76e9d89d`](https://github.com/nix-community/nixvim/commit/76e9d89d96502a4ee8e1cd74a5b50077cf204134) | `` plugins/floaterm: move to mkVimPlugin ``                                                                              |
| [`c179d47d`](https://github.com/nix-community/nixvim/commit/c179d47d3d03075cd48d19d20b983d0445a5c8a1) | `` plugins/*: use new mkSettingsRenamedOptionModules ``                                                                  |
| [`0ddf6e39`](https://github.com/nix-community/nixvim/commit/0ddf6e39ac0dddc02fb0bc45337b4dbb5139b49d) | `` lib/mkSettingsRenamedOptionModules: allow attrs value with 'old' and 'new' keys ``                                    |
| [`7e4f8a2a`](https://github.com/nix-community/nixvim/commit/7e4f8a2a560120d5a21c218d0e80ea18d9397a5e) | `` plugins/friendly-snippets: switch to mkVimPlugin ``                                                                   |
| [`93208b95`](https://github.com/nix-community/nixvim/commit/93208b95362d8b0a8807efc49260d36de13a0c65) | `` plugins/quickmath: migrate to mkVimPlugin ``                                                                          |