### PR TITLE
chore(flake/nixvim): `342161bf` -> `a2a4befd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737484173,
-        "narHash": "sha256-bE9pTDqnSIMAwJeIu0MzA8ZR7LEwRbhnRpnImWIBejc=",
+        "lastModified": 1737578990,
+        "narHash": "sha256-49M9B1nni54cuOH6qPM90U106VSWhAVqpy6f3sz0q4Q=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "342161bf525dd64eb53fea295a2180f71ed06de1",
+        "rev": "a2a4befdaf825d36a50e2fda4a004682ea6b1a22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`a2a4befd`](https://github.com/nix-community/nixvim/commit/a2a4befdaf825d36a50e2fda4a004682ea6b1a22) | `` ci/update: cleanup names & comments ``                                |
| [`6046ad79`](https://github.com/nix-community/nixvim/commit/6046ad79f0f83c828a4edde5b3c4594a4bbcd002) | `` ci/update: schedule main branch daily, other branches weekly ``       |
| [`5bd71b24`](https://github.com/nix-community/nixvim/commit/5bd71b247437156df7e644d2f959bdf83fa1dceb) | `` Revert "[TO-REVERT] tests: disable failing-tests" ``                  |
| [`e7d827bb`](https://github.com/nix-community/nixvim/commit/e7d827bb321ad26a4562757c2e3adffc256f7f39) | `` flake.nix: follow nixpkgs-unstable instead of nixos-unstable ``       |
| [`31b0e360`](https://github.com/nix-community/nixvim/commit/31b0e36087e939844d6e5f0f332389b4094d124a) | `` [TO-REVERT] tests: disable failing-tests ``                           |
| [`e935f7a4`](https://github.com/nix-community/nixvim/commit/e935f7a4076cf15d890ffe15b5c1f8b00c76a8a9) | `` plugins/none-ls: update packages ``                                   |
| [`c289e10a`](https://github.com/nix-community/nixvim/commit/c289e10a0f09846c053511c66a53ce9e2e1e25b3) | `` plugins/lsp: update packages ``                                       |
| [`89260014`](https://github.com/nix-community/nixvim/commit/89260014265da20c325b78ee466da241da189f4b) | `` tests/lsp-servers: disable bitbake_language_server (build failure) `` |
| [`5a980d02`](https://github.com/nix-community/nixvim/commit/5a980d02fad353fa9850222f80ff0dc28acd7be8) | `` plugins/lsp: add atlas and cue ``                                     |
| [`24144954`](https://github.com/nix-community/nixvim/commit/241449544992e7c62b8271310ee5a6deaa1188fb) | `` generated: Updated none-ls.nix ``                                     |
| [`9b6c15e4`](https://github.com/nix-community/nixvim/commit/9b6c15e41e3bdeaa542ad4bd7fca4c237e36edf6) | `` generated: Updated lspconfig-servers.json ``                          |
| [`7f27c464`](https://github.com/nix-community/nixvim/commit/7f27c464a654c07ca50ef76cad0195801f55eb85) | `` flake.lock: Update ``                                                 |
| [`e60ea678`](https://github.com/nix-community/nixvim/commit/e60ea678ac9a4154b641fdaacf03c600d1c661d8) | `` plugins/emmet: cosmetic refactoring ``                                |