### PR TITLE
chore(flake/git-hooks): `0bb4be58` -> `0ddd26d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734379367,
-        "narHash": "sha256-Keu8z5VgT5gnCF4pmB+g7XZFftHpfl4qOn7nqBcywdE=",
+        "lastModified": 1734425854,
+        "narHash": "sha256-nzE5UbJ41aPEKf8R2ZFYtLkqPmF7EIUbNEdHMBLg0Ig=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "0bb4be58f21ff38fc3cdbd6c778eb67db97f0b99",
+        "rev": "0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`03c878f8`](https://github.com/cachix/git-hooks.nix/commit/03c878f82e08d28345604895e84188e249b9ce21) | `` fix: biome write deprecation `` |