### PR TITLE
chore(flake/nixvim): `d4c67764` -> `aa839cf9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736996101,
-        "narHash": "sha256-JP8YUi+BJvEmFYGEmk+vdXAdR7EpPqAg8UDeFYMtXr4=",
+        "lastModified": 1737143193,
+        "narHash": "sha256-+/BdPFrdJpgmzrMEUZMxsLeND8IvFtjyZbxHX2XrNv4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d4c67764a7d4e5dbda611933005560cc5bfcfb3f",
+        "rev": "aa839cf994f6b9a6b38e755597452087beac0567",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`aa839cf9`](https://github.com/nix-community/nixvim/commit/aa839cf994f6b9a6b38e755597452087beac0567) | `` generated: Update rust-analyzer options ``                                  |
| [`d63ac3eb`](https://github.com/nix-community/nixvim/commit/d63ac3eb39161a63a14f54f0be388a9f082a1af3) | `` update-scripts: Handle missing descriptions for enums ``                    |
| [`674790db`](https://github.com/nix-community/nixvim/commit/674790dbf90166ef9c9cb9e55bae967e4956fcd9) | `` update-scripts: Correctly handle propreties without a 'type' ``             |
| [`8e9458ea`](https://github.com/nix-community/nixvim/commit/8e9458eacfbe54b0b9b9f31d24c041236cfaba9a) | `` update-scripts: Add more verbose errors for rust-analyzer ``                |
| [`e4484133`](https://github.com/nix-community/nixvim/commit/e4484133d662ca7cd0f4e15c35100330ddf5d8d0) | `` docs/user-guide: slightly simplify lib-overlay example ``                   |
| [`51474292`](https://github.com/nix-community/nixvim/commit/51474292cd0c5ace056a0b26df6c38e997338399) | `` modules/nixpkgs: remove `pkgs` default text ``                              |
| [`3172e48d`](https://github.com/nix-community/nixvim/commit/3172e48dbbc1f98020894afa3027811ace46508b) | `` lib/tests: simplify access to default `system` ``                           |
| [`9bf4c9d5`](https://github.com/nix-community/nixvim/commit/9bf4c9d55b4fad12dae8f6dfea7d3d43f0a92513) | `` wrappers/standalone: make `pkgs` arg optional, allow specifying `system` `` |
| [`8c6f9ed8`](https://github.com/nix-community/nixvim/commit/8c6f9ed8c45576a3dc26e32f341b2ff8aebb0824) | `` lib/modules: allow specifying `system` as an `evalNixvim` arg ``            |
| [`7790746d`](https://github.com/nix-community/nixvim/commit/7790746d38856872ecaa1b8e69f18044d9a16031) | `` modules/nixpkgs: add `useGlobalPackages` option ``                          |
| [`912841c1`](https://github.com/nix-community/nixvim/commit/912841c1a766271cbf6604f3ced44b080474951c) | `` modules/nixpkgs: construct an instance of `nixpkgs.source` ``               |
| [`8dc8fa38`](https://github.com/nix-community/nixvim/commit/8dc8fa38b0d17953d0d760d3ac267e154f7b1497) | `` modules/nixpkgs: add `hostPlatform` & `buildPlatform` options ``            |
| [`5bd04ce0`](https://github.com/nix-community/nixvim/commit/5bd04ce09a0cef1d90ef5a22c481645f80ed9b5e) | `` modules/nixpkgs: add `config` option ``                                     |
| [`2d68ef84`](https://github.com/nix-community/nixvim/commit/2d68ef843a98aad059c037c13e69e940601de0bf) | `` flake.lock: Update ``                                                       |
| [`30842191`](https://github.com/nix-community/nixvim/commit/30842191e030f4110d8dc12b668d4734f55f9c1f) | `` docs: enable `warningsAreErrors` ``                                         |
| [`c19daee4`](https://github.com/nix-community/nixvim/commit/c19daee4534833b364f101c147a93c22d688c9a4) | `` docs/user-guide: document nixvim's lib overlay ``                           |
| [`b28ebf25`](https://github.com/nix-community/nixvim/commit/b28ebf253592eaf97516a7bcfd231d7d76a5608e) | `` docs/user-guide: add sub-headings to `helpers.md` ``                        |
| [`ff29c977`](https://github.com/nix-community/nixvim/commit/ff29c977236a0cd1ccd4144d4eab8ef2333e079d) | `` modules/test: provide access to `expect` function ``                        |
| [`16662760`](https://github.com/nix-community/nixvim/commit/16662760a92d777ef73d3b54e507455bc66dc114) | `` lib/modules: specify `modulesPath` ``                                       |
| [`b5efe91c`](https://github.com/nix-community/nixvim/commit/b5efe91c5215aaaeefbb117d1951ea773e96ddd1) | `` lib/modules: remove explicit `specialArgs.lib` ``                           |