### PR TITLE
chore(flake/nixvim): `c284a509` -> `6288354d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738528611,
-        "narHash": "sha256-GRyyVXM/0pYnA8voPGZWTi9zDVkIO9O1fzA8cB4oO50=",
+        "lastModified": 1738622717,
+        "narHash": "sha256-XSFbbhN8xdr4qKRFbubXJ3vkSusKSnALf69G9fdGPXE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c284a509952eee265519674e67e70e73ddcbfd05",
+        "rev": "6288354d43ada972480cbd10dc7102637eeafc1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`6288354d`](https://github.com/nix-community/nixvim/commit/6288354d43ada972480cbd10dc7102637eeafc1e) | `` plugins/blink-cmp: remove setting warning ``                   |
| [`563ea558`](https://github.com/nix-community/nixvim/commit/563ea5586dc243f1d3ba776b7593a2637b99e691) | `` plugins/blink-cmp: add rawLua support more provider options `` |
| [`e77af9f8`](https://github.com/nix-community/nixvim/commit/e77af9f81b220e46a5dc1f1faa592c10753a46a6) | `` flake.lock: Update ``                                          |