### PR TITLE
chore(flake/nixvim): `7896856d` -> `81c1ef20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736112263,
-        "narHash": "sha256-tSYWCZhs21SVg+X6jQrHGchok3db6nqZ4vL+x2ySJWk=",
+        "lastModified": 1736207155,
+        "narHash": "sha256-GHCR00qjM3Ux6GfZUQshZCpEIpTeNX+KF6sQ4tMVnqY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7896856db1de897e95333aed381f06fa8788fff7",
+        "rev": "81c1ef2090928715b9c17529880b9b60fe3abfc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`81c1ef20`](https://github.com/nix-community/nixvim/commit/81c1ef2090928715b9c17529880b9b60fe3abfc8) | `` tests/fidget: update to new format ``                            |
| [`038f5656`](https://github.com/nix-community/nixvim/commit/038f5656d8739fb18461aad3e47968e6bb0f361f) | `` plugins/fidget: migrate to mkNeovimPlugin ``                     |
| [`1e564fae`](https://github.com/nix-community/nixvim/commit/1e564fae7d0d41ca9710da81c3165feb17df5054) | `` colorschemes/monokai-pro: init ``                                |
| [`8968da16`](https://github.com/nix-community/nixvim/commit/8968da1617b09b6a2be1bc77cb1917ce713db446) | `` plugins/smear-cursor: init ``                                    |
| [`e59e9931`](https://github.com/nix-community/nixvim/commit/e59e99314b0a74af844bb0189182784b1af5a729) | `` plugins/lsp: add support for mode in non-extra keymaps ``        |
| [`a74897d0`](https://github.com/nix-community/nixvim/commit/a74897d03381659bf609aa8b4bb1201c23fe3eec) | `` mkLsp: remove `with lib;` ``                                     |
| [`5201bb2f`](https://github.com/nix-community/nixvim/commit/5201bb2f6f265300465228b87d75b1684fc2bc78) | `` mkLsp: `helpers` -> `lib.nixvim` ``                              |
| [`48eeef58`](https://github.com/nix-community/nixvim/commit/48eeef58e1ec2e92c246b953e53fbe5fc76cce99) | `` plugins/lsp: migrate to mkNeovimPlugin ``                        |
| [`65d08206`](https://github.com/nix-community/nixvim/commit/65d082069e0cf1edffe0a39dddfac6a2ea870d46) | `` plugins/treesitter: injections support luaConfig strings ``      |
| [`31139e06`](https://github.com/nix-community/nixvim/commit/31139e0605fd886d981e0a197e30ceac4b859d6e) | `` plugins/vimux: init ``                                           |
| [`2d18a774`](https://github.com/nix-community/nixvim/commit/2d18a774328d50ca76b48966e1b658a65bc0479f) | `` Revert "tests/lsp-servers: disable ruby_lsp (broken package)" `` |
| [`7915efce`](https://github.com/nix-community/nixvim/commit/7915efce0f5b07ab20606832887342d69f072993) | `` flake.lock: Update ``                                            |