### PR TITLE
chore(flake/nixvim): `91227dca` -> `e07a482f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735946116,
-        "narHash": "sha256-kLl9B5XLiZd77VT8FDqOsMYIxkY+WrLDXE/jGLUT7T0=",
+        "lastModified": 1736025907,
+        "narHash": "sha256-OopQbnOMP5YCl2aVEQQmPeze8wDmofZjzU6URCFEPQU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "91227dca9e0bb2eab1f165ce05538f38065d37c0",
+        "rev": "e07a482fd86eed90fd9378b97a2f938f07da1499",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`e07a482f`](https://github.com/nix-community/nixvim/commit/e07a482fd86eed90fd9378b97a2f938f07da1499) | `` flake: remove unneeded follows after git-hooks dropped their nixpkgs-stable input `` |
| [`9fec1059`](https://github.com/nix-community/nixvim/commit/9fec10597383c024a2a1a8b71fb58d6b1f30ebb9) | `` flake.lock: Update ``                                                                |