### PR TITLE
chore(flake/nixvim): `81c1ef20` -> `0ebc64a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736207155,
-        "narHash": "sha256-GHCR00qjM3Ux6GfZUQshZCpEIpTeNX+KF6sQ4tMVnqY=",
+        "lastModified": 1736292108,
+        "narHash": "sha256-0mGe0okcNDKp0A9lS/birSP0Z5oheqgrXzQeolHM9U8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "81c1ef2090928715b9c17529880b9b60fe3abfc8",
+        "rev": "0ebc64a2328fc0a0532f9544eb6c6e297135962e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`0ebc64a2`](https://github.com/nix-community/nixvim/commit/0ebc64a2328fc0a0532f9544eb6c6e297135962e) | `` plugins/blink-cmp: remove forced version override ``         |
| [`73303938`](https://github.com/nix-community/nixvim/commit/73303938ee2e8cdc7138db6fc6e42d83cc546a56) | `` plugins/copilot-lua: migrate to mkNeovimPlugin ``            |
| [`a352bb89`](https://github.com/nix-community/nixvim/commit/a352bb89b0cd180f5c767689c4cc310109cd4ad8) | `` plugins/blink-cmp: fix `sources.per_filetype` option type `` |