### PR TITLE
chore(flake/nixvim): `4282b73a` -> `5b068e7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736876796,
-        "narHash": "sha256-Z7zxkh7b7Nfcryir3W2+wy7Ju1i1wSABGX01fA3+3hM=",
+        "lastModified": 1736964246,
+        "narHash": "sha256-gb3ujURRlI/D5Jc8PUDOpJr8RyrTwnDDIDtnQK4upso=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4282b73ac0dbea03ad74ee8975c33ec41b0a7f25",
+        "rev": "5b068e7f8f2b6beaa1fafe0c8b3604b63bcccc2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`5b068e7f`](https://github.com/nix-community/nixvim/commit/5b068e7f8f2b6beaa1fafe0c8b3604b63bcccc2d) | `` tests/nixpkgs: move nixpkgs module test to dedicated drv `` |
| [`54e6dbd8`](https://github.com/nix-community/nixvim/commit/54e6dbd8c83586d9553f61c21fa639b500e51f93) | `` user-configs: add Yohh's configuration ``                   |
| [`33ad2c72`](https://github.com/nix-community/nixvim/commit/33ad2c729dd9b629b0d49ce8ebb4b466105c315c) | `` plugins/flutter-tools: add warnings for dap integration ``  |
| [`d9c4e154`](https://github.com/nix-community/nixvim/commit/d9c4e154a8279de9e5ff37c4b40e28a1d496dc7c) | `` plugins/flutter-tools: add flutterPackageOption ``          |