### PR TITLE
chore(flake/nixvim): `af4483c0` -> `eeafe2a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737995534,
-        "narHash": "sha256-in2EtlH84FJ5+7l2vBWhUiknmDFAHTuHIPSBiMhICyw=",
+        "lastModified": 1738106190,
+        "narHash": "sha256-woDlUpfK4n1znQfGREKDLMVOQ4JZo7L6YY/sTPZGw0g=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "af4483c025ecf02ba36b2013eed0062ccd629809",
+        "rev": "eeafe2a7153197982ccd6ad6678192bca1df446e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`eeafe2a7`](https://github.com/nix-community/nixvim/commit/eeafe2a7153197982ccd6ad6678192bca1df446e) | `` plugins/zotcite: init ``                                                                      |
| [`b6c0cfab`](https://github.com/nix-community/nixvim/commit/b6c0cfab819e351b230fe0ac019e7735e88a53c5) | `` plugins/zotcite: init ``                                                                      |
| [`818c2906`](https://github.com/nix-community/nixvim/commit/818c2906e9a51082da7f2ec70565702d622c2987) | `` ci/update: cleanup summary step ``                                                            |
| [`62a0dfbe`](https://github.com/nix-community/nixvim/commit/62a0dfbe5dceddc6901a71f9b7ad1712279ac8f9) | `` ci/update: cancel gracefully ``                                                               |
| [`4652e38e`](https://github.com/nix-community/nixvim/commit/4652e38ee679c90f484e46d1bdd22831329a6863) | `` ci/update: add input checkbox for checking `nixpkgs` was bumped ``                            |
| [`c3d95240`](https://github.com/nix-community/nixvim/commit/c3d95240c46f36a71fe6d15f74da4a2a11cf94e1) | `` ci/update: check against base branch if no PR is open ``                                      |
| [`635adc07`](https://github.com/nix-community/nixvim/commit/635adc07fa3c09c0c9aa9e43ebb0874abe002292) | `` flake.lock: Update ``                                                                         |
| [`a64048e9`](https://github.com/nix-community/nixvim/commit/a64048e9f5f323c9bc5de29e759ff0531a114604) | `` Fix: example of plugins.bufferline.settings.options.get_element_icon used a wrong variable `` |
| [`8b09c4a8`](https://github.com/nix-community/nixvim/commit/8b09c4a8294f520deec07597864cc4d87a0fd4aa) | `` plugins/clangd-extensions: remove inlay_hints option ``                                       |