### PR TITLE
chore(flake/nixvim): `1671f861` -> `0307cdf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735254735,
-        "narHash": "sha256-byFeQzjeTLgWkk2xEhTYqYvUsID7H2QAkzuFKIL2Stc=",
+        "lastModified": 1735343514,
+        "narHash": "sha256-CZGsEGSRN5PQnf3ciNFdlpCDorvyo6+YQ1cPQ1ebVxk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1671f8618fa347d8a0cd62506df386d58d7608f3",
+        "rev": "0307cdf297cd6bdafd55a66d69c54b55c482edf8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`0307cdf2`](https://github.com/nix-community/nixvim/commit/0307cdf297cd6bdafd55a66d69c54b55c482edf8) | `` plugins/blink-cmp: force version for blink.cmp >= 0.8.2 ``       |
| [`9a08553d`](https://github.com/nix-community/nixvim/commit/9a08553d153a49fc2b6ee476bb860f318f939fa7) | `` plugins/flutter-tools: init ``                                   |
| [`7500425d`](https://github.com/nix-community/nixvim/commit/7500425d31566e96ad2602ebbc9f16599f068290) | `` lib/options/mkRaw': handle pluginDefault=null ``                 |
| [`1702f240`](https://github.com/nix-community/nixvim/commit/1702f2407417b1646f5fb4635476d16df9221c8b) | `` plugins/molten: add wezterm as image provider ``                 |
| [`abe2211a`](https://github.com/nix-community/nixvim/commit/abe2211aef2777c318464f4c76e6aa9a15c4f35e) | `` plugins/wezterm: init ``                                         |
| [`3fa487c8`](https://github.com/nix-community/nixvim/commit/3fa487c81d9f1a9bb2887597cc05331d69aa5247) | `` plugins/lint: migrate to mkNeovimPlugin ``                       |
| [`5b35c4ea`](https://github.com/nix-community/nixvim/commit/5b35c4eaed560576cd756121ef032bcccda1ca5e) | `` plugins/glance: init ``                                          |
| [`fc9176c7`](https://github.com/nix-community/nixvim/commit/fc9176c75b2df5b6b73a5cf449998499b28c7c91) | `` modules/test: hide the deprecated `check*` options ``            |
| [`60e88b87`](https://github.com/nix-community/nixvim/commit/60e88b870c8477bcb043792025eca4c9bb4974e3) | `` docs: treat internal options as invisible ``                     |
| [`e5974b31`](https://github.com/nix-community/nixvim/commit/e5974b316d83540eb79d716ac2ee8c8e35fd61b2) | `` modules/test: document possible types for expectation `value` `` |
| [`e679ee91`](https://github.com/nix-community/nixvim/commit/e679ee91fad3525ce8cfb1b1a34023ac88afc274) | `` tests: omit `default` suffix in test names ``                    |
| [`ae612f82`](https://github.com/nix-community/nixvim/commit/ae612f824918c336de906fd99048366a83591bdb) | `` tests: use warning-expectations options ``                       |
| [`24e3b11b`](https://github.com/nix-community/nixvim/commit/24e3b11b231e972e564546f24d49f35534728104) | `` modules/test: allow specifying expectation value type ``         |
| [`c2e172b0`](https://github.com/nix-community/nixvim/commit/c2e172b0d35c888177515591579e0d80ff5fb7f2) | `` modules/test: allow arbitrary warning/assertion expecations ``   |
| [`e7dcc9b5`](https://github.com/nix-community/nixvim/commit/e7dcc9b51882fd9f74ac52985739ec76709e8d22) | `` modules/test: allow not building nixvim config ``                |