### PR TITLE
chore(flake/treefmt-nix): `64dbb922` -> `4f09b473`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738680491,
-        "narHash": "sha256-8X7tR3kFGkE7WEF5EXVkt4apgaN85oHZdoTGutCFs6I=",
+        "lastModified": 1738953846,
+        "narHash": "sha256-yrK3Hjcr8F7qS/j2F+r7C7o010eVWWlm4T1PrbKBOxQ=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "64dbb922d51a42c0ced6a7668ca008dded61c483",
+        "rev": "4f09b473c936d41582dd744e19f34ec27592c5fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                        |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`4f09b473`](https://github.com/numtide/treefmt-nix/commit/4f09b473c936d41582dd744e19f34ec27592c5fd) | `` sqlfluff: disable default dialect (#310) `` |