### PR TITLE
chore(flake/nixvim): `5b068e7f` -> `d4c67764`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736964246,
-        "narHash": "sha256-gb3ujURRlI/D5Jc8PUDOpJr8RyrTwnDDIDtnQK4upso=",
+        "lastModified": 1736996101,
+        "narHash": "sha256-JP8YUi+BJvEmFYGEmk+vdXAdR7EpPqAg8UDeFYMtXr4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "5b068e7f8f2b6beaa1fafe0c8b3604b63bcccc2d",
+        "rev": "d4c67764a7d4e5dbda611933005560cc5bfcfb3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`d4c67764`](https://github.com/nix-community/nixvim/commit/d4c67764a7d4e5dbda611933005560cc5bfcfb3f) | `` tests/nixpkgs-module: only import the minimal modules for test ``   |
| [`e13b2a51`](https://github.com/nix-community/nixvim/commit/e13b2a51296cccc6bc975ab2dbd6a4e2c2b60efc) | `` tests/nixpkgs-module: split up helper fn ``                         |
| [`5192a85f`](https://github.com/nix-community/nixvim/commit/5192a85f3224cd2ef49da53162c0138823afd4e9) | `` test/nixpkgs-module: use a fixed `runCommand` function ``           |
| [`7854d5f1`](https://github.com/nix-community/nixvim/commit/7854d5f18c750eb7b2df3d3511eb17224ec0e835) | `` modules/test: fix expectations `lib.toJSON` -> `builtins.toJSON` `` |