### PR TITLE
chore(flake/nixvim): `e07a482f` -> `7896856d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736025907,
-        "narHash": "sha256-OopQbnOMP5YCl2aVEQQmPeze8wDmofZjzU6URCFEPQU=",
+        "lastModified": 1736112263,
+        "narHash": "sha256-tSYWCZhs21SVg+X6jQrHGchok3db6nqZ4vL+x2ySJWk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e07a482fd86eed90fd9378b97a2f938f07da1499",
+        "rev": "7896856db1de897e95333aed381f06fa8788fff7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`7896856d`](https://github.com/nix-community/nixvim/commit/7896856db1de897e95333aed381f06fa8788fff7) | `` plugins/treesj: init ``                     |
| [`974b1d2c`](https://github.com/nix-community/nixvim/commit/974b1d2ce577bf07df22f61e0c167fa54dc3e879) | `` plugins/telescope: add project extension `` |