### PR TITLE
chore(flake/nixpkgs): `32fb99ba` -> `0196c017`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740126099,
-        "narHash": "sha256-ozoOtE2hGsqh4XkTJFsrTkNxkRgShxpQxDynaPZUGxk=",
+        "lastModified": 1740367490,
+        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32fb99ba93fea2798be0e997ea331dd78167f814",
+        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`0196c017`](https://github.com/NixOS/nixpkgs/commit/0196c0175e9191c474c26ab5548db27ef5d34b05) | `` ncpamixer: 1.3.7 -> 1.3.9 (#384644) ``                                         |
| [`f3fefcd4`](https://github.com/NixOS/nixpkgs/commit/f3fefcd462e52fa950855cd366b5656a179eb62a) | `` spicedb-zed: 0.26.0 -> 0.27.0 ``                                               |
| [`8066a447`](https://github.com/NixOS/nixpkgs/commit/8066a447894df516a173c9f3e2f21e226c66c3dd) | `` discord: updates ``                                                            |
| [`fa7905ee`](https://github.com/NixOS/nixpkgs/commit/fa7905eeba53accac6204e75660d282422d9975a) | `` python313Packages.psycopg: 3.2.4 -> 3.2.5 ``                                   |
| [`17a5d4a7`](https://github.com/NixOS/nixpkgs/commit/17a5d4a73d48166f3482900a2238f3a45199c7ae) | `` python3Packages.pytensor: 2.26.4 -> 2.28.0 ``                                  |
| [`f142bfb8`](https://github.com/NixOS/nixpkgs/commit/f142bfb8c979776b326c8fcef342eb868c29c75d) | `` vllm: add numba to dependencies ``                                             |
| [`500a8bb9`](https://github.com/NixOS/nixpkgs/commit/500a8bb9d58dc930a98dd9cd311d991c427c2f0b) | `` nixos/cross-seed: re-enable test ``                                            |
| [`4a1cad4c`](https://github.com/NixOS/nixpkgs/commit/4a1cad4c4625355d5fcc5febbbafe07878a067f2) | `` nixos/filesystems: remove unused variable ``                                   |
| [`65981df5`](https://github.com/NixOS/nixpkgs/commit/65981df52bb82827db8556e0ece66d7bef0f0398) | `` python313Packages.qcs-sdk-python: 0.21.4 -> 0.21.12 ``                         |
| [`faf75b65`](https://github.com/NixOS/nixpkgs/commit/faf75b65ae18408c249be32019f800de5a90c7c3) | `` python312Packages.llama-cpp-python: enable parallel building ``                |
| [`4941e0ac`](https://github.com/NixOS/nixpkgs/commit/4941e0ac44ec21540793a45ca50e7c591b8b3ddd) | `` phpPackages.psalm: 6.5.0 -> 6.8.6 ``                                           |
| [`a5de7c94`](https://github.com/NixOS/nixpkgs/commit/a5de7c94c87ea0aa66c9e42ebba2b9e7d6f945c1) | `` python312Packages.django-axes: 7.0.1 -> 7.0.2 ``                               |
| [`d52bb12b`](https://github.com/NixOS/nixpkgs/commit/d52bb12badd55e2ba857b3f2b165a0da1d8de61a) | `` emacs: 30.1-rc1 -> 30.1 ``                                                     |
| [`c1027a8d`](https://github.com/NixOS/nixpkgs/commit/c1027a8d42481d85487c9f0a2086f3feddfe5d40) | `` calamares-nixos-extensions: 0.3.19 -> 0.3.21 ``                                |
| [`93d894be`](https://github.com/NixOS/nixpkgs/commit/93d894be625fa6a2c2446ae7d133b3dd67cab717) | `` python313Packages.qcs-api-client-common: 0.10.2 -> 0.11.8 ``                   |
| [`579bf01c`](https://github.com/NixOS/nixpkgs/commit/579bf01c3526b55e8e3f788081b584e29efef40e) | `` nixos/cross-seed: create outputDir ``                                          |
| [`b6868754`](https://github.com/NixOS/nixpkgs/commit/b6868754e201d0c7e881ccc39a098b50fe819ff0) | `` cross-seed: 6.9.1->6.11.1 ``                                                   |
| [`c6c5ef56`](https://github.com/NixOS/nixpkgs/commit/c6c5ef561b38668a324fd9a67a417f2c9f815a15) | `` magma: fix build on CUDA 11.8 ``                                               |
| [`4d2bb49e`](https://github.com/NixOS/nixpkgs/commit/4d2bb49e75e0f6bbf5de394b3665bea3c9d7bdb4) | `` nixos/meme-bingo-web: harden ``                                                |
| [`db6c5992`](https://github.com/NixOS/nixpkgs/commit/db6c59929b8dd89e563316bd699ebc364a7120be) | `` nixos/meme-bingo-web: add address and openFirewall options ``                  |
| [`fbc4fb40`](https://github.com/NixOS/nixpkgs/commit/fbc4fb40bb3170da6e15b83f5f69445b91dbec13) | `` meme-bingo-web: 1.1.0 → 1.2.0 ``                                               |
| [`359c2ce7`](https://github.com/NixOS/nixpkgs/commit/359c2ce731e5c4561d84e201ce9e1d30426a5c9b) | `` wezterm: 0-unstable-2025-02-13 -> 0-unstable-2025-02-23 ``                     |
| [`ffd8c2e4`](https://github.com/NixOS/nixpkgs/commit/ffd8c2e479c27a105e41162d584736e7965880c9) | `` freenet: 01499 -> 01501 ``                                                     |
| [`e23f2880`](https://github.com/NixOS/nixpkgs/commit/e23f28805bbfd5e954e6d2852bdc3b58fdad88e3) | `` python3Packages.pandas-ta: init at 0.2.86 ``                                   |
| [`80aedefb`](https://github.com/NixOS/nixpkgs/commit/80aedefba4c95fec63ad5a9a6f50d79562069d67) | `` tianshou: init at 1.1.0 ``                                                     |
| [`f01bd0ac`](https://github.com/NixOS/nixpkgs/commit/f01bd0aca29906d2fe4c73ea8b2dea18fdb77b65) | `` sensai-utils: init at 1.4.0 ``                                                 |
| [`4622ddb9`](https://github.com/NixOS/nixpkgs/commit/4622ddb9cbb2015b840bed2b94affd9e37b5757d) | `` rlcard: patch distutils ``                                                     |
| [`869ad3ec`](https://github.com/NixOS/nixpkgs/commit/869ad3ecc1aec5c0f7369b2290907f428aaab84a) | `` pettingzoo: fix dependencies ``                                                |
| [`60fcc35e`](https://github.com/NixOS/nixpkgs/commit/60fcc35e51f0d8d4d91795b8070f94742f793ea2) | `` spacer: 0.3.1 -> 0.3.8 ``                                                      |
| [`171c9f23`](https://github.com/NixOS/nixpkgs/commit/171c9f233b72a037e3e038511612a9f3cf8f4e49) | `` arc-browser: 1.82.1-58845 -> 1.83.0-59042 ``                                   |
| [`e3ac8c88`](https://github.com/NixOS/nixpkgs/commit/e3ac8c88f5ae7f41509363867edd276e7b95bd35) | `` nixos/doc/rl-2505: Fix wrong option name in Xfce 4.20 release notes ``         |
| [`9c9a014f`](https://github.com/NixOS/nixpkgs/commit/9c9a014fb7ea3a6465df4f16528482f8cdc112f6) | `` bitwig: 5.2.7 → 5.3.1 (#383776) ``                                             |
| [`872a9300`](https://github.com/NixOS/nixpkgs/commit/872a9300ddf72e55ddc425b99f026ea524f16595) | `` neatvnc: 0.9.2 -> 0.9.3 ``                                                     |
| [`f0e9b774`](https://github.com/NixOS/nixpkgs/commit/f0e9b7742d6888ce4abb3aa8bef39334b48c1f31) | `` lief: 0.16.3 -> 0.16.4 ``                                                      |
| [`4b7a5000`](https://github.com/NixOS/nixpkgs/commit/4b7a500044d270f99ada79e201dcfd63af9baf94) | `` kdePackages.qwlroots: 0.5.2 -> 0.5.3 ``                                        |
| [`9db1f02d`](https://github.com/NixOS/nixpkgs/commit/9db1f02d65541d6b74d9419146f0107ccec7ce67) | `` tinymist: 0.12.22 -> 0.13.0 ``                                                 |
| [`b3b944c8`](https://github.com/NixOS/nixpkgs/commit/b3b944c861824e761fb07cbcc524c69621ccbdd7) | `` labwc-gtktheme: 0-unstable-2022-07-17 -> 0-unstable-2025-02-11 ``              |
| [`2f097c02`](https://github.com/NixOS/nixpkgs/commit/2f097c0224c3ae77802f51059f03bd768788490e) | `` golly: Use wrapGAppsHook ``                                                    |
| [`39bf3250`](https://github.com/NixOS/nixpkgs/commit/39bf32505df27a7f73db9823ea464b89ddbf86c8) | `` fzf: 0.60.0 -> 0.60.2 ``                                                       |
| [`8ebb4120`](https://github.com/NixOS/nixpkgs/commit/8ebb4120a72b74e79b360ca866f0e5712f11bd0f) | `` mini-calc: 3.4.1 -> 3.4.2 ``                                                   |
| [`abe99987`](https://github.com/NixOS/nixpkgs/commit/abe999871148836ea6a29594d7b8daeca7be9624) | `` peergos: 0.22.0 -> 1.0.0, build from source ``                                 |
| [`6afa88f3`](https://github.com/NixOS/nixpkgs/commit/6afa88f3c36d24acbdc363a6d6cb785d97507617) | `` python313Packages.aiodhcpwatcher: 1.1.0 -> 1.1.1 ``                            |
| [`ec3c1dd5`](https://github.com/NixOS/nixpkgs/commit/ec3c1dd52f3b08977a489d3d55729923178c9189) | `` gat: 0.20.3 -> 0.21.1 ``                                                       |
| [`92dc29c5`](https://github.com/NixOS/nixpkgs/commit/92dc29c5667a176c6e12ebe8aac51b524ac5870f) | `` kittycad-kcl-lsp: 0.1.67 -> 0.1.69 ``                                          |
| [`b7ca780e`](https://github.com/NixOS/nixpkgs/commit/b7ca780ed2675ed4d00adf338c1815e4640dd343) | `` tinymist: 0.12.20 -> 0.12.22 ``                                                |
| [`4fe577d9`](https://github.com/NixOS/nixpkgs/commit/4fe577d9fac6eceef3d758a238b78b831baa1c25) | `` openrefine: 3.8.7 -> 3.9.0 ``                                                  |
| [`10f790b2`](https://github.com/NixOS/nixpkgs/commit/10f790b225c035b357ceadc65e19a545e9e5e594) | `` parlay: 0.7.0 -> 0.8.0 ``                                                      |
| [`92a55af5`](https://github.com/NixOS/nixpkgs/commit/92a55af5c56ef5d5ce31ad9c2a75e79fab4a1f88) | `` niri: refactor ``                                                              |
| [`cf7a6ca9`](https://github.com/NixOS/nixpkgs/commit/cf7a6ca95d8bea0ef5cdf069037c0c6bfb5fad09) | `` ryubing: 1.2.81 -> 1.2.82 ``                                                   |
| [`b5a2db2b`](https://github.com/NixOS/nixpkgs/commit/b5a2db2b4db02c05d93c9ea24fb8a0b543080324) | `` terraform-providers.equinix: 3.1.1 -> 3.2.0 ``                                 |
| [`cdd175ca`](https://github.com/NixOS/nixpkgs/commit/cdd175caa0676a290fbae686cfa736983aa7243c) | `` kvazaar: Fix build on FreeBSD ``                                               |
| [`67077f30`](https://github.com/NixOS/nixpkgs/commit/67077f30bdf7c4c0a9f0369cefb1a8b512705f3e) | `` zsh-fzf-tab: 1.1.2 -> 1.2.0 ``                                                 |
| [`fdb7b982`](https://github.com/NixOS/nixpkgs/commit/fdb7b9822b82be68ef907004714039c906281d9e) | `` parallel: 20250122 -> 20250222 ``                                              |
| [`2840ef5a`](https://github.com/NixOS/nixpkgs/commit/2840ef5a4d5a16a67ee68d3a26d8cbb3014e9803) | `` terraform-providers.spotinst: 1.209.1 -> 1.209.2 ``                            |
| [`b364d0a3`](https://github.com/NixOS/nixpkgs/commit/b364d0a337029c0b5d701bbb72d72ea6c22d3a9d) | `` borgmatic: add meta.mainProgram ``                                             |
| [`55ea910c`](https://github.com/NixOS/nixpkgs/commit/55ea910c1c51c5f2809fd45846097d295f2c047b) | `` openlinkhub: 0.5.0 -> 0.5.1 ``                                                 |
| [`4c2b4208`](https://github.com/NixOS/nixpkgs/commit/4c2b42082d2345f6f0058a9799934eefcd93a8fb) | `` bun: 1.2.2 -> 1.2.3 ``                                                         |
| [`e7f18964`](https://github.com/NixOS/nixpkgs/commit/e7f18964af37b1d0476f22c7c1acd71527a5b74a) | `` python313Packages.pygti: 0.9.4 -> 0.10.0 ``                                    |
| [`5024df2d`](https://github.com/NixOS/nixpkgs/commit/5024df2d7cde035b83715d0d908bafca9cfbb75f) | `` nixos/nix-daemon: allow nix implementations not following nix versioning ``    |
| [`b0c2cba4`](https://github.com/NixOS/nixpkgs/commit/b0c2cba470d8459f029a9dd8d45f61b6478b2f55) | `` mercure: 0.18.2 -> 0.18.4 ``                                                   |
| [`06b36bb5`](https://github.com/NixOS/nixpkgs/commit/06b36bb519629003bc79e4dcc0c4132b2e9e5c47) | `` libaom: fix building with llvm ``                                              |
| [`355a1dee`](https://github.com/NixOS/nixpkgs/commit/355a1dee213a14f79ec405de8ce2db6d31b8d051) | `` ioccheck: fix tweepy override ``                                               |
| [`1121a354`](https://github.com/NixOS/nixpkgs/commit/1121a35416de44ae22d7bec9fa2e50fa9d162da6) | `` python313Packages.scrapy-deltafetch: mark broken ``                            |
| [`a618a123`](https://github.com/NixOS/nixpkgs/commit/a618a1231dcd8a01c9af68a566496075b647f956) | `` python313Packages.scrapy-splash: 0.9.0 -> 0.11.1 ``                            |
| [`014021fd`](https://github.com/NixOS/nixpkgs/commit/014021fd282a73005f2352390d2eed5c2db0c758) | `` python313Packages.great-tables: fix build ``                                   |
| [`f2f4f6d3`](https://github.com/NixOS/nixpkgs/commit/f2f4f6d37e8b1509f24207478f3d227702e4a490) | `` python313Packages.faicons: init at 0.2.2 ``                                    |
| [`8a56b248`](https://github.com/NixOS/nixpkgs/commit/8a56b248d9cc34d8846854eae8fcb1a53b8e35ef) | `` python313Packages.shiny: fix tests ``                                          |
| [`8c37b89f`](https://github.com/NixOS/nixpkgs/commit/8c37b89ff43a771cf4d7043b8a199a279f39eb7e) | `` openscenegraph: Fixing compiling on Darwin ``                                  |
| [`e90dcee5`](https://github.com/NixOS/nixpkgs/commit/e90dcee515484449d2f6b85a61c2568cd41cd888) | `` simp_le: pin josepy to version 1.15.0 ``                                       |
| [`0b963658`](https://github.com/NixOS/nixpkgs/commit/0b96365893ab696cb33eabe4132af1641023c604) | `` home-assistant: pin josepy to version 1.15.0 ``                                |
| [`0d3dcf13`](https://github.com/NixOS/nixpkgs/commit/0d3dcf13a39834195ba52d3ac3c0f11cbf45147c) | `` certbot-full: remove broken plugin ``                                          |
| [`8403747b`](https://github.com/NixOS/nixpkgs/commit/8403747bdfa46adee13b85a9cfe5c8c0902a779f) | `` certbot: pin josepy to version 1.15.0 ``                                       |
| [`11838c38`](https://github.com/NixOS/nixpkgs/commit/11838c38dbd0743d11325b5c67c5b7c08360743a) | `` python313Packages.josepy: 1.15.0 -> 2.0.0 ``                                   |
| [`53739ec4`](https://github.com/NixOS/nixpkgs/commit/53739ec43a544e7a10c74924634460cb769d80c7) | `` miniflux: 2.2.5 -> 2.2.6 ``                                                    |
| [`1b02f51a`](https://github.com/NixOS/nixpkgs/commit/1b02f51a8713783f08db7a84c2a50aaa8770114b) | `` simp_le: unpin acme ``                                                         |
| [`96912b21`](https://github.com/NixOS/nixpkgs/commit/96912b21bf97764dd6d6ad61ccb94e572c654789) | `` vale-ls: allow overriding vale in PATH ``                                      |
| [`53d9c32f`](https://github.com/NixOS/nixpkgs/commit/53d9c32f921229c28b301a3f0cf45b7f2666d68c) | `` vscode-extensions.databricks.databricks: 2.3.1 -> 2.6.0 ``                     |
| [`eb34e702`](https://github.com/NixOS/nixpkgs/commit/eb34e70202190f82c28e8581a51026506b734ccd) | `` rymdport: 3.7.0 -> 3.8.0 ``                                                    |
| [`89440a51`](https://github.com/NixOS/nixpkgs/commit/89440a5116862f956210374e6f9e0d8ff49dd240) | `` pifpaf: 3.2.3 -> 3.3.0 ``                                                      |
| [`fb2551a2`](https://github.com/NixOS/nixpkgs/commit/fb2551a277ff1ed345566342ebd119e1a2406ca0) | `` python313Packages.quil: use nativeBuildInputs ``                               |
| [`25fb2896`](https://github.com/NixOS/nixpkgs/commit/25fb2896ea38048a6c4fd6e1e81dcd0fcd85c71f) | `` warp-terminal: 0.2025.02.19.08.02.stable_04 -> 0.2025.02.19.08.02.stable_05 `` |
| [`fba4d993`](https://github.com/NixOS/nixpkgs/commit/fba4d9937160986f2b0651b7f6f0858709a9f60c) | `` usql: 0.19.16 -> 0.19.17 ``                                                    |
| [`eb427bd3`](https://github.com/NixOS/nixpkgs/commit/eb427bd3bf9305c5dc4581b2e5bcf4bbdd084b9f) | `` isponsorblocktv: 2.2.1 -> 2.3.1 ``                                             |
| [`b55a92ac`](https://github.com/NixOS/nixpkgs/commit/b55a92acec54835f8a2003bddce033f00ab4a747) | `` ariang: 1.3.9 -> 1.3.10 ``                                                     |
| [`af8d3a48`](https://github.com/NixOS/nixpkgs/commit/af8d3a48cd2e71f588bc60e68ad5ea7c3fceb695) | `` mysql-shell-innovation: fix build on Linux ``                                  |
| [`b124d8ce`](https://github.com/NixOS/nixpkgs/commit/b124d8ceaf00e90467f5f2651fb69a28652446df) | `` lemurs: use versionCheckHook ``                                                |
| [`852d8d86`](https://github.com/NixOS/nixpkgs/commit/852d8d86c954f1993846b0f7b6f76745ea7ac477) | `` cargo-leptos: 0.2.27 -> 0.2.28 ``                                              |
| [`4b463c47`](https://github.com/NixOS/nixpkgs/commit/4b463c4760b35a8615555e05993455fb2b2fe0ce) | `` prometheus-pihole-exporter: 0.4.0 -> 1.0.0 ``                                  |
| [`698421d0`](https://github.com/NixOS/nixpkgs/commit/698421d0d9faf27479428c952eb7149c9b05e645) | `` python312Packages.nutpie: 0.13.2 -> 0.13.4 ``                                  |
| [`89f74e9a`](https://github.com/NixOS/nixpkgs/commit/89f74e9a0e934f2191ced01b00b17ae06ca289d4) | `` gh-dash: 4.11.0 -> 4.12.0 ``                                                   |
| [`7574a95a`](https://github.com/NixOS/nixpkgs/commit/7574a95a86bb08b9f16e126d47ebc9ef0ef4910a) | `` qxmpp: 1.9.4 -> 1.10.0 ``                                                      |
| [`a834e1a0`](https://github.com/NixOS/nixpkgs/commit/a834e1a0477a0c52024313f0118b497fb8d11da0) | `` python312Packages.oryx: 0.2.7 -> 0.2.9 ``                                      |
| [`7b6f2eee`](https://github.com/NixOS/nixpkgs/commit/7b6f2eee117a469a954bbbd39cc721bfc8609bd5) | `` e1s: 1.0.44 -> 1.0.45 ``                                                       |
| [`db4d31d4`](https://github.com/NixOS/nixpkgs/commit/db4d31d4f7e2e2a13d8f18818384f6c15d5beea5) | `` kubie: 0.24.1 -> 0.25.0 ``                                                     |
| [`a61120b3`](https://github.com/NixOS/nixpkgs/commit/a61120b3d5a18fc8a928472a18c2132350b5e897) | `` roon-server: 2.0-1496 -> 2.47.1510 ``                                          |
| [`83375986`](https://github.com/NixOS/nixpkgs/commit/833759866a44e49414d6a45d7aef42a3de1f05d2) | `` supersonic: 0.13.2 -> 0.14.0 ``                                                |
| [`1dde96d1`](https://github.com/NixOS/nixpkgs/commit/1dde96d1fd1910bacd489b86f7835fce5f001377) | `` kdePackages.qtforkawesome: 0.1.0 -> 0.3.1 ``                                   |
| [`e1b085ae`](https://github.com/NixOS/nixpkgs/commit/e1b085aec38653f0607ca5d43356924dd446ad3a) | `` qtforkawesome: refactor ``                                                     |