### PR TITLE
chore(flake/nixvim): `11a80c1a` -> `5024ef21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738787701,
-        "narHash": "sha256-BJtDKM0143pmBS5cdpyjS2R/AIDLGVP6ooD2yvBSJGo=",
+        "lastModified": 1738844060,
+        "narHash": "sha256-N5aqp83tNnX6X+28CYhieUTHJjNTWyXCMUB4xyvMSO8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "11a80c1a80b16016ad03e703d1c9dea07f495cb7",
+        "rev": "5024ef216f0e5d84adf1da703445de4ca1f8f9fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`5024ef21`](https://github.com/nix-community/nixvim/commit/5024ef216f0e5d84adf1da703445de4ca1f8f9fb) | `` flake.lock: Update ``                                  |
| [`2ecc5359`](https://github.com/nix-community/nixvim/commit/2ecc5359f804bc98901dee0c95999ac3fa308388) | `` plugins/nvim-ufo: Set lsp capabilities ``              |
| [`56e82309`](https://github.com/nix-community/nixvim/commit/56e82309398f3d09eba7d6bc5bf04691c4483556) | `` lib/options: Add `mkEnabledOption` ``                  |
| [`7f2601ad`](https://github.com/nix-community/nixvim/commit/7f2601adc172747647235108a3ab7a07a8d19521) | `` Editorconfig: configure `indent_size` for nix files `` |