### PR TITLE
chore(flake/nixvim): `5fda6e09` -> `d7df5832`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737747541,
-        "narHash": "sha256-dA54OnUCUtVZfnSuD1dAEcosZzx/tch9KvtDz/Y3FIo=",
+        "lastModified": 1737832569,
+        "narHash": "sha256-VkK73VRVgvSQOPw9qx9HzvbulvUM9Ae4nNd3xNP+pkI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "5fda6e093da13f37c63a5577888a668c38f30dc7",
+        "rev": "d7df58321110d3b0e12a829bbd110db31ccd34b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`d7df5832`](https://github.com/nix-community/nixvim/commit/d7df58321110d3b0e12a829bbd110db31ccd34b1) | `` docs: eval modules without access to `pkgs` ``                           |
| [`0b4a4e83`](https://github.com/nix-community/nixvim/commit/0b4a4e83277de46b39c4c80d01e11f980d2d9a55) | `` docs: don't set `allowUnfree` ``                                         |
| [`796ace65`](https://github.com/nix-community/nixvim/commit/796ace65f71755fab62e9a316341e6a72c5e8961) | `` plugins/lsp: set a `defaultText` for `cmd` ``                            |
| [`88652ce6`](https://github.com/nix-community/nixvim/commit/88652ce69a9ced055eb9998db484e9bb8a9acf30) | `` plugins/efmls: package option defaultText should not depend on pkgs ``   |
| [`09733a55`](https://github.com/nix-community/nixvim/commit/09733a5539e9e57ebc3ac5c945e03cf0e108f1bf) | `` plugins/fzf-lua: use `literalExpression` for `keymaps` example ``        |
| [`1c137a73`](https://github.com/nix-community/nixvim/commit/1c137a73f08d5f1a59e8ceb6aa4c12e5e4b7acef) | `` plugins/clipboard-image: use `mkPackageOption` for `clipboardPackage` `` |
| [`dbcdff7b`](https://github.com/nix-community/nixvim/commit/dbcdff7bbb101bbb8cc1cb16630f80e71ac5947b) | `` plugins/copilot-vim: set `defaultText` for `node_command` ``             |
| [`758bdd8d`](https://github.com/nix-community/nixvim/commit/758bdd8dd112dda7fbe6d0a12fc75c7b85613189) | `` plugins/codeium-vim: set `defaultText` for `bin` ``                      |
| [`0d230038`](https://github.com/nix-community/nixvim/commit/0d23003878d2df87647667e96450bfc39b102c21) | `` plugins/dap-python: set `defaultText` for `adapterPythonPath` ``         |
| [`30c2292b`](https://github.com/nix-community/nixvim/commit/30c2292b293e31f419ea52a715abe21ac21e6873) | `` ci/update-other: use a job matrix ``                                     |
| [`5121c309`](https://github.com/nix-community/nixvim/commit/5121c309b37ab2c8d884d18711d53fc7bda8ff77) | `` ci/update-other: remove redundant condition ``                           |
| [`91e2e6fa`](https://github.com/nix-community/nixvim/commit/91e2e6fa032ad4906c2e48c06d96474a08f3f94f) | `` ci/update-other: pass `--repo` to `gh` ``                                |
| [`4751cb55`](https://github.com/nix-community/nixvim/commit/4751cb55f745150152d6e4999f99f297007b8352) | `` docs/user-guide: Add an entry for collisions with combinePlugins ``      |
| [`086c154c`](https://github.com/nix-community/nixvim/commit/086c154cc0ad7bca758b656f5fef7362a61d59ec) | `` generated: Updated rust-analyzer.nix ``                                  |
| [`ea02d3e1`](https://github.com/nix-community/nixvim/commit/ea02d3e187a5c988c79f28d7935a82ee2cef9af2) | `` flake.lock: Update ``                                                    |