### PR TITLE
chore(flake/nixvim): `6288354d` -> `11a80c1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738622717,
-        "narHash": "sha256-XSFbbhN8xdr4qKRFbubXJ3vkSusKSnALf69G9fdGPXE=",
+        "lastModified": 1738787701,
+        "narHash": "sha256-BJtDKM0143pmBS5cdpyjS2R/AIDLGVP6ooD2yvBSJGo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6288354d43ada972480cbd10dc7102637eeafc1e",
+        "rev": "11a80c1a80b16016ad03e703d1c9dea07f495cb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`11a80c1a`](https://github.com/nix-community/nixvim/commit/11a80c1a80b16016ad03e703d1c9dea07f495cb7) | `` plugins/blink-cmp-dictionary: init ``                 |
| [`2061a9ad`](https://github.com/nix-community/nixvim/commit/2061a9ad95ca320a2bca00de6a9e30dbc5f52d74) | `` plugins/blink-cmp-git: init ``                        |
| [`7d975e35`](https://github.com/nix-community/nixvim/commit/7d975e3598c94c8a75c605cfcfb65dd59741a8a2) | `` plugins/blink-cmp-spell: init ``                      |
| [`859a97bd`](https://github.com/nix-community/nixvim/commit/859a97bd8e54aa7e4fde0439a73dd03cf59a753a) | `` plugins/blink-ripgrep: init ``                        |
| [`d5406e54`](https://github.com/nix-community/nixvim/commit/d5406e546b58bb7f90c1e8aecfbbd6fd74a28ac9) | `` plugins/blink-emoji: init ``                          |
| [`cf01c024`](https://github.com/nix-community/nixvim/commit/cf01c024af844bf89c9b296fc1627abffe038ecf) | `` plugins/blink-copilot: init ``                        |
| [`5281e8c5`](https://github.com/nix-community/nixvim/commit/5281e8c583a5fcdda7ca8373c7032bb9c5219ff3) | `` ci/update: allow disabling re-applying commits ``     |
| [`61fdbe26`](https://github.com/nix-community/nixvim/commit/61fdbe26476b031d407e9b873fffe235ff2b8364) | `` ci/update: fix re-apply commit order ``               |
| [`d709c12c`](https://github.com/nix-community/nixvim/commit/d709c12cdd0cf449415ad8fa627cedb6516588c8) | `` tests/texpresso: re-enable test on darwin ``          |
| [`2d4db5a4`](https://github.com/nix-community/nixvim/commit/2d4db5a41ff044415f7dd81f22e088540ef8fe0c) | `` Revert "tests/texpresso: disable test" ``             |
| [`ba2e2a1f`](https://github.com/nix-community/nixvim/commit/ba2e2a1f694627b17f1a9abe9ec88a500081c359) | `` flake.lock: Update ``                                 |
| [`f99264c1`](https://github.com/nix-community/nixvim/commit/f99264c1fb8e98e0712cdad2744afa8b40661dcc) | `` modules/nixpkgs: don't assign elaborated platforms `` |