### PR TITLE
chore(flake/nixvim): `d7df5832` -> `8e5422bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737832569,
-        "narHash": "sha256-VkK73VRVgvSQOPw9qx9HzvbulvUM9Ae4nNd3xNP+pkI=",
+        "lastModified": 1737914312,
+        "narHash": "sha256-PBF4R+yQt5Sls7CsA9Miwx28XtOP/yqaqejZ3RKSes0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d7df58321110d3b0e12a829bbd110db31ccd34b1",
+        "rev": "8e5422bf3e76f410b97d2da640d0829e87657de9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`8e5422bf`](https://github.com/nix-community/nixvim/commit/8e5422bf3e76f410b97d2da640d0829e87657de9) | `` plugins/base16: fix packPathName ``                                                       |
| [`63d9bb0d`](https://github.com/nix-community/nixvim/commit/63d9bb0d774f548261effa290c5d4456352f0637) | `` plugins/lsp: mark typst_lsp as unpackaged as the package has been removed from nixpkgs `` |
| [`97a58e94`](https://github.com/nix-community/nixvim/commit/97a58e944782a8717180090fee29cdb4f9426c2b) | `` flake.lock: Update ``                                                                     |