### PR TITLE
chore(flake/nixvim): `aab2b817` -> `5fda6e09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737667561,
-        "narHash": "sha256-BKUapQPTji3V2uxymGq62/UWF1XMjfHvKd565jj1HlA=",
+        "lastModified": 1737747541,
+        "narHash": "sha256-dA54OnUCUtVZfnSuD1dAEcosZzx/tch9KvtDz/Y3FIo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "aab2b81792567237c104b90c3936e073d28a9ac6",
+        "rev": "5fda6e093da13f37c63a5577888a668c38f30dc7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`5fda6e09`](https://github.com/nix-community/nixvim/commit/5fda6e093da13f37c63a5577888a668c38f30dc7) | `` ci/update: slightly cleanup cancellation summary ``             |
| [`0b6be867`](https://github.com/nix-community/nixvim/commit/0b6be867566ae79aaac4e1a05202765868cafcad) | `` ci/update: fix graphql formatting ``                            |
| [`f4ba4422`](https://github.com/nix-community/nixvim/commit/f4ba44225e661323e61fa4b2c92ca0547477951e) | `` ci/update: slightly simplify jq query ``                        |
| [`bd3184f4`](https://github.com/nix-community/nixvim/commit/bd3184f4957d5484bb5ebef4b9bc6f9cc53cfad5) | `` ci/update: check whether a PR is already open ``                |
| [`16f92ff8`](https://github.com/nix-community/nixvim/commit/16f92ff8a6fe3681a8286e377054296c585935f4) | `` plugins/gx: init ``                                             |
| [`683e5ea4`](https://github.com/nix-community/nixvim/commit/683e5ea4b52092aa5318b5a2f0aec70681831636) | `` flake.lock: Update ``                                           |
| [`c7a600c3`](https://github.com/nix-community/nixvim/commit/c7a600c3f3878f3c60b03b2f68c2080c742793e8) | `` plugins/git-worktree: migrate to mkNeovimPlugin ``              |
| [`4ae6136d`](https://github.com/nix-community/nixvim/commit/4ae6136d12e16990b07ba262c961ae994d9afed7) | `` plugins/git-worktree: remove helpers ``                         |
| [`7dd96842`](https://github.com/nix-community/nixvim/commit/7dd9684264a9ced32c01684f16be841d48cb2e7d) | `` plugins/git-worktree: remove with lib ``                        |
| [`ff7570d7`](https://github.com/nix-community/nixvim/commit/ff7570d781f7ccd5a611008246ffa36627c9341e) | `` plugins/markdown-preview: move deprecations to separate file `` |
| [`c269e1b9`](https://github.com/nix-community/nixvim/commit/c269e1b9670dbd8166152a9208e1e02ecbc8ccc4) | `` plugins/markdown-preview: remove helpers ``                     |
| [`c0dda6cf`](https://github.com/nix-community/nixvim/commit/c0dda6cf49b1582838a864fdf667fc4d2bbc35b3) | `` plugins/markdown-preview: remove with lib ``                    |