### PR TITLE
chore(flake/nixvim): `115994f1` -> `342161bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737385899,
-        "narHash": "sha256-/zyvdstDpPhc5lhFMtKgyQdU2oXGXDb0cg4BY91NKvg=",
+        "lastModified": 1737484173,
+        "narHash": "sha256-bE9pTDqnSIMAwJeIu0MzA8ZR7LEwRbhnRpnImWIBejc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "115994f18e439a1cca9cdaaf15c004870256814d",
+        "rev": "342161bf525dd64eb53fea295a2180f71ed06de1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`342161bf`](https://github.com/nix-community/nixvim/commit/342161bf525dd64eb53fea295a2180f71ed06de1) | `` templates: add experimental-flake-parts template ``        |
| [`e3938e94`](https://github.com/nix-community/nixvim/commit/e3938e9464c2f860bfe303dd986243880c0b4075) | `` templates: inherit `checks` from _all_ templates ``        |
| [`53bfadc2`](https://github.com/nix-community/nixvim/commit/53bfadc2c2a6cdc12b8f8cf5b4e24701e213cb34) | `` lib/modules: work-around a submodule type-merging issue `` |
| [`77c78bd0`](https://github.com/nix-community/nixvim/commit/77c78bd04e6a1f600d5ce94c869e11b44cee1b7d) | `` tests/platforms: move out of flake `wrappers` module ``    |