### PR TITLE
chore(flake/nixvim): `0ab99471` -> `53f9d242`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,32 +129,20 @@
     },
     "nixvim": {
       "inputs": {
-        "devshell": [],
-        "flake-compat": [
-          "flake-compat"
-        ],
         "flake-parts": [
           "flake-parts"
         ],
-        "git-hooks": [
-          "git-hooks"
-        ],
-        "home-manager": [],
-        "nix-darwin": [],
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nuschtosSearch": [],
-        "treefmt-nix": [
-          "treefmt-nix"
-        ]
+        "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1739902813,
-        "narHash": "sha256-BgOQcKKz7VNvSHIbBllHisv32HvF3W3ALF9sdnC++V8=",
+        "lastModified": 1740432393,
+        "narHash": "sha256-uXlB7bTlrl0q2jryKMSRlU+GptkVJN7PTsqdKkaFg1M=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0ab9947137cd034ec64eb5cd9ede94e53af21f50",
+        "rev": "53f9d242ffdf0997109d0b5b8bbbcc67a4296077",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`53f9d242`](https://github.com/nix-community/nixvim/commit/53f9d242ffdf0997109d0b5b8bbbcc67a4296077) | `` ci/update: link to workflow run in PR body ``      |
| [`5cd74b54`](https://github.com/nix-community/nixvim/commit/5cd74b54ad5843a078277783487568f0bf5779c8) | `` ci/update: document how to re-update in PR body `` |
| [`723630ca`](https://github.com/nix-community/nixvim/commit/723630ca403cc2dcc163656fe4051edb2c6b3147) | `` ci/update: write PR body dynamically ``            |
| [`977b7a9f`](https://github.com/nix-community/nixvim/commit/977b7a9fa3fb87098de1841ed14ce3d004d7a125) | `` docs/fix-links: pandoc `markdown` -> `gfm` ``      |
| [`4b0de83c`](https://github.com/nix-community/nixvim/commit/4b0de83c39718e6fca0c80fdeae7c4a9b2cb6c10) | `` ci/update: drop empty commits on re-apply ``       |
| [`05981008`](https://github.com/nix-community/nixvim/commit/05981008b77496a93837c00da3f9306ecd52b760) | `` ci/update: fix `inputs.nixpkgs.rev` eval ``        |
| [`6d10fc0c`](https://github.com/nix-community/nixvim/commit/6d10fc0c871a93164bd473fe7de9dbcc41439799) | `` flake: partition dev dependencies ``               |