### PR TITLE
chore(flake/nixvim): `a2a4befd` -> `aab2b817`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737578990,
-        "narHash": "sha256-49M9B1nni54cuOH6qPM90U106VSWhAVqpy6f3sz0q4Q=",
+        "lastModified": 1737667561,
+        "narHash": "sha256-BKUapQPTji3V2uxymGq62/UWF1XMjfHvKd565jj1HlA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a2a4befdaf825d36a50e2fda4a004682ea6b1a22",
+        "rev": "aab2b81792567237c104b90c3936e073d28a9ac6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`aab2b817`](https://github.com/nix-community/nixvim/commit/aab2b81792567237c104b90c3936e073d28a9ac6) | `` plugins/git-conflict: fix packPath name ``                  |
| [`32bf82eb`](https://github.com/nix-community/nixvim/commit/32bf82ebe8d4469c17f3c55a4226498f7d1abe82) | `` flake.lock: Update ``                                       |
| [`e22bb46c`](https://github.com/nix-community/nixvim/commit/e22bb46c8863c30a791a4183aa9013d542cc5be5) | `` plugins/quicker: init ``                                    |
| [`85bef9e1`](https://github.com/nix-community/nixvim/commit/85bef9e19191000db4a13337198266359cefb9b6) | `` ci/update: fix `getFlake` expecting an absolute path ``     |
| [`7dc67410`](https://github.com/nix-community/nixvim/commit/7dc67410bbfa82d7650b80401219f864fa077542) | `` ci/update: cancel scheduled runs that don't bump nixpkgs `` |