### PR TITLE
chore(flake/treefmt-nix): `0ce9d149` -> `76159fc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733761991,
-        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
+        "lastModified": 1734543842,
+        "narHash": "sha256-/QceWozrNg915Db9x/Ie5k67n9wKgGdTFng+Z1Qw0kE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
+        "rev": "76159fc74eeac0599c3618e3601ac2b980a29263",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                           |
| ---------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`76159fc7`](https://github.com/numtide/treefmt-nix/commit/76159fc74eeac0599c3618e3601ac2b980a29263) | `` Fix copy-paste error (#279) `` |