### PR TITLE
chore(flake/nixvim): `f584d1d7` -> `93df574b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738188154,
-        "narHash": "sha256-2C0rEZ1l/X3nCwaQtulTXkmREZ/46TdWLYv1+BiCx3U=",
+        "lastModified": 1738272272,
+        "narHash": "sha256-zVw0JrvXJ29HnjEsNUInqi5Zw+J8QLHk2EuPN12dTXc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "f584d1d70d36cd29d45abce91776f8425398a97f",
+        "rev": "93df574b42928d631d31fe312cadb3899eb5b1bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                 |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`93df574b`](https://github.com/nix-community/nixvim/commit/93df574b42928d631d31fe312cadb3899eb5b1bd) | `` ci/update: fix create pr step not having `$pr_num` ``                |
| [`7f5dc96b`](https://github.com/nix-community/nixvim/commit/7f5dc96b83e915e84029c0dc6ce4e2c4e59a9cad) | `` ci/update: re-apply manual commits from open PR ``                   |
| [`f9904d22`](https://github.com/nix-community/nixvim/commit/f9904d22df5a15d280bd6313bcec6259097a8a9c) | `` ci/update: don't request review on the PR ``                         |
| [`f0282018`](https://github.com/nix-community/nixvim/commit/f028201847f771802c3b6fe574beb9d0b854c91a) | `` ci/update: don't assign a team to the PR ``                          |
| [`8bf206eb`](https://github.com/nix-community/nixvim/commit/8bf206eb751ba33daf0f62b7c782e3f90ec19295) | `` ci/update: drop dependency on peter-evans/create-pull-request ``     |
| [`e4ed227f`](https://github.com/nix-community/nixvim/commit/e4ed227f99be42cd0ce28b6ae0c85c306ef70d40) | `` plugins/gitsigns: remove deprecated option 'show_deleted' ``         |
| [`d997bec0`](https://github.com/nix-community/nixvim/commit/d997bec044b0c13440e4fd4354917b91207db69d) | `` plugins/lsp: add oxlint package ``                                   |
| [`d9c8897c`](https://github.com/nix-community/nixvim/commit/d9c8897cbc7330c77a12b4ba4cbf4012cd03f6cb) | `` generated: Updated lspconfig-servers.json ``                         |
| [`8efa326c`](https://github.com/nix-community/nixvim/commit/8efa326c74c41e67f1635304bcd81e17a4adec71) | `` flake.lock: Update ``                                                |
| [`bffee37f`](https://github.com/nix-community/nixvim/commit/bffee37f57dc6e3b04ed574f8dc2aaf9dc9769b8) | `` ci/update: use `if then else` for setting `cancelled` step output `` |