### PR TITLE
chore(flake/nixpkgs): `73cf49b8` -> `32fb99ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739866667,
-        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
+        "lastModified": 1740126099,
+        "narHash": "sha256-ozoOtE2hGsqh4XkTJFsrTkNxkRgShxpQxDynaPZUGxk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
+        "rev": "32fb99ba93fea2798be0e997ea331dd78167f814",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`31aa4c5f`](https://github.com/NixOS/nixpkgs/commit/31aa4c5fefd7b53bbfb4ba52f25edb6da47bdf3f) | `` nixos/iso-image: fix build ``                                        |
| [`0c3729a9`](https://github.com/NixOS/nixpkgs/commit/0c3729a9d60c1442fff160b23cd67aa9b46776ab) | `` ocamlPackages.sexp: mark broken at versions 0.15 & 0.14 ``           |
| [`5e281f0f`](https://github.com/NixOS/nixpkgs/commit/5e281f0f6eba6fba658f2785973dd7c3ca9649fd) | `` ocamlPackages.shell: disable tests of version 0.14 ``                |
| [`35bd105d`](https://github.com/NixOS/nixpkgs/commit/35bd105dc889fd509dbb2645dde733bc537e0849) | `` ocamlPackages.async_ssl: mark broken at version 0.14 ``              |
| [`22c572eb`](https://github.com/NixOS/nixpkgs/commit/22c572eb22247517ff2838e9b1ad06a7784cefdb) | `` ocamlPackages.asai: disable for OCaml < 5.2 ``                       |
| [`e8dd8f96`](https://github.com/NixOS/nixpkgs/commit/e8dd8f96aaf4a763d3a45c1dffd5d01aecc05708) | `` ecapture: 0.9.3 -> 0.9.4 ``                                          |
| [`e7d9d982`](https://github.com/NixOS/nixpkgs/commit/e7d9d982ffea3fec781a0c1dcadfacb7a8ae930e) | `` violet: 0.5.2 -> 0.5.3 ``                                            |
| [`dd34c8e8`](https://github.com/NixOS/nixpkgs/commit/dd34c8e8bce8a1a80c37d929208b7d8f6a6f438c) | `` halloy: 2025.1 -> 2025.2 ``                                          |
| [`baf59e4e`](https://github.com/NixOS/nixpkgs/commit/baf59e4eb8d26fc8901f6e4e98350f413cd49523) | `` python313Packages.pymicro-vad: 1.0.1 -> 1.0.2 ``                     |
| [`6cafdc6a`](https://github.com/NixOS/nixpkgs/commit/6cafdc6a56d3856e830363c8078c1aa26c897636) | `` ludtwig: 0.9.0 -> 0.10.0 ``                                          |
| [`fd756758`](https://github.com/NixOS/nixpkgs/commit/fd7567582546877fce5577bfa8bdeea6e78a765e) | `` python313Packages.paypalhttp: fix http header case issue ``          |
| [`1d50dcd5`](https://github.com/NixOS/nixpkgs/commit/1d50dcd57199c8658ef6c6c178e04d8edf3165e0) | `` python313Packages.click-datetime: 0.2.0 -> 0.4.0 ``                  |
| [`178a2484`](https://github.com/NixOS/nixpkgs/commit/178a2484daf9698a514e1ef50d968d912354cf2e) | `` servo: 0-unstable-2025-02-19 -> 0-unstable-2025-02-20 ``             |
| [`6422cfc4`](https://github.com/NixOS/nixpkgs/commit/6422cfc497e6f2983f4b8a764fa4a3b86bf70858) | `` python313Packages.pyopenweathermap: 0.2.1 -> 0.2.2 ``                |
| [`f81a2066`](https://github.com/NixOS/nixpkgs/commit/f81a2066f9b104a8f556099575e4672cfd4a3d88) | `` python313Packages.teslemetry-stream: 0.6.10 -> 0.6.12 ``             |
| [`f998a07d`](https://github.com/NixOS/nixpkgs/commit/f998a07d73b057ee168f9b08fa61bdde501a6631) | `` python313Packages.aiojellyfin: 0.13.0 -> 0.14.1 ``                   |
| [`46146152`](https://github.com/NixOS/nixpkgs/commit/461461526efa196ec94bfa33978d1c2f16ea7612) | `` catppuccin: quote paths ``                                           |
| [`67e14024`](https://github.com/NixOS/nixpkgs/commit/67e1402464a88895f40edc34aeab6d073d3294f5) | `` catppuccin: unstable-2024-03-12 -> unstable-2025-02-21 ``            |
| [`5837cd48`](https://github.com/NixOS/nixpkgs/commit/5837cd48c2d58c3da3507ae6c8e92af42a7393ad) | `` mautrix-slack: init at 0.1.4 ``                                      |
| [`7712e9ff`](https://github.com/NixOS/nixpkgs/commit/7712e9ffa52915c6addac83148df5f120312522d) | `` python312Packages.cvxpy: 1.6.0 -> 1.6.1 ``                           |
| [`4a84f6a2`](https://github.com/NixOS/nixpkgs/commit/4a84f6a2ca65291e5dd38c0f9b4dde2df2142999) | `` ser2net: 4.6.3 -> 4.6.4 ``                                           |
| [`03380158`](https://github.com/NixOS/nixpkgs/commit/03380158c4b2df85e689b8f626ae53a5ba243be5) | `` python312Packages.transformers: 4.49.0-SmolVLM-2 -> 4.49.0 ``        |
| [`9df48799`](https://github.com/NixOS/nixpkgs/commit/9df487993daabd4a7b126c87ec7e3b2d7be455a5) | `` firefox-{beta,devedition}: make binaryName match desktop file ``     |
| [`6fe32918`](https://github.com/NixOS/nixpkgs/commit/6fe329180f2e7fd38b061308b63dcf7bd5a852c5) | `` bitrise: 2.27.0 -> 2.29.1 ``                                         |
| [`da8fc771`](https://github.com/NixOS/nixpkgs/commit/da8fc77184f9d9f75580fb9aa1232d11fc4c5481) | `` rosa: 1.2.49 -> 1.2.50 ``                                            |
| [`21862634`](https://github.com/NixOS/nixpkgs/commit/21862634ccc7f2453cad20ea2c354f4539d90e13) | `` ollama: 0.5.7 -> 0.5.11 ``                                           |
| [`2678ec04`](https://github.com/NixOS/nixpkgs/commit/2678ec0447b44ae226de78b3bd194140cd9cf9f6) | `` python312Packages.transformers: 4.49.0 -> 4.49.0-SmolVLM-2 ``        |
| [`d42a4af6`](https://github.com/NixOS/nixpkgs/commit/d42a4af67866a3970a7fe88cd4acce6111b1b570) | `` python312Packages.huggingface-hub: 0.28.1 -> 0.29.1 ``               |
| [`f9b6a32d`](https://github.com/NixOS/nixpkgs/commit/f9b6a32d96ede1b6586d672aa5dbdbea50f9e0e7) | `` python312Packages.onedrive-personal-sdk: 0.0.10 -> 0.0.11 ``         |
| [`4e028ffd`](https://github.com/NixOS/nixpkgs/commit/4e028ffddceb63125fd6fcd4f7455bef570792b6) | `` vscode-extensions.ms-python.debugpy: 2024.6.0 -> 2025.0.1 ``         |
| [`9f1d8ddc`](https://github.com/NixOS/nixpkgs/commit/9f1d8ddcc623ba1b56733d0e63656bb8aeed4884) | `` python313Packages.tencentcloud-sdk-python: 3.0.1320 -> 3.0.1321 ``   |
| [`d930b94c`](https://github.com/NixOS/nixpkgs/commit/d930b94c8b9bf0e136a69d92d509fbb0e665c0a2) | `` k9s: 0.40.3 -> 0.40.5 ``                                             |
| [`fa249532`](https://github.com/NixOS/nixpkgs/commit/fa2495327223fb83ca4d2f2d49e0e9def5d4f62a) | `` terraform-providers.ibm: 1.75.1 -> 1.75.2 ``                         |
| [`23eca5e1`](https://github.com/NixOS/nixpkgs/commit/23eca5e10fcadaf0b5489c707be9021011871faf) | `` gitify: 5.18.0 -> 6.1.0 ``                                           |
| [`69cf3222`](https://github.com/NixOS/nixpkgs/commit/69cf32228f64f790efe95b297e4e5271080fa6a1) | `` open-webui: 0.5.14 -> 0.5.15 ``                                      |
| [`be1bd24f`](https://github.com/NixOS/nixpkgs/commit/be1bd24fa8dca56c6cb745a3ddb62690d9344617) | `` python312Packages.firecrawl-py: init at 1.5.0 ``                     |
| [`bc15bf2b`](https://github.com/NixOS/nixpkgs/commit/bc15bf2bf712cd0d8f6fb6d5b3bcccff9de3fde8) | `` kopia: 0.18.2 -> 0.19.0 (#377435) ``                                 |
| [`6074ca60`](https://github.com/NixOS/nixpkgs/commit/6074ca604c14b2623c5ebb33fe0366c222d77e34) | `` ledger-live-desktop: 2.98.0 -> 2.100.0 ``                            |
| [`f8be5beb`](https://github.com/NixOS/nixpkgs/commit/f8be5beb7bb15cef3f4298f0aa44dfa4257b0a6f) | `` pyenv: 2.5.2 -> 2.5.3 ``                                             |
| [`3e356f81`](https://github.com/NixOS/nixpkgs/commit/3e356f81cbd24c8e33d6256658355cc8d100eb1d) | `` go-minimock: 3.4.4 -> 3.4.5 ``                                       |
| [`f1380936`](https://github.com/NixOS/nixpkgs/commit/f138093685fb93c179234b634eeed029e8fd6dd0) | `` i2p: 2.8.0 -> 2.8.1 ``                                               |
| [`051ab390`](https://github.com/NixOS/nixpkgs/commit/051ab390cb342387c4214bc0c9288766826ba9d1) | `` urn-timer: 0-unstable-2025-02-02 -> 0-unstable-2025-02-07 ``         |
| [`35db52e2`](https://github.com/NixOS/nixpkgs/commit/35db52e2af1aca1a5e0b642c92056657d8d21abd) | `` vulkan-memory-allocator: 3.2.0 -> 3.2.1 ``                           |
| [`ca49a138`](https://github.com/NixOS/nixpkgs/commit/ca49a1389e32f870b4a60043afdd1098ebddc963) | `` tclPackages.tclreadline: 2.4.0 -> 2.4.1 ``                           |
| [`43588413`](https://github.com/NixOS/nixpkgs/commit/43588413e397224dff4e159faa12aa1fb3ebdb46) | `` ft2-clone: 1.93 -> 1.94 ``                                           |
| [`677ed80c`](https://github.com/NixOS/nixpkgs/commit/677ed80c4d666092707baaa9e4b511f5b67c33b0) | `` libblake3: 1.5.5 -> 1.6.0 ``                                         |
| [`19379c0f`](https://github.com/NixOS/nixpkgs/commit/19379c0f6a3280cc1a9c05d58f7df1d40b0d8d8c) | `` libblake3: build as dynamic library if hostPlatform is not static `` |
| [`e24bb30b`](https://github.com/NixOS/nixpkgs/commit/e24bb30bdd537e414f0cb74cdee23c1bc749d3d6) | `` astromenace: 1.4.2 -> 1.4.3 ``                                       |
| [`a2464f4c`](https://github.com/NixOS/nixpkgs/commit/a2464f4cfb0cb912fa254d474ab3b5a43d0a9847) | `` k8sgpt: 0.3.48 -> 0.3.49 ``                                          |
| [`3b24a40c`](https://github.com/NixOS/nixpkgs/commit/3b24a40c64a28568193f48242b68fedbae2b02c1) | `` kuttl: 0.21.0 -> 0.22.0 ``                                           |
| [`de7903fc`](https://github.com/NixOS/nixpkgs/commit/de7903fc48a02517c50b05efe7628a06387d7524) | `` cargo-deny: 0.16.4 -> 0.17.0 ``                                      |
| [`50d1c134`](https://github.com/NixOS/nixpkgs/commit/50d1c13414650572d98d8a580956bcb09ed14d81) | `` android-studio: 2024.2.2.13 -> 2024.2.2.14 (#382566) ``              |
| [`8ed94b5b`](https://github.com/NixOS/nixpkgs/commit/8ed94b5b438b5b6e7dcd1e6adade49af82ea4cb7) | `` nixos/mosh: make package overridable (#383643) ``                    |
| [`4f2c917e`](https://github.com/NixOS/nixpkgs/commit/4f2c917ec5e969c12f06dcea4f9b0ffbd0745376) | `` xdg-terminal-exec: 0.12.0 -> 0.12.1 (#383642) ``                     |
| [`79f1b8d8`](https://github.com/NixOS/nixpkgs/commit/79f1b8d8882decd8b78788098319f0d48f304acc) | `` gnupg: don't use autoreconfHook ``                                   |
| [`dfe2c94d`](https://github.com/NixOS/nixpkgs/commit/dfe2c94d9c392b486e6696ef9555dd5487978268) | `` inv-sig-helper: 0-unstable-2025-02-07 -> 0-unstable-2025-02-15 ``    |
| [`9562d26e`](https://github.com/NixOS/nixpkgs/commit/9562d26ef08430dfd399ca44199341daaab33ffc) | `` home-assistant-custom-components.moonraker: 1.5.1 -> 1.6.0 ``        |
| [`76f1d667`](https://github.com/NixOS/nixpkgs/commit/76f1d6677b6978e514d4ab5685f06de8c69fa777) | `` python312Packages.fastembed: 0.5.0 -> 0.5.1 ``                       |
| [`e5ac19d5`](https://github.com/NixOS/nixpkgs/commit/e5ac19d57fdedd07b4ea28dedfc2217c566ae100) | `` python312Packages.py-rust-stemmers: init at 0.1.5 ``                 |
| [`a5c1503f`](https://github.com/NixOS/nixpkgs/commit/a5c1503feff03f2efe6737f4a3872abca85e20fb) | `` haskellPackages.sensei: re-enable it as it it now builds fine ``     |
| [`36b71eb5`](https://github.com/NixOS/nixpkgs/commit/36b71eb508cd430222b68b00386e3ba999f2fc4b) | `` adminerneo: 4.13 -> 4.14 ``                                          |
| [`c0dd3a9f`](https://github.com/NixOS/nixpkgs/commit/c0dd3a9f5892deab3892a3c9be93630bdfa63317) | `` adminerneo: expose indexPHP to be used by similar packages ``        |
| [`e7479fa7`](https://github.com/NixOS/nixpkgs/commit/e7479fa7e5b214c0510fd6260442b7c2bad28d54) | `` adminerneo: rename from adminer-pematon ``                           |
| [`bfc2a5b1`](https://github.com/NixOS/nixpkgs/commit/bfc2a5b13561488e777b13a259d1eeb495654241) | `` python312Packages.mmh3: 5.0.1 -> 5.1.0 ``                            |
| [`355bab5e`](https://github.com/NixOS/nixpkgs/commit/355bab5e2e706803d231e4c1ef61149de305a5b7) | `` mdbook-pdf: 0.1.10 -> 0.1.11 ``                                      |
| [`2a43d8c4`](https://github.com/NixOS/nixpkgs/commit/2a43d8c4041800c7b902ce8de6527c1ca338d4a4) | `` python312Packages.json-repair: 0.35.0 -> 0.39.0 ``                   |
| [`69bd941b`](https://github.com/NixOS/nixpkgs/commit/69bd941b4ea971c5b23379948b56bcd6a6a601ca) | `` lemmy-server: 0.19.8 -> 0.19.9 ``                                    |
| [`78b6d0ed`](https://github.com/NixOS/nixpkgs/commit/78b6d0edff7bfcbff04514ee6e7fa3df2bc87382) | `` notonoto-hs-console: init at 0.0.3 ``                                |
| [`6eec2b42`](https://github.com/NixOS/nixpkgs/commit/6eec2b42d6850d6850dfcbdca7919df127f93f13) | `` notonoto-hs-35: init at 0.0.3 ``                                     |
| [`cbe4fad8`](https://github.com/NixOS/nixpkgs/commit/cbe4fad8c2b80aef68512e4c58cc040d456a705a) | `` notonoto-console: init at 0.0.3 ``                                   |
| [`dfb30725`](https://github.com/NixOS/nixpkgs/commit/dfb307257694dc274b6b24bf39085fd2c1a3303d) | `` notonoto-35: init at 0.0.3 ``                                        |
| [`97a86007`](https://github.com/NixOS/nixpkgs/commit/97a86007abcb6ba7cfbedb1e77a250d667178be6) | `` sshuttle: 1.1.2 -> 1.2.0 (#380452) ``                                |
| [`114d799f`](https://github.com/NixOS/nixpkgs/commit/114d799f124b15fdb19994c6c31fd218dbc65223) | `` gopass-jsonapi: add native messaging manifest (#381123) ``           |
| [`fc59b1b6`](https://github.com/NixOS/nixpkgs/commit/fc59b1b651d45ec1a76cd1724f3f625c6474c929) | `` h5glance: init at 0.9 ``                                             |
| [`940a26d9`](https://github.com/NixOS/nixpkgs/commit/940a26d96a0171a2b6638cae23aa595d86aed102) | `` python312Packages.htmlgen: init at 2.0.0 ``                          |
| [`3b3bced9`](https://github.com/NixOS/nixpkgs/commit/3b3bced9c5da2a36f29dbec11f1164dd1bf1d97b) | `` nixos/cross-seed: init module ``                                     |
| [`c81b9b21`](https://github.com/NixOS/nixpkgs/commit/c81b9b2162e81ed4f5004559a0d1b53728d1c5ac) | `` google-chrome: 133.0.6943.98 -> 133.0.6943.126 (#383605) ``          |
| [`e6863a5b`](https://github.com/NixOS/nixpkgs/commit/e6863a5b8ccfe03d3c2f91bbcd76b0b6642707d7) | `` hyprutils: 0.5.0 -> 0.5.1 (#383603) ``                               |
| [`91bbf254`](https://github.com/NixOS/nixpkgs/commit/91bbf2540a4e16f2e1fe14daf483766be91fae3e) | `` vi-mongo: init at 0.1.22 ``                                          |
| [`61da3c0b`](https://github.com/NixOS/nixpkgs/commit/61da3c0b37262a0a12a282f3c5c548a3c1e42db3) | `` ceph: disable more pyopenssl tests ``                                |
| [`94b00e99`](https://github.com/NixOS/nixpkgs/commit/94b00e99f3204bc7113537e3991b626f6690caf7) | `` pkg: 1.21.3 -> 2.0.6 ``                                              |
| [`83f1f2d2`](https://github.com/NixOS/nixpkgs/commit/83f1f2d2519d60d9e10c71288a6d9fea297f823d) | `` snapcraft: 8.7.0 -> 8.7.1 ``                                         |
| [`dfd9fbdc`](https://github.com/NixOS/nixpkgs/commit/dfd9fbdc069685c82a1d0171fb5ab2914aa6a16a) | `` dprint: skip unstable test to fix build on darwin (#383569) ``       |
| [`b1c2f449`](https://github.com/NixOS/nixpkgs/commit/b1c2f449929f0c5c4c7840024219ebdd8bc25fd0) | `` deepin.deepin-calculator: 6.5.4 -> 6.5.7 (#383563) ``                |
| [`96547154`](https://github.com/NixOS/nixpkgs/commit/96547154b2f9ddb2cfa742d0c5e2745a7b2572dd) | `` eza: 0.20.21 -> 0.20.22 (#383566) ``                                 |
| [`3e42914c`](https://github.com/NixOS/nixpkgs/commit/3e42914c054570cb574e31f4d69376a1be4af977) | `` koboldcpp: 1.83.1 -> 1.84.2 (#383573) ``                             |
| [`b1b6bcd1`](https://github.com/NixOS/nixpkgs/commit/b1b6bcd1fe90d00bfe16ba78ce029e43b8ce5909) | `` uv: 0.6.1 -> 0.6.2 ``                                                |
| [`9b299511`](https://github.com/NixOS/nixpkgs/commit/9b299511efdba5a88536e1c87759c3c0197268b7) | `` libretro.gambatte: 0-unstable-2025-01-24 -> 0-unstable-2025-02-14 `` |
| [`daab98fc`](https://github.com/NixOS/nixpkgs/commit/daab98fc06950402f407792c609e95966a0e0aad) | `` libretro.fceumm: 0-unstable-2024-11-23 -> 0-unstable-2025-02-12 ``   |
| [`e2ef6ab1`](https://github.com/NixOS/nixpkgs/commit/e2ef6ab19b0d27aeb0469c73131d84d093ff4f20) | `` python312Packages.flow-record: 3.18 -> 3.19 ``                       |
| [`35b6232d`](https://github.com/NixOS/nixpkgs/commit/35b6232dabd0db76ff71cc6b713ffaec86fa00d2) | `` python312Packages.pubnub: 10.1.0 -> 10.2.0 ``                        |
| [`3624c92d`](https://github.com/NixOS/nixpkgs/commit/3624c92d9680eda987a014b172321a4dc8d66f5e) | `` gitleaks: 8.23.3 -> 8.24.0 ``                                        |