### PR TITLE
chore(flake/nixvim): `3285bbda` -> `91227dca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735802549,
-        "narHash": "sha256-aS03+IGLexQt5HL+tLZqSko6Jpxa+eozqcide/pab34=",
+        "lastModified": 1735946116,
+        "narHash": "sha256-kLl9B5XLiZd77VT8FDqOsMYIxkY+WrLDXE/jGLUT7T0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "3285bbda0aa0151c3b1914758e6950dfb554962f",
+        "rev": "91227dca9e0bb2eab1f165ce05538f38065d37c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`91227dca`](https://github.com/nix-community/nixvim/commit/91227dca9e0bb2eab1f165ce05538f38065d37c0) | `` lib/options: add defaultNullOpts.mkFloat ``                                           |
| [`24ac8f65`](https://github.com/nix-community/nixvim/commit/24ac8f651dc0e65cb26553760c39b9c6f9de732b) | `` plugins.*: use defaultNullOpts.mkProportion wherever possible ``                      |
| [`2e600f57`](https://github.com/nix-community/nixvim/commit/2e600f579621aacfce084057e0d80b97f9949080) | `` lib/options: add defaultNullOpts.mkProportion ``                                      |
| [`4f4917be`](https://github.com/nix-community/nixvim/commit/4f4917be697e7ef39ebada3737e51cb42e0cbe79) | `` plugins/csvview: init ``                                                              |
| [`6c93c52d`](https://github.com/nix-community/nixvim/commit/6c93c52dc1958a2e17313480e2fc68601bcbb0a6) | `` Revert "tests/lsp-servers: disable solc (broken package)" ``                          |
| [`153ddee6`](https://github.com/nix-community/nixvim/commit/153ddee666c59ed6b6e3b33d18d711fd2a3639e6) | `` Revert "tests/{efmls-configs,none-ls}: disable ansible_lint test (broken package)" `` |
| [`647b1de9`](https://github.com/nix-community/nixvim/commit/647b1de9b9954a3a70b29e7e6291b2e28a6deb5f) | `` Revert "tests/efmls-configs: disable cppcheck test on darwin (broken package)" ``     |
| [`9eb21bbd`](https://github.com/nix-community/nixvim/commit/9eb21bbdeab94831d8f4815be0d7575e72f31028) | `` Revert "tests/openscad: disable on darwin (broken package)" ``                        |
| [`49f9176f`](https://github.com/nix-community/nixvim/commit/49f9176f8016fab132357f8615eec021be2755c8) | `` Revert "tests/{efmls-configs,none-ls}: disable clazy test (broken package)" ``        |
| [`2ef0818d`](https://github.com/nix-community/nixvim/commit/2ef0818d2e632d897141f60cf75f3fc11001adf7) | `` generated: Updated rust-analyzer.nix ``                                               |
| [`696e5e5c`](https://github.com/nix-community/nixvim/commit/696e5e5ca0681aff52c6cf910b79cc8475d28241) | `` flake.lock: Update ``                                                                 |
| [`93b5fb04`](https://github.com/nix-community/nixvim/commit/93b5fb04783b58afa691977dcbb90b58483b3d82) | `` plugins/distant: init ``                                                              |
| [`e1b39b72`](https://github.com/nix-community/nixvim/commit/e1b39b725e779cdcf674bd1389b79691600c67a2) | `` plugins/fugit2: init ``                                                               |