### PR TITLE
chore(flake/nixvim): `78b6f8e1` -> `7f29e4b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739353096,
-        "narHash": "sha256-w/T2uYCoq4k6K46GX2CMGWsKfMvcqnxC41LIgnvGifE=",
+        "lastModified": 1739469954,
+        "narHash": "sha256-faUXxkM3yYm++fpEw02tbAgPJprVB0xOtrU87BEQkuI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "78b6f8e1e5b37a7789216e17a96ebc117660f0e7",
+        "rev": "7f29e4b2ae34c1ba5fe650d74c8f28b0d1fa21ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------- |
| [`7f29e4b2`](https://github.com/nix-community/nixvim/commit/7f29e4b2ae34c1ba5fe650d74c8f28b0d1fa21ee) | `` docs/fix-links: init ``  |
| [`ff63fc92`](https://github.com/nix-community/nixvim/commit/ff63fc92ed38a00e7b3ba60a828870017428436a) | `` plugins/bullets: init `` |