### PR TITLE
chore(flake/nixvim): `caef3913` -> `87ee6609`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735639220,
-        "narHash": "sha256-WveMlpmtNAdM6LY40X2z1RzDrl/MfMKiJI+blHq5UWY=",
+        "lastModified": 1735772847,
+        "narHash": "sha256-g2kXpnAHXpwDfz/4Q2Kwzmee+QQKIhmo4DC6JXA8d18=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "caef39133f187a9ba138c5779a6c33307caaf149",
+        "rev": "87ee660991fa0e1b7b4e3f43a6dd1d126e64f3fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`87ee6609`](https://github.com/nix-community/nixvim/commit/87ee660991fa0e1b7b4e3f43a6dd1d126e64f3fa) | `` plugins/flit: init ``                                                                   |
| [`cbddd58c`](https://github.com/nix-community/nixvim/commit/cbddd58c6987e674dbbf9fc20e3f14b7c8f1232b) | `` lib/maintainers: add jolars ``                                                          |
| [`3399ebfe`](https://github.com/nix-community/nixvim/commit/3399ebfedd741456f45de6148fc36e7fcc74fcfa) | `` fix: use proper auto_insert option in `blink-cmp.settings.completion.list.selection` `` |
| [`d608bccd`](https://github.com/nix-community/nixvim/commit/d608bccddd810482495d5ba4134ea824879cf118) | `` Replace runCommandNoCCLocal alias with runCommandLocal ``                               |
| [`bc87d912`](https://github.com/nix-community/nixvim/commit/bc87d91273928c97a47eab0df9b303bb45adc6f4) | `` tests/{efmls-configs,none-ls}: disable clazy test (broken package) ``                   |
| [`29fbcbc2`](https://github.com/nix-community/nixvim/commit/29fbcbc21bc54ed250cdb288bf63df811a013908) | `` tests/openscad: disable on darwin (broken package) ``                                   |
| [`80b5d141`](https://github.com/nix-community/nixvim/commit/80b5d141df3dcec6da5625e9a8c3cae47bdc1870) | `` tests/efmls-configs: disable cppcheck test on darwin (broken package) ``                |
| [`9159f9e9`](https://github.com/nix-community/nixvim/commit/9159f9e97e5e6f192c188757974b1be81d6fc332) | `` tests/{efmls-configs,none-ls}: disable ansible_lint test (broken package) ``            |
| [`3fd7c3bf`](https://github.com/nix-community/nixvim/commit/3fd7c3bf598129b94353fe7906f6aa78cb88b85c) | `` plugins/blink-cmp: rework options ``                                                    |
| [`c2e88653`](https://github.com/nix-community/nixvim/commit/c2e88653576b9bfd8634db4882a97b4c29a6d706) | `` tests/lsp-servers: disable solc (broken package) ``                                     |
| [`7347e450`](https://github.com/nix-community/nixvim/commit/7347e4508e5bedc2220a2625aba150e6e9e06a3a) | `` tests/lsp-servers: disable ruby_lsp (broken package) ``                                 |
| [`1753c4a5`](https://github.com/nix-community/nixvim/commit/1753c4a5d280acce62754e14cb5e4173bbc35659) | `` plugins/lsp: mark autohotkey_lsp as unpackaged ``                                       |
| [`33373d8f`](https://github.com/nix-community/nixvim/commit/33373d8f3c94266b1113a5ab406591191e3ba839) | `` generated: Update ``                                                                    |
| [`6d6bc31d`](https://github.com/nix-community/nixvim/commit/6d6bc31d0c5b4a26c541e32159893e7f5a0369c8) | `` flake.lock: Update ``                                                                   |