### PR TITLE
chore(flake/nixvim): `eeafe2a7` -> `f584d1d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738106190,
-        "narHash": "sha256-woDlUpfK4n1znQfGREKDLMVOQ4JZo7L6YY/sTPZGw0g=",
+        "lastModified": 1738188154,
+        "narHash": "sha256-2C0rEZ1l/X3nCwaQtulTXkmREZ/46TdWLYv1+BiCx3U=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "eeafe2a7153197982ccd6ad6678192bca1df446e",
+        "rev": "f584d1d70d36cd29d45abce91776f8425398a97f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`f584d1d7`](https://github.com/nix-community/nixvim/commit/f584d1d70d36cd29d45abce91776f8425398a97f) | `` docs/mdbook: support `visible = "shallow"` ``                 |
| [`2f5374c3`](https://github.com/nix-community/nixvim/commit/2f5374c3dcd06c750c36798bce6bccdf8a25bc89) | `` plugins/lexima: init ``                                       |
| [`1a5f1b43`](https://github.com/nix-community/nixvim/commit/1a5f1b43930807e1faa30c6fba814f8f2cfa3c37) | `` lib/plugins: introduce `mkMetaModule` ``                      |
| [`e908e344`](https://github.com/nix-community/nixvim/commit/e908e344f4cd7b3eb629b93e8af312888f3ee681) | `` treewide: use boolean comparison to simplify the code base `` |
| [`5066c715`](https://github.com/nix-community/nixvim/commit/5066c71549b17042dfdbbf0faae07688c971cdae) | `` misc/statix: disable the "bool_comparison" lint ``            |
| [`d4170423`](https://github.com/nix-community/nixvim/commit/d41704233a8d863843590571dda386b15ade1e27) | `` misc: delete useless statix.toml config file ``               |
| [`ce82e585`](https://github.com/nix-community/nixvim/commit/ce82e5859d8f5cdc72e5b4137c5355efec16450a) | `` treewide: use mkAssertions where possible ``                  |
| [`12e658ec`](https://github.com/nix-community/nixvim/commit/12e658eca85e149a23d55ec48078367928c4c544) | `` treewide: use mkWarnings where possible ``                    |
| [`abba4af1`](https://github.com/nix-community/nixvim/commit/abba4af10b52ed7f9c02b615dfab487e24a52db3) | `` lib/utils: fix typo in example of mkAssertions ``             |