### PR TITLE
chore(flake/git-hooks): `0ddd26d0` -> `f0f0dc49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734425854,
-        "narHash": "sha256-nzE5UbJ41aPEKf8R2ZFYtLkqPmF7EIUbNEdHMBLg0Ig=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`3e3ebb27`](https://github.com/cachix/git-hooks.nix/commit/3e3ebb2765e48344a3ab700fc25c125181eb8bcb) | `` chore(cabal2nix): stick to camelCase ``                                  |
| [`be16516d`](https://github.com/cachix/git-hooks.nix/commit/be16516ddd761e03509849c2d037925f826740cc) | `` feat: add an option to cabal2nix hook for specifying output filename. `` |