### PR TITLE
chore(flake/nixvim): `8fb2fe22` -> `115994f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737308837,
-        "narHash": "sha256-Sro74XNFgGgIIW4uo/YSVGafZhKnZwPLJNBvMsgpl4k=",
+        "lastModified": 1737385899,
+        "narHash": "sha256-/zyvdstDpPhc5lhFMtKgyQdU2oXGXDb0cg4BY91NKvg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8fb2fe22c237b25b8af346870e126fdaeaff688b",
+        "rev": "115994f18e439a1cca9cdaaf15c004870256814d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`115994f1`](https://github.com/nix-community/nixvim/commit/115994f18e439a1cca9cdaaf15c004870256814d) | `` flake/auto: `nameFunction` default to `lib.id` ``        |
| [`780d3eec`](https://github.com/nix-community/nixvim/commit/780d3eec7209c7a08a585f5b680ed359ed68e62c) | `` wrappers/standalone: simplify `extend` ``                |
| [`00586f8f`](https://github.com/nix-community/nixvim/commit/00586f8f1b9880db79e9304a9415e157f3d5a9be) | `` modules/output: move `symlinkJoin` to `build.package` `` |
| [`731699a2`](https://github.com/nix-community/nixvim/commit/731699a24c9a6400aebba179c0156be14b5ec217) | `` plugins/gitsigns: cosmetic refactoring ``                |
| [`af6e4b0b`](https://github.com/nix-community/nixvim/commit/af6e4b0bad72e8bbdcafc4dd7655539e4aa5c557) | `` treewide: use mkAssertions wherever possible ``          |
| [`a7e516b3`](https://github.com/nix-community/nixvim/commit/a7e516b322fbdbe62ad15ea3d0cd3d82f21c42a3) | `` lib/utils: add mkAssertions ``                           |
| [`60adb6c5`](https://github.com/nix-community/nixvim/commit/60adb6c56b9153d73e6275321017eaf19f0be424) | `` treewide: use mkWarnings wherever possible ``            |
| [`2ec6218f`](https://github.com/nix-community/nixvim/commit/2ec6218f87a7ddeaa1887424d5883b3d0d9b3a23) | `` treewide: use mkWarnings wherever possible ``            |
| [`02e16b2a`](https://github.com/nix-community/nixvim/commit/02e16b2a761f79058d3635d50579edb41cf6f46c) | `` lib/utils: add mkWarnings ``                             |
| [`1036b8f8`](https://github.com/nix-community/nixvim/commit/1036b8f8b6c2983b03849f7ded79865eb457ddc7) | `` ci/update: remove nixos-24.05 update action ``           |
| [`a70b1697`](https://github.com/nix-community/nixvim/commit/a70b16976bac7d5baf5ce735ac7d0f9db1641d7d) | `` lib: export `evalNixvim` as top-level alias ``           |
| [`e793c5cd`](https://github.com/nix-community/nixvim/commit/e793c5cdc608cfe998319cff56b99a73a70f33f8) | `` flake: add `auto` flake-parts module ``                  |