### PR TITLE
chore(flake/nixpkgs): `550e11f2` -> `64e75cd4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738824222,
-        "narHash": "sha256-U3SNq+waitGIotmgg/Et3J7o4NvUtP2gb2VhME5QXiw=",
+        "lastModified": 1739214665,
+        "narHash": "sha256-26L8VAu3/1YRxS8MHgBOyOM8xALdo6N0I04PgorE7UM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "550e11f27ba790351d390d9eca3b80ad0f0254e7",
+        "rev": "64e75cd44acf21c7933d61d7721e812eac1b5a0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`64e75cd4`](https://github.com/NixOS/nixpkgs/commit/64e75cd44acf21c7933d61d7721e812eac1b5a0a) | `` oh-my-zsh: Fix template (#380911) ``                                                 |
| [`f580aca5`](https://github.com/NixOS/nixpkgs/commit/f580aca59ba9fbd25dc6515c382b4f56d5441347) | `` _389-ds-base: fix cargo deps vendoring ``                                            |
| [`017ab730`](https://github.com/NixOS/nixpkgs/commit/017ab730c842f3c458e0b46fa53632167dd1e043) | `` _389-ds-base: 3.0.5 -> 3.1.2 ``                                                      |
| [`43a989e6`](https://github.com/NixOS/nixpkgs/commit/43a989e6b1c301e64c7224dd35d652cd14e95c8c) | `` saucectl: 0.192.0 -> 0.193.0 ``                                                      |
| [`ac794b1c`](https://github.com/NixOS/nixpkgs/commit/ac794b1c1338ad6ab3b2054a073f2c4ce2abd3a3) | `` omnictl: 0.46.0 -> 0.46.3 ``                                                         |
| [`829df5c4`](https://github.com/NixOS/nixpkgs/commit/829df5c4de86583d28ca050ac17650bd93655771) | `` kustomize-sops: 4.3.2 -> 4.3.3 ``                                                    |
| [`390fecc6`](https://github.com/NixOS/nixpkgs/commit/390fecc61dfac0bc690f205568fd5f5f971e23af) | `` vimPlugins.gitlab-vim: unstable-2025-01-23 -> 0.1.1 ``                               |
| [`9b112168`](https://github.com/NixOS/nixpkgs/commit/9b112168a6882ba5d9ce94b62b4b581c2994da5c) | `` pulumi-bin: 3.148.0 -> 3.149.0 ``                                                    |
| [`669ebb99`](https://github.com/NixOS/nixpkgs/commit/669ebb997857cb45bb2c1316eccf6a5f8c8f51cf) | `` vimPlugins.lsp_lines-nvim: unstable-2024-12-10 -> 3.0.0 ``                           |
| [`5156904c`](https://github.com/NixOS/nixpkgs/commit/5156904c711d340e303ad800b94369b3a7085e42) | `` kubernetes-controller-tools: 0.17.1 -> 0.17.2 (#380899) ``                           |
| [`0d2649a0`](https://github.com/NixOS/nixpkgs/commit/0d2649a0b83d58d9402254b1aebb4d4c9c72eae0) | `` cirrus-cli: 0.135.0 -> 0.137.3 ``                                                    |
| [`f8bd998b`](https://github.com/NixOS/nixpkgs/commit/f8bd998b4e6926445ab0fd7c95e1e29687c8edcf) | `` python3Packages.jax-cuda12-pjrt: don't try to build on aarch64-linux ``              |
| [`e8039271`](https://github.com/NixOS/nixpkgs/commit/e803927113c284a2faa76bb335f8989ad8d7c079) | `` fusuma: 3.5.0 -> 3.7.0 ``                                                            |
| [`f7408d31`](https://github.com/NixOS/nixpkgs/commit/f7408d31489c6e19d165f15ca0a988618df9df65) | `` vimPlugins.rocks-nvim: add initLua for a working out of the box exper… (#375083) ``  |
| [`e3d7bbab`](https://github.com/NixOS/nixpkgs/commit/e3d7bbab8b3bad048037823b6200ae17471225d5) | `` electrum: patch for aiorpcx 0.24 compatibility ``                                    |
| [`b0c4f34b`](https://github.com/NixOS/nixpkgs/commit/b0c4f34b535c4400f60bc4aa568adb39d53e2620) | `` electrum: substitute with `--replace-fail` ``                                        |
| [`32e09278`](https://github.com/NixOS/nixpkgs/commit/32e09278844c1bdb22d191710da4e87e60d35a55) | `` Revert "electrum: fixup Exec lines in .desktop" ``                                   |
| [`1ba6c775`](https://github.com/NixOS/nixpkgs/commit/1ba6c7754fb6278c15f9c68360e6bfa4b0381d14) | `` flintlock: 0.8.0 -> 0.8.1 ``                                                         |
| [`ba5135dd`](https://github.com/NixOS/nixpkgs/commit/ba5135dd8040ef300e515b46cf5992f8eb67e514) | `` nezha-theme-nazhua: 0.5.6 -> 0.5.7 ``                                                |
| [`f56ea409`](https://github.com/NixOS/nixpkgs/commit/f56ea4095bb4faf653ac33ea75d9371df7070db4) | `` python3Packages.tensorflow: fix typo ``                                              |
| [`45f3a21f`](https://github.com/NixOS/nixpkgs/commit/45f3a21fe2a34cb4b9a65ab1d1a29e1c4da2b9e9) | `` autobrr: 1.57.0 -> 1.58.0 ``                                                         |
| [`2b36139f`](https://github.com/NixOS/nixpkgs/commit/2b36139fbe7feab5349e4b7b9d9e864c9f65a269) | `` sipexer: 1.1.0 -> 1.2.0 ``                                                           |
| [`a0519880`](https://github.com/NixOS/nixpkgs/commit/a05198804cdf53c214864a4b7e2eb0db5c25aa5c) | `` nixos/nfc-nci: init ``                                                               |
| [`735f85e8`](https://github.com/NixOS/nixpkgs/commit/735f85e845803b8e6e8915d99e9bead9c18373a9) | `` pcscd: allow multiple readerConfig entries ``                                        |
| [`f6e9c847`](https://github.com/NixOS/nixpkgs/commit/f6e9c847439a95d916abc4eb5f83df7cefa166e9) | `` ifdnfc-nci: init at 0.2.1 ``                                                         |
| [`0d67f93d`](https://github.com/NixOS/nixpkgs/commit/0d67f93d7ea0b459a6259555a0ab71a70c94ac0b) | `` libnfc-nci: init at 2.4.1-unstable ``                                                |
| [`a02b183b`](https://github.com/NixOS/nixpkgs/commit/a02b183b85d7147a03361226ffe984d43dba0544) | `` linuxPackages.nxp-pn5xx: init at 0.4-unstable ``                                     |
| [`3c911b2a`](https://github.com/NixOS/nixpkgs/commit/3c911b2aca0599b15b9d58f7339d73666ffb394a) | `` lib.types: init mergeTypes ``                                                        |
| [`da86067e`](https://github.com/NixOS/nixpkgs/commit/da86067e1ffffa345d9fc4e3df8a704545a7aa59) | `` lprobe: 0.1.4 -> 0.1.5 ``                                                            |
| [`7b925c96`](https://github.com/NixOS/nixpkgs/commit/7b925c96f925402bdfd529bf70d734c61444ed76) | `` python3Packages.nixpkgs-updaters-library: 1.0.2 -> 1.1.0 ``                          |
| [`259b7b53`](https://github.com/NixOS/nixpkgs/commit/259b7b53f4af3a382840fa4c4057ec935408a555) | `` python312Packages.ruff-lsp: 0.0.61 -> 0.0.62 ``                                      |
| [`49e10c7b`](https://github.com/NixOS/nixpkgs/commit/49e10c7b806b7fe9bdc8941fa29d2167238a9156) | `` luaPackages.nvim-dbee: init at 0.1.9-1 ``                                            |
| [`76320c89`](https://github.com/NixOS/nixpkgs/commit/76320c89a8dca7477bd8e0ff9d4eae4eaf14752c) | `` ocamlPackages.async_ssl: fix build of version 0.16.1 ``                              |
| [`8e260adb`](https://github.com/NixOS/nixpkgs/commit/8e260adb6d42ff196366652e2bba994d53c9e9d3) | `` ocamlPackages.shell: disable tests of version 0.15 ``                                |
| [`feedcd92`](https://github.com/NixOS/nixpkgs/commit/feedcd9238c611513ffc2605101c27c20a4cf636) | `` goat-cli: 1.3.0 -> 1.4.0 ``                                                          |
| [`c8c2d504`](https://github.com/NixOS/nixpkgs/commit/c8c2d50415ce3531ba55494e8d424d53134c83a6) | `` ruff: 0.9.5 -> 0.9.6 ``                                                              |
| [`ac1ae580`](https://github.com/NixOS/nixpkgs/commit/ac1ae5809bcaf713171de2c40afd75b8af0ec630) | `` erofs-utils: 1.8.4 -> 1.8.5 ``                                                       |
| [`15fdb273`](https://github.com/NixOS/nixpkgs/commit/15fdb273b8f523e0742dd2a898713833ac549296) | `` coq: align rocq-core version on overrides ``                                         |
| [`9f49de26`](https://github.com/NixOS/nixpkgs/commit/9f49de26057c35d916d4745dcba546f4355f3336) | `` xfce.xfce4-settings: 4.20.0 -> 4.20.1 ``                                             |
| [`95e123c7`](https://github.com/NixOS/nixpkgs/commit/95e123c78346d0d483c2d2b3d968fbe559e03acb) | `` build(deps): bump actions/create-github-app-token from 1.11.1 to 1.11.3 ``           |
| [`40e73443`](https://github.com/NixOS/nixpkgs/commit/40e73443881e577305d560fc9dfae5a18dcaed86) | `` nixos/sway: restore list type of xdg.portal.config.sway.default ``                   |
| [`3f50bc0a`](https://github.com/NixOS/nixpkgs/commit/3f50bc0a4eac6630bbaf5d262a55f8296cfc0eba) | `` vimPlugins.mini-nvim: reduce closure size ``                                         |
| [`4ae67c71`](https://github.com/NixOS/nixpkgs/commit/4ae67c716e56ba9e5dea42d91aae780b488dd254) | `` linux_latest-libre: 19707 -> 19712 ``                                                |
| [`aa8f0c3d`](https://github.com/NixOS/nixpkgs/commit/aa8f0c3da23ffd3481a38dedd3759d2159bb3963) | `` linux_testing: 6.14-rc1 -> 6.14-rc2 ``                                               |
| [`f09a72a8`](https://github.com/NixOS/nixpkgs/commit/f09a72a89131e63d793a8e8c856ab60cb784e1f1) | `` python312Packages.amaranth-boards: 0-unstable-2024-12-21 -> 0-unstable-2025-02-07 `` |
| [`7e5604eb`](https://github.com/NixOS/nixpkgs/commit/7e5604eba24bad9eb0bc58eda40c14ebbfbacaf9) | `` linux/hardened/patches/6.6: v6.6.73-hardened1 -> v6.6.75-hardened1 ``                |
| [`5f703fcf`](https://github.com/NixOS/nixpkgs/commit/5f703fcfad4761c024be7b633b18732817130f92) | `` linux/hardened/patches/6.12: v6.12.10-hardened1 -> v6.12.12-hardened1 ``             |
| [`9e1464b3`](https://github.com/NixOS/nixpkgs/commit/9e1464b34732564618c15a283aaa06753663493e) | `` linux/hardened/patches/6.1: v6.1.126-hardened1 -> v6.1.128-hardened1 ``              |
| [`43519bc0`](https://github.com/NixOS/nixpkgs/commit/43519bc0e747b0f5dd300e98d11610c949665c61) | `` linux/hardened/patches/5.4: v5.4.289-hardened1 -> v5.4.290-hardened1 ``              |
| [`084714f8`](https://github.com/NixOS/nixpkgs/commit/084714f8d4257a8a0db7ff56cb5cfc0d1ddc7c13) | `` linux/hardened/patches/5.15: v5.15.176-hardened1 -> v5.15.178-hardened1 ``           |
| [`ba3471b5`](https://github.com/NixOS/nixpkgs/commit/ba3471b5e7504af0a0c82aa644d55e2596f6cf40) | `` linux/hardened/patches/5.10: v5.10.233-hardened1 -> v5.10.234-hardened1 ``           |
| [`586fa8aa`](https://github.com/NixOS/nixpkgs/commit/586fa8aae46d37c000cff6441698bee8f7557899) | `` zbus-xmlgen: 5.0.2 -> 5.1.0 ``                                                       |
| [`a88eedee`](https://github.com/NixOS/nixpkgs/commit/a88eedeec72e99093232dc5491d20725d8da55bf) | `` maildir-rank-addr: init at 1.4.1 ``                                                  |
| [`ab15e3b7`](https://github.com/NixOS/nixpkgs/commit/ab15e3b7e847c2f646c00f3b6a9f40aa9aac5a2f) | `` litestar: build for all python version ``                                            |
| [`1495671a`](https://github.com/NixOS/nixpkgs/commit/1495671a0c6d69c63f22a4110d7800e0e1fc98ef) | `` python312Packages.dvclive: 3.48.1 -> 3.48.2 ``                                       |
| [`4d376f1f`](https://github.com/NixOS/nixpkgs/commit/4d376f1f8c2ccf7266875f78a20a9dc24419dbce) | `` brlaser: Change maintainers ``                                                       |
| [`cc1265d9`](https://github.com/NixOS/nixpkgs/commit/cc1265d99558e02ab13a26372c38dd2b56baf924) | `` brlaser: Switch to maintained fork ``                                                |
| [`ec2d3cd6`](https://github.com/NixOS/nixpkgs/commit/ec2d3cd6577a0ecda42f7251d19d6ff39fc507de) | `` open-webui: 0.5.9 -> 0.5.10 ``                                                       |
| [`61e539c4`](https://github.com/NixOS/nixpkgs/commit/61e539c4ba0b02c037a395e86505deaa94e522a5) | `` deepin.deepin-icon-theme: fix build ``                                               |
| [`3d4b7767`](https://github.com/NixOS/nixpkgs/commit/3d4b776702ad085925909be57a213d45e20127de) | `` python312Packages.primp: 0.6.5 -> 0.12.0 ``                                          |
| [`52740553`](https://github.com/NixOS/nixpkgs/commit/527405539523b5ec60451f5f3825cc91545bb98d) | `` python313Packages.psycopg: 3.2.3 -> 3.2.4 ``                                         |
| [`27490dc9`](https://github.com/NixOS/nixpkgs/commit/27490dc932ac59cc6941e50b6312c755f6e0e909) | `` python313Packages.picologging: fix build ``                                          |
| [`d509c476`](https://github.com/NixOS/nixpkgs/commit/d509c47663027a854c59a857a950badb47e07652) | `` immich-cli: fix broken symlink (#380796) ``                                          |
| [`fe1d0f13`](https://github.com/NixOS/nixpkgs/commit/fe1d0f13516d291186403eb895a6991327a643aa) | `` python3Packages.truststore: 0.10.0 -> 0.10.1 ``                                      |
| [`30f46aec`](https://github.com/NixOS/nixpkgs/commit/30f46aecba53aa1966a797c3240668d5bf418f67) | `` roundcube: 1.6.9 -> 1.6.10 ``                                                        |
| [`c5cd0ac7`](https://github.com/NixOS/nixpkgs/commit/c5cd0ac769d51c7d03c72057c787fcf5f2b78dc0) | `` roundcube: temporarily disable symlinks check ``                                     |
| [`4cc025e2`](https://github.com/NixOS/nixpkgs/commit/4cc025e22e6d55d2288d5c8cf355e94aff801176) | `` python313Packages.publicsuffixlist: 1.0.2.20250202 -> 1.0.2.20250207 ``              |
| [`064b13dc`](https://github.com/NixOS/nixpkgs/commit/064b13dc8c36935a42e6b38726c3b66e90d6944d) | `` python313Packages.tencentcloud-sdk-python: 3.0.1314 -> 3.0.1315 ``                   |
| [`10ac6580`](https://github.com/NixOS/nixpkgs/commit/10ac6580d0b9786dba029e0fde8452fdf849c668) | `` h2o: add mainProgram ``                                                              |
| [`91e7e82d`](https://github.com/NixOS/nixpkgs/commit/91e7e82d0c7afed14309861dae89968daaa2f33b) | `` python313Packages.msgraph-sdk: 1.18.0 -> 1.20.0 ``                                   |
| [`7147ab20`](https://github.com/NixOS/nixpkgs/commit/7147ab20f316cf9e07d0369a76fbb3244545b4c4) | `` python313Packages.msgraph-core: 1.2.0 -> 1.3.1 ``                                    |
| [`8493848a`](https://github.com/NixOS/nixpkgs/commit/8493848a9ad3cd7df8e0d09394bac892e5179a26) | `` python313Packages.identify: 2.6.6 -> 2.6.7 ``                                        |
| [`53a609dd`](https://github.com/NixOS/nixpkgs/commit/53a609dd6e94eda8a08fa00db6108085ae57cb39) | `` python313Packages.aioshelly: 12.4.1 -> 12.4.2 ``                                     |
| [`d09e16b1`](https://github.com/NixOS/nixpkgs/commit/d09e16b1e438291629a647bb43a925a1f6af8e05) | `` python313Packages.bring-api: 1.0.1 -> 1.0.2 ``                                       |
| [`605a7ee4`](https://github.com/NixOS/nixpkgs/commit/605a7ee46b79d4beecf690906c1d816b5a8cd2c0) | `` qimgv: 1.0.3-alpha -> 1.0.3-unstable-2024-10-11 ``                                   |
| [`4f630e0e`](https://github.com/NixOS/nixpkgs/commit/4f630e0e92150cbdc1703aed4e8c46cc5a2f55c4) | `` python3Packages.rioxarray: drop patch applied upstream ``                            |
| [`62cd5d5f`](https://github.com/NixOS/nixpkgs/commit/62cd5d5f7e6a1f682cfa42ae467b370310b04c2c) | `` python312Packages.microsoft-kiota-serialization-multipart: 1.9.1 -> 1.9.2 ``         |
| [`f780db45`](https://github.com/NixOS/nixpkgs/commit/f780db4505588b541fd472cd1c7ed9cbd9c4b469) | `` ocamlPackages.magic: 0.7.3 -> 0.7.4, remove myself from maintainer ``                |
| [`16398cdc`](https://github.com/NixOS/nixpkgs/commit/16398cdcd42a7dd09586beaed0c25a41feb866c5) | `` python312Packages.deepsearch-toolkit: 2.0.0 -> 2.0.1 ``                              |
| [`151acd07`](https://github.com/NixOS/nixpkgs/commit/151acd07537ed8866d7dfd043f564a8c1cb7f24e) | `` circt: 1.104.0 -> 1.105.0 ``                                                         |
| [`d0431c98`](https://github.com/NixOS/nixpkgs/commit/d0431c9884cb73b8c9779eea5ec63900e3d167ad) | `` websurfx: 1.23.0 -> 1.23.6 ``                                                        |
| [`6eba2ef2`](https://github.com/NixOS/nixpkgs/commit/6eba2ef25a17bd11bd3aeea237c77e05d8677c94) | `` jenkins: 2.479.3 -> 2.492.1 ``                                                       |
| [`62a3d78c`](https://github.com/NixOS/nixpkgs/commit/62a3d78cb73556bd532024ed3b0c148924618496) | `` chatgpt: init at 1.2025.014 ``                                                       |
| [`09331cc1`](https://github.com/NixOS/nixpkgs/commit/09331cc1cc4e8939054ff091f93d4ef0c6c4e044) | `` zoxide: 0.9.6 -> 0.9.7 ``                                                            |
| [`29aae62e`](https://github.com/NixOS/nixpkgs/commit/29aae62ed1c548953b44bc0a929664a7d347a3ff) | `` python312Packages.llama-index-graph-stores-neptune: 0.3.0 -> 0.3.1 ``                |
| [`c62d1dce`](https://github.com/NixOS/nixpkgs/commit/c62d1dce962ec2d9adbf557f64e6ee453bca40c6) | `` proton-ge-bin: GE-Proton9-24 -> GE-Proton9-25 ``                                     |
| [`6399f3b2`](https://github.com/NixOS/nixpkgs/commit/6399f3b22d6f7ed0cdc4d4b6fe9e43fd87d6edef) | `` cargo-temp: 0.3.1 -> 0.3.2 ``                                                        |
| [`6647b53c`](https://github.com/NixOS/nixpkgs/commit/6647b53cd6f970b7b51d3f92fa10bb28b81c8163) | `` cargo-mutants: 25.0.0 -> 25.0.1 ``                                                   |
| [`63446d92`](https://github.com/NixOS/nixpkgs/commit/63446d92c6c0b8df396265c3fac4f519464cca3c) | `` nvidia_oc: 0.1.16 -> 0.1.18 ``                                                       |
| [`0c229d36`](https://github.com/NixOS/nixpkgs/commit/0c229d3692e44a9975279c8caa537f4dc509f7b9) | `` mdbook-d2: 0.3.1 -> 0.3.2 ``                                                         |
| [`c976561f`](https://github.com/NixOS/nixpkgs/commit/c976561fcf9764eb09eedbf7db6bd498e9cee9ff) | `` mihomo: 1.19.1 -> 1.19.2 ``                                                          |
| [`7a57caad`](https://github.com/NixOS/nixpkgs/commit/7a57caade0267dbc7fb6d68390a55fd48990c128) | `` cargo-zigbuild: 0.19.7 -> 0.19.8 ``                                                  |
| [`bf236cc4`](https://github.com/NixOS/nixpkgs/commit/bf236cc49d7ca410ccaac4cc348f25422cf724f2) | `` wgo: 0.5.7 -> 0.5.9 ``                                                               |
| [`b120605d`](https://github.com/NixOS/nixpkgs/commit/b120605deb471c4078fc9f9b502c092743bb14fd) | `` python313Packages.homeassistant-stubs: 2025.2.0 -> 2025.2.1 ``                       |
| [`ce9c3ba2`](https://github.com/NixOS/nixpkgs/commit/ce9c3ba23a51d774c608fdc75b2f418a3a7f1ecb) | `` gowall: 0.1.9 -> 0.2.0 ``                                                            |
| [`55e9df7f`](https://github.com/NixOS/nixpkgs/commit/55e9df7f95048d4db59f9ed9387a620c6b92586b) | `` cppreference-doc: 20241110 -> 20250209 ``                                            |
| [`2cc96c17`](https://github.com/NixOS/nixpkgs/commit/2cc96c173f001071180a20d56ebaa2588e0f97f1) | `` clap: 1.2.2 -> 1.2.3 ``                                                              |
| [`36f020a5`](https://github.com/NixOS/nixpkgs/commit/36f020a50fa8ad5b7b56cbc472decf47106fc489) | `` adrs: 0.2.9 -> 0.3.0 ``                                                              |
| [`ad60461a`](https://github.com/NixOS/nixpkgs/commit/ad60461a744300f61aac738d41ff01b61572c5ab) | `` python312Packages.mkdocs-git-committers-plugin-2: 2.4.1 -> 2.5.0 ``                  |
| [`6a68f2f7`](https://github.com/NixOS/nixpkgs/commit/6a68f2f732a0fa76dd7f086bf3c9853dbf4542d4) | `` immich-public-proxy: 1.6.3 -> 1.7.2 ``                                               |
| [`8d4f14e2`](https://github.com/NixOS/nixpkgs/commit/8d4f14e20d71aed5b733db065d16661f991e5497) | `` zoxide: 0.9.6 -> 0.9.7 ``                                                            |
| [`19f7ed2c`](https://github.com/NixOS/nixpkgs/commit/19f7ed2c2c9ea4268ec2af4b3910ab568d786a5d) | `` python313Packages.meross-iot: mark broken with paho-mqtt v2 ``                       |
| [`24b53d05`](https://github.com/NixOS/nixpkgs/commit/24b53d053ecf1bd358328aca8b6d15be1b772734) | `` python313Packages.amshan: skip bulk update ``                                        |
| [`8cd3dc02`](https://github.com/NixOS/nixpkgs/commit/8cd3dc02231177b62d137b103615b0d08e46f658) | `` Revert "python3Packages.amshan: 2.1.1 -> 2021.12.1" ``                               |
| [`ab15130c`](https://github.com/NixOS/nixpkgs/commit/ab15130c1a8a76cea8fd5bf8ee4728d209bedbb2) | `` python313Packages.azure-iot-device: mark broken with paho-mqtt v2 ``                 |
| [`c45a2f9d`](https://github.com/NixOS/nixpkgs/commit/c45a2f9d7568acfe876ea32f88939120e15049b0) | `` ha-mqtt-discoverable-cli: pin paho-mqtt to v1 ``                                     |
| [`6ca1674e`](https://github.com/NixOS/nixpkgs/commit/6ca1674e4c5424a9738dbd40272646cdb8f64b9b) | `` jefferson: relax cstruct dependency ``                                               |
| [`430baeed`](https://github.com/NixOS/nixpkgs/commit/430baeedba5ab4eaca3030a74941cf3b777ac4b8) | `` python313Packages.ha-mqtt-discoverable: mark broken with paho-mqtt v2 ``             |
| [`f37ff3af`](https://github.com/NixOS/nixpkgs/commit/f37ff3af3ea38672553f40070a433d82563d4345) | `` mqtt-exporter: unpin paho-mqtt ``                                                    |
| [`369074d4`](https://github.com/NixOS/nixpkgs/commit/369074d4bd2f601fc6ea1ea5eeaf1a1aeb147bca) | `` python313Packages.weconnect-mqtt: unpin paho-mqtt ``                                 |
| [`d7d9a598`](https://github.com/NixOS/nixpkgs/commit/d7d9a5982f39aeeddfa41474829701b70c07687b) | `` frigate: unpin paho-mqtt ``                                                          |
| [`05f423eb`](https://github.com/NixOS/nixpkgs/commit/05f423eb0002ec86489dacc96b44e9616b284f20) | `` python313Packages.paho-mqtt: 1.6.1 -> 2.1.0 ``                                       |
| [`a21f682b`](https://github.com/NixOS/nixpkgs/commit/a21f682b66c6c9b05a5c736cc856fbbc3a347fb5) | `` openvino: 2024.6.0 -> 2025.0.0 ``                                                    |
| [`fcb71bf6`](https://github.com/NixOS/nixpkgs/commit/fcb71bf658d15153b3aff455bae568e0407465ec) | `` nixos/tests/vaultwarden: adapt to new webvault ``                                    |
| [`e6682ef3`](https://github.com/NixOS/nixpkgs/commit/e6682ef3f668726fc71883c96fb6501f0b7ebf64) | `` python312Packages.gto: fix build; set SSL_CERT_FILE ``                               |
| [`d15cb142`](https://github.com/NixOS/nixpkgs/commit/d15cb14276e18e09c55fa7cec87b94d43ec7e757) | `` nix-prefetch: modernize ``                                                           |
| [`ae744717`](https://github.com/NixOS/nixpkgs/commit/ae7447170667497a992c9333bafe731691b46aba) | `` nixVersions.nix_2_26: Drop libgit2-thin-packfile override ``                         |
| [`1b0c666e`](https://github.com/NixOS/nixpkgs/commit/1b0c666e99f71e14241258d900c3f2920e1ec1d2) | `` forgejo-runner: 6.2.0 -> 6.2.2 ``                                                    |
| [`64a95324`](https://github.com/NixOS/nixpkgs/commit/64a9532416f4f2cd88e4b16a8f7433d87555aee5) | `` nix//.version: Drop newline ``                                                       |
| [`3cbcec03`](https://github.com/NixOS/nixpkgs/commit/3cbcec03f22d70bc6df9b5c99e380a08a3968133) | `` nixVersions.nix_2_26: Use default boost package ``                                   |
| [`430a6df7`](https://github.com/NixOS/nixpkgs/commit/430a6df76f75d78feece9b7a6e25837b524973b3) | `` nixVersions.nix_2_26: 2.26.0 -> 2.26.1 ``                                            |
| [`34f269c1`](https://github.com/NixOS/nixpkgs/commit/34f269c14ac18d89ddee9a8f54b1ca92a85bbcc6) | `` Format ``                                                                            |
| [`c40da46b`](https://github.com/NixOS/nixpkgs/commit/c40da46bc7c6d8e311a9590efcf741d9e4f9e93a) | `` nix_2_26: Fix dev output shim ``                                                     |
| [`82dbd490`](https://github.com/NixOS/nixpkgs/commit/82dbd490221a44f5956f3836117d244d39664577) | `` refactor: Extract pkgs/.../nix/tests.nix ``                                          |
| [`062c34cd`](https://github.com/NixOS/nixpkgs/commit/062c34cdace499aa44f0fa6ca6f2ca71769f6c43) | `` Format ``                                                                            |
| [`0c89e259`](https://github.com/NixOS/nixpkgs/commit/0c89e259affea05b309877b2830cb3a8cb582046) | `` nixVersions.nix_2_26: init ``                                                        |
| [`b5b2a913`](https://github.com/NixOS/nixpkgs/commit/b5b2a913f87470c9502c8b7ba4db6e4f4d3317bd) | `` nix/2_26: Add files ``                                                               |
| [`78ffd8bb`](https://github.com/NixOS/nixpkgs/commit/78ffd8bb3795c7f336ac599bd89bc1efbdace5a5) | `` proton-ge-bin: remove uneeded changes ``                                             |
| [`9d049880`](https://github.com/NixOS/nixpkgs/commit/9d049880c02badb14c36c28246bbabb84ab0303a) | `` tsm-client: fix symlink fixup ``                                                     |
| [`19a096fe`](https://github.com/NixOS/nixpkgs/commit/19a096fe9ff6ff1894d5bc8cb56cca081e954646) | `` zotero: 7.0.10 -> 7.0.11 ``                                                          |
| [`41b9d91a`](https://github.com/NixOS/nixpkgs/commit/41b9d91a495f4714a7b54c7bc838b951f09203a8) | `` tuicam: init at 0.0.2 (#377825) ``                                                   |
| [`8b223bcb`](https://github.com/NixOS/nixpkgs/commit/8b223bcba08ae575997f808a21ccf868f11c2d6b) | `` vimPlugins.avante-nvim: 0.0.16 -> 0.0.18 ``                                          |