### PR TITLE
chore(flake/nixvim): `ca3c7e29` -> `1671f861`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735124172,
-        "narHash": "sha256-2X2yCslRVWAmD/2IuiGGRJxEX+CMM7uuI81VZz+WJMU=",
+        "lastModified": 1735254735,
+        "narHash": "sha256-byFeQzjeTLgWkk2xEhTYqYvUsID7H2QAkzuFKIL2Stc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ca3c7e29a857084c4b311aa714b88ab789760fe0",
+        "rev": "1671f8618fa347d8a0cd62506df386d58d7608f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`1671f861`](https://github.com/nix-community/nixvim/commit/1671f8618fa347d8a0cd62506df386d58d7608f3) | `` lib/mk-neovim-plugin: allow lazy-loading without `luaConfig` `` |
| [`f8782897`](https://github.com/nix-community/nixvim/commit/f8782897227d5dbc054e481f7756db6b3bf544f2) | `` lib/plugins: make plugin optional when lazy-loading ``          |
| [`87b2679d`](https://github.com/nix-community/nixvim/commit/87b2679d6fb61bac08b2a17501e14da7be534fcb) | `` user-configs: add @r6t config ``                                |
| [`25c13524`](https://github.com/nix-community/nixvim/commit/25c13524642cb7fe98583a5dd5f90992c76198b9) | `` docs/contributing: fix hyperlink issues ``                      |