### PR TITLE
chore(flake/nixvim): `93df574b` -> `c75e4ea3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738272272,
-        "narHash": "sha256-zVw0JrvXJ29HnjEsNUInqi5Zw+J8QLHk2EuPN12dTXc=",
+        "lastModified": 1738366771,
+        "narHash": "sha256-nyEBrP5t1g4vmy7YBkiGaIu19eG8zV3T4IQLQbJsVU8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "93df574b42928d631d31fe312cadb3899eb5b1bd",
+        "rev": "c75e4ea37f25ec98aa6f2035e03e748e7369662c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`c75e4ea3`](https://github.com/nix-community/nixvim/commit/c75e4ea37f25ec98aa6f2035e03e748e7369662c) | `` plugins/lean: migrate to mkNeovimPlugin ``                                   |
| [`0e92aaf3`](https://github.com/nix-community/nixvim/commit/0e92aaf3f2f0c1b6789a408584486ff4f03abde9) | `` plugins/blink-cmp: support raw lua for settings.sources.providers.enabled `` |
| [`a2f01876`](https://github.com/nix-community/nixvim/commit/a2f01876f721d3361f33845397de77ca19e5734a) | `` lib: Harmonize package options which may not exist in nixpkgs ``             |
| [`eb611349`](https://github.com/nix-community/nixvim/commit/eb611349a70df9f87001752aa7c49e9672099415) | `` flake.lock: Update ``                                                        |