### PR TITLE
chore(flake/nixvim): `2b039331` -> `c284a509`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738451863,
-        "narHash": "sha256-JXA/ffSl42rZjqUgBq1I5C3NVYrFaTw8pGHca54QMis=",
+        "lastModified": 1738528611,
+        "narHash": "sha256-GRyyVXM/0pYnA8voPGZWTi9zDVkIO9O1fzA8cB4oO50=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2b03933101012cc5830d5dd7167d4544902a51b1",
+        "rev": "c284a509952eee265519674e67e70e73ddcbfd05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`c284a509`](https://github.com/nix-community/nixvim/commit/c284a509952eee265519674e67e70e73ddcbfd05) | `` dev/list-plugins: remove various outdated overrides `` |
| [`56d0c457`](https://github.com/nix-community/nixvim/commit/56d0c4579e022b44a3e324f722fa23a6f4295798) | `` plugins/typescript-tools: use plugin's luaConfig ``    |
| [`b0906aca`](https://github.com/nix-community/nixvim/commit/b0906aca2e5e3bb41602ef968c60c0ae363220b2) | `` plugins/mark-radar: migrate to mkNeovimPlugin ``       |
| [`0827c5cb`](https://github.com/nix-community/nixvim/commit/0827c5cb6caf32f3b917d2fb6c67340435d07f68) | `` plugins/notify: migrate to mkNeovimPlugin ``           |
| [`10ea28ff`](https://github.com/nix-community/nixvim/commit/10ea28fff49ec4f0452b4544a0003b187d38d5f4) | `` plugins/lastplace: migrate to mkNeovimPlugin ``        |
| [`a3eed84e`](https://github.com/nix-community/nixvim/commit/a3eed84e1e62ab399897d8314f7a67892091f47c) | `` flake.lock: Update ``                                  |
| [`8104356a`](https://github.com/nix-community/nixvim/commit/8104356af6536df366eea4b8bcc409320323b959) | `` plugins/startify: options -> settings-options ``       |
| [`e0f838b5`](https://github.com/nix-community/nixvim/commit/e0f838b58da8f0a2458d349d8fb8a57f5013fd29) | `` plugins/neotest: options -> settings-options ``        |
| [`09e857bf`](https://github.com/nix-community/nixvim/commit/09e857bfdd17489b66e3f4ec75ae342938deef2b) | `` plugins/neogit: options -> settings-options ``         |
| [`f6182890`](https://github.com/nix-community/nixvim/commit/f6182890279ed06eb139121db49c8ac1e463821c) | `` dev/list-plugins: remove redundant exclude ``          |
| [`0d160c19`](https://github.com/nix-community/nixvim/commit/0d160c19d6c515eeca6c3620cd3b64534a4bfb97) | `` plugins/obsidian: options -> settings-options ``       |
| [`86cc0386`](https://github.com/nix-community/nixvim/commit/86cc03863f91a959fbc477009eaa8e19a917b68a) | `` plugins/obsidian: move deprecations ``                 |
| [`e68b8e9c`](https://github.com/nix-community/nixvim/commit/e68b8e9c9196a55fccf491b19aa8e8f47ba7ef6b) | `` plugins/obsidian: remove with lib and helpers ``       |