### PR TITLE
chore(flake/nixvim): `2fc2132a` -> `35d6c126`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736598781,
-        "narHash": "sha256-Y0o9ahm6Kk0DumTo80/vKspkHOkbtFgKCNiICyRjhMs=",
+        "lastModified": 1736715511,
+        "narHash": "sha256-5YAiZ3wrEJ/fzFoCwNf14xqfRTvgdcnl/+y0vye3Y6A=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2fc2132a78753fc3d7ec732044eff7ad69530055",
+        "rev": "35d6c12626f9895cd5d8ccf5d19c3d00de394334",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`35d6c126`](https://github.com/nix-community/nixvim/commit/35d6c12626f9895cd5d8ccf5d19c3d00de394334) | `` plugins/clangd-extensions: convert to mkNeovimPlugin `` |
| [`56877b8f`](https://github.com/nix-community/nixvim/commit/56877b8f763d6cadd42981d6c2bbf1222d621300) | `` plugins/llm: init ``                                    |
| [`8f4bf6d3`](https://github.com/nix-community/nixvim/commit/8f4bf6d300195da9dfa60df999c254d866e4d4ff) | `` plugins/sg: init ``                                     |
| [`5f3785fe`](https://github.com/nix-community/nixvim/commit/5f3785feb8564354a6fa9359fddcd38b32bd6efd) | `` plugins/projections: init ``                            |
| [`4527abba`](https://github.com/nix-community/nixvim/commit/4527abba5870b5650604eece6020a5d0361fe4cf) | `` plugins/visual-multi: init ``                           |
| [`8db6c517`](https://github.com/nix-community/nixvim/commit/8db6c5176242c2049d57bb9b30d1faac7c0cc2b1) | `` plugins/lir: init ``                                    |