### PR TITLE
chore(flake/nixvim): `67de8484` -> `2fc2132a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736430661,
-        "narHash": "sha256-0dabFSGqcPo47WfgPRM5usnVXaGMdYvPlDJ5PeIqjr4=",
+        "lastModified": 1736598781,
+        "narHash": "sha256-Y0o9ahm6Kk0DumTo80/vKspkHOkbtFgKCNiICyRjhMs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "67de84848e43ca6a5025e4f8eddc2f6684a51f2b",
+        "rev": "2fc2132a78753fc3d7ec732044eff7ad69530055",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------ |
| [`2fc2132a`](https://github.com/nix-community/nixvim/commit/2fc2132a78753fc3d7ec732044eff7ad69530055) | `` flake.lock: Update `` |