### PR TITLE
chore(flake/nix-github-actions): `7b5f051d` -> `f4158fa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,11 +86,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731952509,
-        "narHash": "sha256-p4gB3Rhw8R6Ak4eMl8pqjCPOLCZRqaehZxdZ/mbFClM=",
+        "lastModified": 1737420293,
+        "narHash": "sha256-F1G5ifvqTpJq7fdkT34e/Jy9VCyzd5XfJ9TO8fHhJWE=",
         "owner": "nix-community",
         "repo": "nix-github-actions",
-        "rev": "7b5f051df789b6b20d259924d349a9ba3319b226",
+        "rev": "f4158fa080ef4503c8f4c820967d946c2af31ec9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`f4158fa0`](https://github.com/nix-community/nix-github-actions/commit/f4158fa080ef4503c8f4c820967d946c2af31ec9) | `` feat: add aarch64-linux via ubuntu-24.04-arm `` |
| [`32f8fc27`](https://github.com/nix-community/nix-github-actions/commit/32f8fc27f0559fcab2d6c46089ac4e5e26204578) | `` chore: update x86_64-linux to ubuntu-24.04 ``   |