### PR TITLE
chore(flake/nixvim): `e7f20a60` -> `13341a4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738966895,
-        "narHash": "sha256-OXOh35rTEnFSO4vj/SDMIlDvFPGW0ba1XhZkfx+AlL0=",
+        "lastModified": 1739121491,
+        "narHash": "sha256-BEmyAozR3Pc2qwPtC4rgUglzi3cw4nv4fXEY23NxOrQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e7f20a602f6e08a70045f36c531bc44ba1baed07",
+        "rev": "13341a4c1238b7974e7bad9c7a6d5c51ca3cf81a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`13341a4c`](https://github.com/nix-community/nixvim/commit/13341a4c1238b7974e7bad9c7a6d5c51ca3cf81a) | `` plugins/blink-emoji: fix packPathName ``   |
| [`7dfd5513`](https://github.com/nix-community/nixvim/commit/7dfd5513d84dc0e529a00190f70ec61c85246fc1) | `` plugins/blink-ripgrep: fix packPathName `` |