### PR TITLE
chore(flake/nixvim): `83153e96` -> `67de8484`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736374433,
-        "narHash": "sha256-oziJ5klXSS/wTJaoyL6oSYmRGpRFCYpJhq8Jl6q6NRU=",
+        "lastModified": 1736430661,
+        "narHash": "sha256-0dabFSGqcPo47WfgPRM5usnVXaGMdYvPlDJ5PeIqjr4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "83153e96c25d989020d028af51cf947aa843dc3c",
+        "rev": "67de84848e43ca6a5025e4f8eddc2f6684a51f2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`67de8484`](https://github.com/nix-community/nixvim/commit/67de84848e43ca6a5025e4f8eddc2f6684a51f2b) | `` tests/lean: disable lean tests on x86_64-darwin ``              |
| [`bca43a2a`](https://github.com/nix-community/nixvim/commit/bca43a2a8ed137a760c51ddc05442ea940e4cf73) | `` tests/lsp/all-servers: disable autotools_ls on aarch64-linux `` |
| [`574e78bb`](https://github.com/nix-community/nixvim/commit/574e78bb76f9de79f7f325f716445e4d479d9df5) | `` flake.lock: Update ``                                           |