### PR TITLE
chore(flake/nixpkgs): `0aa47554` -> `852ff1d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737632463,
-        "narHash": "sha256-38J9QfeGSej341ouwzqf77WIHAScihAKCt8PQJ+NH28=",
+        "lastModified": 1737885589,
+        "narHash": "sha256-Zf0hSrtzaM1DEz8//+Xs51k/wdSajticVrATqDrfQjg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0aa475546ed21629c4f5bbf90e38c846a99ec9e9",
+        "rev": "852ff1d9e153d8875a83602e03fdef8a63f0ecf8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`173cc4d4`](https://github.com/NixOS/nixpkgs/commit/173cc4d47099a0de48a45cb04bad0a38b7fcad04) | `` todiff: remove ``                                                                |
| [`a51f81e5`](https://github.com/NixOS/nixpkgs/commit/a51f81e58f2d42becb75417466ad92f180407a7a) | `` buildpack: 0.36.2 -> 0.36.4 ``                                                   |
| [`1586c4b1`](https://github.com/NixOS/nixpkgs/commit/1586c4b142e64b383178ee26884fb7d2a5afcfef) | `` ardour: bump c++ standard  to c++17 ``                                           |
| [`d15e6703`](https://github.com/NixOS/nixpkgs/commit/d15e670379b81c860fd3377cd6afaadd008f8ad5) | `` lock: 1.3.8 -> 1.3.9 ``                                                          |
| [`7c251e2b`](https://github.com/NixOS/nixpkgs/commit/7c251e2b5fda2b42c3ff2983fdcc9eac82f2ced6) | `` Revert "pkgs/top-level: make package sets composable" ``                         |
| [`a9f3d45f`](https://github.com/NixOS/nixpkgs/commit/a9f3d45fb167a6da686fcf6f8e06758d28ef331c) | `` stubby: fix build on non-Linux ``                                                |
| [`ed2db2cd`](https://github.com/NixOS/nixpkgs/commit/ed2db2cdf05f552a108020864adf7615412d8bbd) | `` blade-formatter: 1.42.0 -> 1.42.1 ``                                             |
| [`d5a88413`](https://github.com/NixOS/nixpkgs/commit/d5a884134272d7c8ba7600a84b165df7e3ce1825) | `` aerc: 0.19.0 -> 0.20.0 ``                                                        |
| [`36b75458`](https://github.com/NixOS/nixpkgs/commit/36b75458cf632d6b854037050e061579c472b882) | `` cargo-tauri: 2.2.2 -> 2.2.3 ``                                                   |
| [`db9ef3e6`](https://github.com/NixOS/nixpkgs/commit/db9ef3e66bfd8b2347aa477abacce436dbeac474) | `` linuxPackages_latest.nvidiaPackages.latest: fix fbdev on 6.13 ``                 |
| [`668d9558`](https://github.com/NixOS/nixpkgs/commit/668d9558b4513be25a3edc7db0814706c0b4e246) | `` mattermost: fix update script attributes ``                                      |
| [`0e8b2d82`](https://github.com/NixOS/nixpkgs/commit/0e8b2d828d911d3c61f727e0a0a97ddea266db8b) | `` handlr-regex: 0.12.0 -> 0.12.1 ``                                                |
| [`432c7e10`](https://github.com/NixOS/nixpkgs/commit/432c7e10d722a4914c0645f0c6a46e27d392d338) | `` epsonscan: minor refactoring ``                                                  |
| [`614404df`](https://github.com/NixOS/nixpkgs/commit/614404df3e643f38102b662b8c53f296d41de384) | `` nixos/gdomap: fix eval ``                                                        |
| [`25245681`](https://github.com/NixOS/nixpkgs/commit/25245681972fb5e186a5c9d7d0eabc6fef5f3733) | `` headscale: 0.24.0 -> 0.24.1 ``                                                   |
| [`9d71dc70`](https://github.com/NixOS/nixpkgs/commit/9d71dc7005c4d2b601bf2f5343746d57e89c25a3) | `` nixos/pixelfed: bump php version ``                                              |
| [`a5ff9f55`](https://github.com/NixOS/nixpkgs/commit/a5ff9f5558169a67571b7d576060f86a2622fccd) | `` pixelfed: 0.12.3 -> 0.12.4 ``                                                    |
| [`ed3c6584`](https://github.com/NixOS/nixpkgs/commit/ed3c6584a476e75c972fc19a7f2f04bdffd8217a) | `` stylelint: 16.13.0 -> 16.14.0 ``                                                 |
| [`329bbc7a`](https://github.com/NixOS/nixpkgs/commit/329bbc7aeece310d893549efb2ad525f574c8240) | `` libdigidocpp: 4.0.0 -> 4.1.0 ``                                                  |
| [`fdbbb617`](https://github.com/NixOS/nixpkgs/commit/fdbbb617af0bf2948218db823aa6b4f99b31c014) | `` got: 0.106 -> 0.108 ``                                                           |
| [`437e8110`](https://github.com/NixOS/nixpkgs/commit/437e81102f1fd010d5683cda019359bc92d2d572) | `` bpftrace: remove llvm version patch ``                                           |
| [`9be0d585`](https://github.com/NixOS/nixpkgs/commit/9be0d5856afdc4ccfcefbfbf78bae24993059566) | `` maintainers: remove aucub ``                                                     |
| [`37d3f041`](https://github.com/NixOS/nixpkgs/commit/37d3f041d17a36aec1af5f2f0ec69d2d1672b3a0) | `` windterm: remove aucub from maintainers ``                                       |
| [`adf60b98`](https://github.com/NixOS/nixpkgs/commit/adf60b985518345df93849f15fbb239427c43fc2) | `` waveterm: remove aucub from maintainers ``                                       |
| [`9ca1587a`](https://github.com/NixOS/nixpkgs/commit/9ca1587ac0f112a294e703d0927b13d41bf00ecd) | `` venera: remove aucub from maintainers ``                                         |
| [`3da8734f`](https://github.com/NixOS/nixpkgs/commit/3da8734f23c57106c4cef2825fb36b97f7cc80d6) | `` v2rayn: remove aucub from maintainers ``                                         |
| [`e26c94dd`](https://github.com/NixOS/nixpkgs/commit/e26c94ddbbc9db5b304547b056dcba20fb8a5ee3) | `` sonusmix: remove aucub from maintainers ``                                       |
| [`cb5e3533`](https://github.com/NixOS/nixpkgs/commit/cb5e35333313b3c1a034d26dfb403106310dc4d3) | `` sly: remove aucub from maintainers ``                                            |
| [`d7a46af7`](https://github.com/NixOS/nixpkgs/commit/d7a46af77086c3ef9ad472625b80d4b253e376a0) | `` simple-live-app: remove aucub from maintainers ``                                |
| [`56d96ce4`](https://github.com/NixOS/nixpkgs/commit/56d96ce4aa404493471fc01b49f5c733d9201880) | `` saber: remove aucub from maintainers ``                                          |
| [`8f05c5c8`](https://github.com/NixOS/nixpkgs/commit/8f05c5c8c9d42482fcc568d6b187807f590983be) | `` refine: remove aucub from maintainers ``                                         |
| [`dc9a20eb`](https://github.com/NixOS/nixpkgs/commit/dc9a20eb81c2ef079dd1cdecb7e62710c6e3d067) | `` pilipalax: remove aucub from maintainers ``                                      |
| [`480a2199`](https://github.com/NixOS/nixpkgs/commit/480a2199498583cfa1b2fcd58ee385a8542680fc) | `` pdfium-binaries: remove aucub from maintainers ``                                |
| [`2315b9d7`](https://github.com/NixOS/nixpkgs/commit/2315b9d7aa4b30e071cab878900b8becebc5cc6c) | `` oneanime: remove aucub from maintainers ``                                       |
| [`04c0b3b9`](https://github.com/NixOS/nixpkgs/commit/04c0b3b96f602c72ef5d68845aa52b8981005242) | `` navicat-premium: remove aucub from maintainers ``                                |
| [`e4904762`](https://github.com/NixOS/nixpkgs/commit/e4904762c46cae6241bd7c52f4f0e9ca6645ea4a) | `` mihomo-party: remove aucub from maintainers ``                                   |
| [`a62f4bf1`](https://github.com/NixOS/nixpkgs/commit/a62f4bf10a935ba1c04af1172152db2a2d572a0d) | `` marble-shell-theme: remove aucub from maintainers ``                             |
| [`10a3e861`](https://github.com/NixOS/nixpkgs/commit/10a3e8613d45cf9a1e740d0a9f00aa3317dd486a) | `` mangayomi: remove aucub from maintainers ``                                      |
| [`8f139ded`](https://github.com/NixOS/nixpkgs/commit/8f139dedabd807f54ae534b7dce9baf9d6815917) | `` linux-wallpaperengine: remove aucub from maintainers ``                          |
| [`506929f4`](https://github.com/NixOS/nixpkgs/commit/506929f453544bd9d8dee68e9f4144bf52a50336) | `` keyguard: remove aucub from maintainers ``                                       |
| [`7b283d2b`](https://github.com/NixOS/nixpkgs/commit/7b283d2b51483ce852b82fd191bbcfa57bceaeac) | `` kazumi: remove aucub from maintainers ``                                         |
| [`b9609244`](https://github.com/NixOS/nixpkgs/commit/b9609244261107665e20bda8beb618e134c78269) | `` jhentai: remove aucub from maintainers ``                                        |
| [`f267c6d2`](https://github.com/NixOS/nixpkgs/commit/f267c6d2a9eac0e1b02b05692e4c90d73f3223bc) | `` hiddify-app: remove aucub from maintainers ``                                    |
| [`cf2e79a3`](https://github.com/NixOS/nixpkgs/commit/cf2e79a3152ed4813b05c8449375d529de68d632) | `` harmony-music: remove aucub from maintainers ``                                  |
| [`61edcdd5`](https://github.com/NixOS/nixpkgs/commit/61edcdd5d1e1994ef762997cfb2769f6917fb469) | `` gui-for-singbox: remove aucub from maintainers ``                                |
| [`8d2d8d91`](https://github.com/NixOS/nixpkgs/commit/8d2d8d91f8e90f9eb0cf0d5cc7d9462fe2e6f40c) | `` gui-for-clash: remove aucub from maintainers ``                                  |
| [`fa6dec27`](https://github.com/NixOS/nixpkgs/commit/fa6dec277feb3ac98ffc2deb6252559b2455b6d4) | `` gopeed: remove aucub from maintainers ``                                         |
| [`c29d3347`](https://github.com/NixOS/nixpkgs/commit/c29d3347095e72cafd40f8bb1c01f9971c7dd597) | `` flclash: remove aucub from maintainers ``                                        |
| [`af19eea9`](https://github.com/NixOS/nixpkgs/commit/af19eea9104779524b1ad203eb0420133edbae95) | `` devtoolbox: remove aucub from maintainers ``                                     |
| [`039d942c`](https://github.com/NixOS/nixpkgs/commit/039d942c7839ec341747df285fa8abf1adf2770f) | `` deskflow: remove aucub from maintainers ``                                       |
| [`2ebdb929`](https://github.com/NixOS/nixpkgs/commit/2ebdb9297137f180a0fa8826cca59115aa05d73d) | `` clash-rs: remove aucub from maintainers ``                                       |
| [`d656f8cc`](https://github.com/NixOS/nixpkgs/commit/d656f8ccf56edc1e91aab228ea57fa950a15bbd3) | `` butterfly: remove aucub from maintainers ``                                      |
| [`ff8f821b`](https://github.com/NixOS/nixpkgs/commit/ff8f821bc804bdd6b8f2c38163b00a1898925d35) | `` bloomeetunes: remove aucub from maintainers ``                                   |
| [`be8536f0`](https://github.com/NixOS/nixpkgs/commit/be8536f09a26e94d458290cdda8c2c4c62d59f46) | `` bitcomet: remove aucub from maintainers ``                                       |
| [`855c873b`](https://github.com/NixOS/nixpkgs/commit/855c873b6e123a1182bb9e3ea3063805f0df241b) | `` ayugram-desktop: remove aucub from maintainers ``                                |
| [`428fdfac`](https://github.com/NixOS/nixpkgs/commit/428fdface1e9c4cf457cbd8474801e840039cbf2) | `` bitrise: 2.25.0 -> 2.26.1 ``                                                     |
| [`fcbacedb`](https://github.com/NixOS/nixpkgs/commit/fcbacedbf22cc3d195f924fd66de8febff5692b5) | `` gnustep: propagate dependencies ``                                               |
| [`4d96ec04`](https://github.com/NixOS/nixpkgs/commit/4d96ec04543aa0885a5e12b86eb3ccfd93292c68) | `` gnustep: move GNUstep packages to by-name ``                                     |
| [`df5ec1a2`](https://github.com/NixOS/nixpkgs/commit/df5ec1a2e07ba61de62dd9401222e1f282daa340) | `` nixos/paperless: #242084 follow up to fix defaultText (#373472) ``               |
| [`ad2c044b`](https://github.com/NixOS/nixpkgs/commit/ad2c044b6293b7e01f0b1681ca3a2c3031aaf6a0) | `` python312Packages.cymem: 2.0.10 -> 2.0.11 ``                                     |
| [`9a08314a`](https://github.com/NixOS/nixpkgs/commit/9a08314a190d08a26ba2c028f1e7a55ba7d27a04) | `` dotslash: 0.4.3 -> 0.5.0 ``                                                      |
| [`1471bf60`](https://github.com/NixOS/nixpkgs/commit/1471bf60c8b8c71bcc5a33469b9e170ed494a8a2) | `` pack: 0.36.2 -> 0.36.4 ``                                                        |
| [`f0732a73`](https://github.com/NixOS/nixpkgs/commit/f0732a73d628c4762865f7b4bc09de3c26eecf3c) | `` lucenepp: fix darwin build ``                                                    |
| [`1eb49447`](https://github.com/NixOS/nixpkgs/commit/1eb49447c587d0c951d89dcfba1b4d051461dde0) | `` tbtools: init at v0.5.0 (#374988) ``                                             |
| [`b2492b37`](https://github.com/NixOS/nixpkgs/commit/b2492b3777bcee677cf75237229898e3356eaa03) | `` gitlab-ci-local: 4.56.2 -> 4.57.0 ``                                             |
| [`eb454c6e`](https://github.com/NixOS/nixpkgs/commit/eb454c6e989b64b238dd1cc21d420e457abb0771) | `` got: use nix-update-script ``                                                    |
| [`36cb620f`](https://github.com/NixOS/nixpkgs/commit/36cb620fb6ece5bf2f8ec521fdedb72a94f4d2e8) | `` got: format ``                                                                   |
| [`5c64063e`](https://github.com/NixOS/nixpkgs/commit/5c64063e8478e736e321a5cc375a7c3595bc1078) | `` vimPlugins.cord-nvim: 0-unstable-2024-12-17 -> 1.0.0 ``                          |
| [`2be3693b`](https://github.com/NixOS/nixpkgs/commit/2be3693b868f000f72dbc2442980b8a5ca2de622) | `` vaultwarden-vault: 2024.6.2c -> 2025.1.1 ``                                      |
| [`c7d980a7`](https://github.com/NixOS/nixpkgs/commit/c7d980a73eb6a67e9cc1d1ee7f816773419692c3) | `` vaultwarden: 1.32.7 -> 1.33.0 ``                                                 |
| [`2acca93b`](https://github.com/NixOS/nixpkgs/commit/2acca93befe5cfef5e1fbde08f5068d6d312bfbf) | `` pkgs/top-level: fix composing "native cross" package sets ``                     |
| [`69775e2d`](https://github.com/NixOS/nixpkgs/commit/69775e2deb4be02ec34c8055f7c005867fce5f4c) | `` pkgs/top-level: refactor mkHybridPkgs ``                                         |
| [`ba6262f2`](https://github.com/NixOS/nixpkgs/commit/ba6262f2ebb78ea506a98bfc6e4e857f8047e32d) | `` pkgs/top-level: refactor mkCrossPkgs ``                                          |
| [`01a02e41`](https://github.com/NixOS/nixpkgs/commit/01a02e41f7ba456172eed105511c94a27a8c3848) | `` pkgs/top-level: make package sets composable ``                                  |
| [`eec21001`](https://github.com/NixOS/nixpkgs/commit/eec21001b0f7961cb84fe40512e8238ec3effb87) | `` nixos/nixpkgs: pass original system args instead of elaborated ``                |
| [`b75355cc`](https://github.com/NixOS/nixpkgs/commit/b75355ccc317b8562c4a7a66373070f210f6ed72) | `` pkgs/test/top-level: add tests for package set composability ``                  |
| [`bb199323`](https://github.com/NixOS/nixpkgs/commit/bb1993232d1a03128793a625305291ff18f800da) | `` squid: add config validation ``                                                  |
| [`3be72f3b`](https://github.com/NixOS/nixpkgs/commit/3be72f3bc292ed52b36805ea7eb47b3ec098d80d) | `` squid: make ipv6 configurable ``                                                 |
| [`ab097402`](https://github.com/NixOS/nixpkgs/commit/ab097402432cd299418eedec90d2bfcca18bdfc7) | `` gitify: 5.17.0 -> 5.18.0 ``                                                      |
| [`da1df294`](https://github.com/NixOS/nixpkgs/commit/da1df2947269159848b062f353e2ab80015c9def) | `` television: 0.9.3 -> 0.9.4 ``                                                    |
| [`941f3d43`](https://github.com/NixOS/nixpkgs/commit/941f3d430aa1d80f17a142dc7dff5a18554de759) | `` xpraWithNvenc: add nvjpeg support ``                                             |
| [`07185129`](https://github.com/NixOS/nixpkgs/commit/071851299f3a5b2880b456e487fd9010011118ae) | `` pkgs/top-level: refactor mkPkgs ``                                               |
| [`3fcedef0`](https://github.com/NixOS/nixpkgs/commit/3fcedef056944942c9d368ea785ecb1fe6ff5f57) | `` pkgs/top-level/stage: refactor moving more generic package sets to the bottom `` |
| [`4e7cc47a`](https://github.com/NixOS/nixpkgs/commit/4e7cc47a2261b3d9270abfa260120dfa3fba3f45) | `` pkgs/top-level: rewrite some outdated comments ``                                |
| [`c33c3066`](https://github.com/NixOS/nixpkgs/commit/c33c3066be8ee4bcb26dc329207c2836fe561df4) | `` oxefmsynth: use the packaged version of `vst2-sdk` ``                            |
| [`0285aa63`](https://github.com/NixOS/nixpkgs/commit/0285aa63477857cfe1d481180bf7ff8117fcbcd8) | `` jackass: use the packaged version of `vst2-sdk` ``                               |
| [`80b19f8e`](https://github.com/NixOS/nixpkgs/commit/80b19f8e497af6b33e3cd53f84e801abbcdc9f43) | `` bespokesynth: use the packaged version of `vst2-sdk` ``                          |
| [`eee2e78a`](https://github.com/NixOS/nixpkgs/commit/eee2e78a74d7c0a8000a40dd93a16ad4f6855da8) | `` airwindows: use the packaged copy of `vst2-sdk` ``                               |
| [`c6f20632`](https://github.com/NixOS/nixpkgs/commit/c6f20632f5aa3e1a0aae148d3721c9cd136b524b) | `` airwave.meta: min-scope `with lib` ``                                            |
| [`b9841867`](https://github.com/NixOS/nixpkgs/commit/b98418678dc6d0e69c584511266980d7fe984ee8) | `` airwave: use the packaged version of `vst2-sdk` ``                               |
| [`c8721658`](https://github.com/NixOS/nixpkgs/commit/c8721658d50e7792ee2769f50069db84d94c8402) | `` vst2-sdk: init at 2018-06-11 ``                                                  |
| [`fce0852e`](https://github.com/NixOS/nixpkgs/commit/fce0852e77262497a5a8cd9d398b9a9e4fa65b2c) | `` vkquake: install a desktop file ``                                               |
| [`272fb5ba`](https://github.com/NixOS/nixpkgs/commit/272fb5babf63d95410023cf6cd214123138c77cb) | `` nixos/tests/incus: extend check timeouts ``                                      |
| [`b457d4c7`](https://github.com/NixOS/nixpkgs/commit/b457d4c76beace1b85f9edacc3a4103c328ed73b) | `` incus: 6.8.0 -> 6.9.0 ``                                                         |
| [`30c355bd`](https://github.com/NixOS/nixpkgs/commit/30c355bde01a4e4439c17b853c74a952a45e2891) | `` chawan: fix search path patching ``                                              |
| [`e6c76c05`](https://github.com/NixOS/nixpkgs/commit/e6c76c051f96f3f0991faad5dc78fea86adf35f9) | `` gui-for-clash: fix basepath patching ``                                          |
| [`dcc754b5`](https://github.com/NixOS/nixpkgs/commit/dcc754b57cd434ba9769d878cabdcaa1320a1041) | `` linux: remove linuxPackages.zfs alias ``                                         |
| [`ce1ba13c`](https://github.com/NixOS/nixpkgs/commit/ce1ba13c718372ba10ebd217f1b9c330ab00ce1a) | `` gui-for-singbox: fix basepath patching ``                                        |
| [`0790597f`](https://github.com/NixOS/nixpkgs/commit/0790597f4dd8febcd9355cae227a4d119c06aa8b) | `` pik: 0.14.0 -> 0.15.0 ``                                                         |