### PR TITLE
chore(flake/nixvim): `13341a4c` -> `78b6f8e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739121491,
-        "narHash": "sha256-BEmyAozR3Pc2qwPtC4rgUglzi3cw4nv4fXEY23NxOrQ=",
+        "lastModified": 1739353096,
+        "narHash": "sha256-w/T2uYCoq4k6K46GX2CMGWsKfMvcqnxC41LIgnvGifE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "13341a4c1238b7974e7bad9c7a6d5c51ca3cf81a",
+        "rev": "78b6f8e1e5b37a7789216e17a96ebc117660f0e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`78b6f8e1`](https://github.com/nix-community/nixvim/commit/78b6f8e1e5b37a7789216e17a96ebc117660f0e7) | `` plugins/easy-dotnet: init `` |