### PR TITLE
chore(flake/nixvim): `c75e4ea3` -> `2b039331`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738366771,
-        "narHash": "sha256-nyEBrP5t1g4vmy7YBkiGaIu19eG8zV3T4IQLQbJsVU8=",
+        "lastModified": 1738451863,
+        "narHash": "sha256-JXA/ffSl42rZjqUgBq1I5C3NVYrFaTw8pGHca54QMis=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c75e4ea37f25ec98aa6f2035e03e748e7369662c",
+        "rev": "2b03933101012cc5830d5dd7167d4544902a51b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`2b039331`](https://github.com/nix-community/nixvim/commit/2b03933101012cc5830d5dd7167d4544902a51b1) | `` plugins/clipboard-image: migrate to mkneovimplugin `` |
| [`3aabd321`](https://github.com/nix-community/nixvim/commit/3aabd321817cfcfce14690badf79c9bf1901b58a) | `` plugins/cursorline: migrate to mkNeovimPlugin ``      |
| [`ccd00929`](https://github.com/nix-community/nixvim/commit/ccd009298879f555b2a051fca02911b2a90a7b96) | `` plugins/autoclose: migrate to mkNeovimPlugin ``       |
| [`8f8f5024`](https://github.com/nix-community/nixvim/commit/8f8f50243ea803304b1bd04aa56bd736fe2c28eb) | `` plugins/java: init ``                                 |
| [`e75f0aac`](https://github.com/nix-community/nixvim/commit/e75f0aac9071ddbb7ff7944ec47b7aff647d5227) | `` tests/texpresso: disable test ``                      |
| [`a86d1150`](https://github.com/nix-community/nixvim/commit/a86d11507f1c5b6396b32d9b8e3bb436d6975a62) | `` flake.lock: Update ``                                 |