### PR TITLE
chore(flake/nixvim): `5024ef21` -> `e7f20a60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738844060,
-        "narHash": "sha256-N5aqp83tNnX6X+28CYhieUTHJjNTWyXCMUB4xyvMSO8=",
+        "lastModified": 1738966895,
+        "narHash": "sha256-OXOh35rTEnFSO4vj/SDMIlDvFPGW0ba1XhZkfx+AlL0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "5024ef216f0e5d84adf1da703445de4ca1f8f9fb",
+        "rev": "e7f20a602f6e08a70045f36c531bc44ba1baed07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`e7f20a60`](https://github.com/nix-community/nixvim/commit/e7f20a602f6e08a70045f36c531bc44ba1baed07) | `` flake: remove unused 'inputs' ``                       |
| [`b5bb7ddf`](https://github.com/nix-community/nixvim/commit/b5bb7ddf8026a7cf564e2b1bc9814eb00d8c4d00) | `` flake.lock: Update ``                                  |
| [`f2f70b43`](https://github.com/nix-community/nixvim/commit/f2f70b4376874b74d9bae0df2d4bfd5292c1499e) | `` blink-cmp: Set lsp capabilities ``                     |
| [`a5147a36`](https://github.com/nix-community/nixvim/commit/a5147a36f9d3df06fd1246cf5a089678cbf59d3a) | `` plugins/schemastore: set the correct jsonls default `` |