### PR TITLE
chore(flake/nixvim): `8e5422bf` -> `af4483c0`

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -40,10 +40,8 @@
       enable = true;
       settings.options.diagnostics = lib.mkIf config.plugins.lsp.enable "nvim_lsp";
     };
-    dap = {
-      enable = true;
-      extensions.dap-ui.enable = true;
-    };
+    dap.enable = true;
+    dap-ui.enable = true;
     dressing.enable = true;
     gitsigns.enable = true;
     guess-indent.enable = true;

--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737914312,
-        "narHash": "sha256-PBF4R+yQt5Sls7CsA9Miwx28XtOP/yqaqejZ3RKSes0=",
+        "lastModified": 1737995534,
+        "narHash": "sha256-in2EtlH84FJ5+7l2vBWhUiknmDFAHTuHIPSBiMhICyw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8e5422bf3e76f410b97d2da640d0829e87657de9",
+        "rev": "af4483c025ecf02ba36b2013eed0062ccd629809",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`af4483c0`](https://github.com/nix-community/nixvim/commit/af4483c025ecf02ba36b2013eed0062ccd629809) | `` docs/lazy-loading: add extra examples ``               |
| [`a879adb2`](https://github.com/nix-community/nixvim/commit/a879adb2088d3b20819782a818bf609c7373744b) | `` dev/list-plugins: fix dap state ``                     |
| [`32aa73af`](https://github.com/nix-community/nixvim/commit/32aa73af4742dce6532abe7a181370290fe8a727) | `` plugins/dap-virtual-text: migrate to mkNeovimPlugin `` |
| [`9eae5db2`](https://github.com/nix-community/nixvim/commit/9eae5db29abfbe1f737ad635519b010216f3af92) | `` plugins/dap-ui: migrate to mkNeovimPlugin ``           |
| [`a70168e0`](https://github.com/nix-community/nixvim/commit/a70168e0faa9648a8ac7785fd4f422aeff770617) | `` plugins/dap-python: migrate to mkNeovimPlugin ``       |
| [`6ff71272`](https://github.com/nix-community/nixvim/commit/6ff71272915b99218de615ad25fce33d10c79b84) | `` plugins/dap-go: migrate to mkNeovimPlugin ``           |
| [`4d1bd375`](https://github.com/nix-community/nixvim/commit/4d1bd375c7b2d69a05e12d9d41629da09ffaefa8) | `` plugins/dap: migrate to mkNeovimPlugin ``              |
| [`216ae2bf`](https://github.com/nix-community/nixvim/commit/216ae2bf40777d907953ae8d273268e615f2a7ea) | `` plugins/dap: remove helpers ``                         |
| [`e48dda4f`](https://github.com/nix-community/nixvim/commit/e48dda4fe4ae7ac22ba718467202f5785a7ee2fc) | `` plugins/dap: remove with lib ``                        |
| [`fe2789e4`](https://github.com/nix-community/nixvim/commit/fe2789e40730039cba4e5f3e9770fc48d254adb8) | `` flake.lock: Update ``                                  |