### PR TITLE
chore(flake/nixvim): `0ebc64a2` -> `83153e96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736292108,
-        "narHash": "sha256-0mGe0okcNDKp0A9lS/birSP0Z5oheqgrXzQeolHM9U8=",
+        "lastModified": 1736374433,
+        "narHash": "sha256-oziJ5klXSS/wTJaoyL6oSYmRGpRFCYpJhq8Jl6q6NRU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0ebc64a2328fc0a0532f9544eb6c6e297135962e",
+        "rev": "83153e96c25d989020d028af51cf947aa843dc3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`83153e96`](https://github.com/nix-community/nixvim/commit/83153e96c25d989020d028af51cf947aa843dc3c) | `` plugins/blink-cmp: add khaneliman maintainer ``                    |
| [`2f9b103d`](https://github.com/nix-community/nixvim/commit/2f9b103d2ea5c3a127d883fc1965b620cc83dd72) | `` plugins/blink-cmp: update completion.list.selection type ``        |
| [`20540945`](https://github.com/nix-community/nixvim/commit/2054094544f03daf746160cd47e1860ebbb129e9) | `` plugins/dropbar: init ``                                           |
| [`592e9eaf`](https://github.com/nix-community/nixvim/commit/592e9eaff04fab033427d8c5fb747866b68d6f18) | `` plugins/inc-rename: convert to mkNeovimPlugin and add option ``    |
| [`092a46a1`](https://github.com/nix-community/nixvim/commit/092a46a1ca8697a4f0420099fd2d610a951ea5d4) | `` plugins/neoconf: setup before lspconfig ``                         |
| [`8899663b`](https://github.com/nix-community/nixvim/commit/8899663b5928c1326a4d8f721430da7e947f4dc1) | `` plugins/persistence: convert to mkNeovimPlugin and fix settings `` |