### PR TITLE
chore(flake/git-hooks): `f0f0dc49` -> `a5a96138`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,17 +42,14 @@
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1734797603,
-        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
+        "lastModified": 1735882644,
+        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
+        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                   |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`ef1a5f9e`](https://github.com/cachix/git-hooks.nix/commit/ef1a5f9ec103334d1960852e943c5411828b9d75) | `` ci: limit concurrency ``               |
| [`0070c0b9`](https://github.com/cachix/git-hooks.nix/commit/0070c0b94a528fe745843b2a68e3a9ae5bbb2ecd) | `` ci: split stable and unstable tests `` |
| [`76a43622`](https://github.com/cachix/git-hooks.nix/commit/76a436220ae3fea161c7370c06efa1e55cbb1f00) | `` Remove nixpkgs-stable input ``         |