### PR TITLE
chore(flake/treefmt-nix): `13c913f5` -> `97871d41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736154270,
-        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
+        "lastModified": 1737054102,
+        "narHash": "sha256-saLiCRQ5RtdTnznT/fja7GxcYRAzeY3k8S+IF/2s/2A=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
+        "rev": "97871d416166803134ba64597a1006f3f670fbde",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                   |
| ---------------------------------------------------------------------------------------------------- | ------------------------- |
| [`97871d41`](https://github.com/numtide/treefmt-nix/commit/97871d416166803134ba64597a1006f3f670fbde) | `` pinact: init (#300) `` |