### PR TITLE
chore(flake/nixvim): `cbf960e5` -> `8fb2fe22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737200978,
-        "narHash": "sha256-QTUx/F8HVjrRIHQxHKrr72aPMj+cDk18WTbvBCCBBdI=",
+        "lastModified": 1737308837,
+        "narHash": "sha256-Sro74XNFgGgIIW4uo/YSVGafZhKnZwPLJNBvMsgpl4k=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "cbf960e5659054b2ccf27b67218782e69016bef5",
+        "rev": "8fb2fe22c237b25b8af346870e126fdaeaff688b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`8fb2fe22`](https://github.com/nix-community/nixvim/commit/8fb2fe22c237b25b8af346870e126fdaeaff688b) | `` flake: add `nixvimModules` flake-parts module ``         |
| [`5426c9dd`](https://github.com/nix-community/nixvim/commit/5426c9dd83151c39fd8ad88f69b2b3fad40f8a38) | `` flake: add `nixvimConfigurations` flake-parts module ``  |
| [`9aa6d0f6`](https://github.com/nix-community/nixvim/commit/9aa6d0f6e62d9a179d20bcb364917eb30bb52adf) | `` flake: add initial flake-parts module ``                 |
| [`1654f97a`](https://github.com/nix-community/nixvim/commit/1654f97a79455efe9e578c5b70243e8333b126eb) | `` docs: use README as a source for the docs ``             |
| [`ab693bb1`](https://github.com/nix-community/nixvim/commit/ab693bb1cd63d83e6a4653715f2475a45789246c) | `` plugins/vim-suda: add back the smart_edit option ``      |
| [`85e4e16d`](https://github.com/nix-community/nixvim/commit/85e4e16de8690eedd136c59900771991e77951ee) | `` docs: notify `useGlobalPackages` breaking change ``      |
| [`82415eaa`](https://github.com/nix-community/nixvim/commit/82415eaa5d0f3e71e7fcbc0b4038aef1220737f0) | `` modules/nixpkgs: warn about changing defaults ``         |
| [`3a22953b`](https://github.com/nix-community/nixvim/commit/3a22953bea77bf3b8f6559de0c55838cd5fc76bc) | `` modules/nixpkgs: `useGlobalPackages` default to false `` |
| [`fecc8921`](https://github.com/nix-community/nixvim/commit/fecc8921459578c32eb371341c2c14e3c70424ba) | `` flake: remove `pkgsUnfree` arg ``                        |
| [`998bae9d`](https://github.com/nix-community/nixvim/commit/998bae9daceeb9bcad8126a3c4d159d9a677ba2c) | `` flake-modules -> flake ``                                |
| [`cf647bc0`](https://github.com/nix-community/nixvim/commit/cf647bc045567f27e9c5eabaa26111b4c7bbc169) | `` ci: drop 24.05 support ``                                |