### PR TITLE
chore(flake/nixvim): `450cccf4` -> `8938e09d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734880727,
-        "narHash": "sha256-bQfaaYoH8kSdw2UWb8RLZoa/2jPvDjaw87nvj+pO5lE=",
+        "lastModified": 1734956286,
+        "narHash": "sha256-8h7Fs6S+Ftg3NNmwT/KkYWI9epUNPCMPn56QFXOfmTM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "450cccf472f40ae8e3b92eec9e5f4b071693ac85",
+        "rev": "8938e09db14d510dcc2f266e8b2e738ee527d386",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`8938e09d`](https://github.com/nix-community/nixvim/commit/8938e09db14d510dcc2f266e8b2e738ee527d386) | `` modules/output: add `manDocsPackage` ``                          |
| [`94874035`](https://github.com/nix-community/nixvim/commit/948740353295d181cd846331dea4f81695f98684) | `` modules/context: `flake` option, provides access to our flake `` |
| [`7391dc14`](https://github.com/nix-community/nixvim/commit/7391dc14ca4642ab43029ac15dc23b5fab721f31) | `` plugins/blink-compat: init ``                                    |
| [`6f45ca4a`](https://github.com/nix-community/nixvim/commit/6f45ca4a22c2f18d72bb582d35421eb6994d5263) | `` lib/modules: `flake` is now required ``                          |
| [`403d5e23`](https://github.com/nix-community/nixvim/commit/403d5e23c5fffe53395425234288f29bb5704bca) | `` lib/modules: remove assertion message for removed `check` arg `` |
| [`f1b5c2c5`](https://github.com/nix-community/nixvim/commit/f1b5c2c59345a125ea71b1fcd0e4e74a115ba786) | `` lib/tests: remove deprecated dontRun ``                          |
| [`472526d7`](https://github.com/nix-community/nixvim/commit/472526d7aa7f9ff16ae9d443f2fe62596ac0f2eb) | `` wrappers: extract nixvim-lib from extended lib ``                |
| [`aefab28b`](https://github.com/nix-community/nixvim/commit/aefab28b3b3cd87cc3aa8f27a3984faf7902fb30) | `` lib/overlay: init ``                                             |