### PR TITLE
chore(flake/nixvim): `a39e0a65` -> `b8c55873`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739527837,
-        "narHash": "sha256-dsb5iSthp5zCWhdV0aXPunFSCkS0pCvRXMMgTEFjzew=",
+        "lastModified": 1739632145,
+        "narHash": "sha256-maNBjf9whO303r4+8ekfAZOrf3sHnw6DLiSph5xnXJw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a39e0a651657046f3b936d842147fa51523b6818",
+        "rev": "b8c55873998948bf14a2b6cf30f9ad5ecdf79818",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`b8c55873`](https://github.com/nix-community/nixvim/commit/b8c55873998948bf14a2b6cf30f9ad5ecdf79818) | `` lib/keymaps: make `mode` type's description more readable `` |
| [`bd46d896`](https://github.com/nix-community/nixvim/commit/bd46d896a8eb517314163264606bd70859082339) | `` lib/keymaps: add a link to `:h map-modes` ``                 |
| [`d3a25cb9`](https://github.com/nix-community/nixvim/commit/d3a25cb97f8e8c4b77949b1e9fcf26b7ded42fbc) | `` lib/keymaps: add abbreviation support to `modes` enum ``     |
| [`a1e168a2`](https://github.com/nix-community/nixvim/commit/a1e168a2a01e7b5c67ebf9183e1a27804a6add86) | `` lib/keymaps: replace `modes` attrs with list ``              |
| [`d542e373`](https://github.com/nix-community/nixvim/commit/d542e373f16cfa03ef7ad71f4cf6d479144a08a6) | `` readme: use `:h map-table` for mapping modes ``              |