### PR TITLE
chore(flake/nixvim): `35d6c126` -> `4282b73a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736715511,
-        "narHash": "sha256-5YAiZ3wrEJ/fzFoCwNf14xqfRTvgdcnl/+y0vye3Y6A=",
+        "lastModified": 1736876796,
+        "narHash": "sha256-Z7zxkh7b7Nfcryir3W2+wy7Ju1i1wSABGX01fA3+3hM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "35d6c12626f9895cd5d8ccf5d19c3d00de394334",
+        "rev": "4282b73ac0dbea03ad74ee8975c33ec41b0a7f25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`4282b73a`](https://github.com/nix-community/nixvim/commit/4282b73ac0dbea03ad74ee8975c33ec41b0a7f25) | `` plugins/flutter-tools: move settings to dedicated file `` |
| [`a54b7522`](https://github.com/nix-community/nixvim/commit/a54b752259ff16d340d270928ee603b4b9599192) | `` plugins/femaco: init ``                                   |
| [`b3d85757`](https://github.com/nix-community/nixvim/commit/b3d857573b92e1cc7b9b9c7c242c8dee61ebf359) | `` plugins/papis: init ``                                    |
| [`b7f783a8`](https://github.com/nix-community/nixvim/commit/b7f783a8dc733df2d33b5d32665339216cd04177) | `` plugins/tailwind-tools: init ``                           |
| [`67bbdf93`](https://github.com/nix-community/nixvim/commit/67bbdf9318aa27961ebb18b4581aad7cc4c87598) | `` plugins/cornelis: init ``                                 |
| [`8f7600ac`](https://github.com/nix-community/nixvim/commit/8f7600aca0b859b7d2c25ce8d6000b7ea87d4c82) | `` plugins/lazydev: init ``                                  |