### PR TITLE
chore(flake/nixvim): `aa839cf9` -> `cbf960e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737143193,
-        "narHash": "sha256-+/BdPFrdJpgmzrMEUZMxsLeND8IvFtjyZbxHX2XrNv4=",
+        "lastModified": 1737200978,
+        "narHash": "sha256-QTUx/F8HVjrRIHQxHKrr72aPMj+cDk18WTbvBCCBBdI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "aa839cf994f6b9a6b38e755597452087beac0567",
+        "rev": "cbf960e5659054b2ccf27b67218782e69016bef5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`cbf960e5`](https://github.com/nix-community/nixvim/commit/cbf960e5659054b2ccf27b67218782e69016bef5) | `` plugins/flutter-tools: update options ``         |
| [`4f2d78fc`](https://github.com/nix-community/nixvim/commit/4f2d78fcaf3550c1f5d98f2f8af78a2011e5354e) | `` plugins/flutter-tools: update settingsExample `` |
| [`a1b44cfd`](https://github.com/nix-community/nixvim/commit/a1b44cfdf48019d69713328ac28e12c1789ef21c) | `` templates: remove `_wrapper` ``                  |