### PR TITLE
chore(flake/nixpkgs): `0196c017` -> `5135c594`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740367490,
-        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
+        "lastModified": 1740560979,
+        "narHash": "sha256-Vr3Qi346M+8CjedtbyUevIGDZW8LcA1fTG0ugPY/Hic=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
+        "rev": "5135c59491985879812717f4c9fea69604e7f26f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`a8ff6cf2`](https://github.com/NixOS/nixpkgs/commit/a8ff6cf2e076f49a01f8568b83f332a29c1b782a) | `` nixos/release-small: fix nesting on new acme tests ``                            |
| [`07f24f59`](https://github.com/NixOS/nixpkgs/commit/07f24f592b7b69277c8b440cdb3c7782948507e7) | `` exiv2: 0.28.4 -> 0.28.5 ``                                                       |
| [`23cb6b69`](https://github.com/NixOS/nixpkgs/commit/23cb6b69f0380e11432391a86c9005a9a7ed8a26) | `` symfony-cli: 5.10.9 -> 5.11.0 ``                                                 |
| [`88d1fc20`](https://github.com/NixOS/nixpkgs/commit/88d1fc206b2a43c28d1793222016ec235bfb03fd) | `` phpExtensions.memprof: 3.0.2 -> 3.1.0 ``                                         |
| [`f50e86a2`](https://github.com/NixOS/nixpkgs/commit/f50e86a2a5568e3b2c21ef025246cbdc52705c4c) | `` kdePackages.kwin: 6.3.2 -> 6.3.2.1 ``                                            |
| [`c273acfb`](https://github.com/NixOS/nixpkgs/commit/c273acfbfeabe1c3b41da6fd009ae6594cf6e203) | `` incus-ui-canonical: 0.14.6 -> 0.15 ``                                            |
| [`42419fab`](https://github.com/NixOS/nixpkgs/commit/42419faba2485547862e7116c0017131f9354d0e) | `` scaleway-cli: 2.36.0 -> 2.37.0 ``                                                |
| [`9e23d798`](https://github.com/NixOS/nixpkgs/commit/9e23d798aada60880b81dcbf7ca5520972d73f1c) | `` kanata: fix darwin build ``                                                      |
| [`a6874344`](https://github.com/NixOS/nixpkgs/commit/a68743444176cdc9bca2dfe307c8a6ec53f7c746) | `` kdePackages.waylib: 0.6.10-alpha -> 0.6.11 ``                                    |
| [`31f0a8b6`](https://github.com/NixOS/nixpkgs/commit/31f0a8b6fae8c82e14126b31c91ecc31ec28fa89) | `` firefox: use regular wrapper ``                                                  |
| [`e8a420aa`](https://github.com/NixOS/nixpkgs/commit/e8a420aa9d65341bcc6f9788a4a0389ae4f1bb6f) | `` python313Packages.aioesphomeapi: 29.1.1 -> 29.2.0 ``                             |
| [`1f05c38a`](https://github.com/NixOS/nixpkgs/commit/1f05c38ab8b237f98bd2efba3fd3a0c90b5b4e28) | `` fetchgit: now accepts nativeBuildInputs, similar to e.g. fetchzip, fetchpatch `` |
| [`df3f0432`](https://github.com/NixOS/nixpkgs/commit/df3f043232c2e65ab780bfd52f2c0c9bc19727af) | `` python312Packages.equinox: 0.11.11 -> 0.11.12 ``                                 |
| [`a5f9eff9`](https://github.com/NixOS/nixpkgs/commit/a5f9eff98304c4b066c65764d0b096bf091b6f38) | `` esphome: 2025.2.0 -> 2025.2.1 ``                                                 |
| [`89f72f45`](https://github.com/NixOS/nixpkgs/commit/89f72f45aa1a3296c599908d3650e0be1ca2c336) | `` claude-code: 0.2.9 -> 0.2.14 ``                                                  |
| [`e3144303`](https://github.com/NixOS/nixpkgs/commit/e3144303f50fa4c60c90aa69d84a82546cdfe2e6) | `` pretix: pin geoip2 at 5.0.1 ``                                                   |
| [`31474826`](https://github.com/NixOS/nixpkgs/commit/31474826bf6c5d9e85a196f968bf47971d5a5bfe) | `` Revert "python313Packages.geoip2: 4.8.1 -> 5.0.1" ``                             |
| [`5638f2f3`](https://github.com/NixOS/nixpkgs/commit/5638f2f36d9eb5d564c5acde80769687bdd92bf8) | `` find-billy: 0.37.3 -> 1.0.12 ``                                                  |
| [`382bd9fc`](https://github.com/NixOS/nixpkgs/commit/382bd9fc3ad5691ea10fd09a4845707a89306c0a) | `` pretix.plugins.zugferd: 2.3.0 -> 2.4.0 ``                                        |
| [`c8b63983`](https://github.com/NixOS/nixpkgs/commit/c8b639835d52a3119f4e9c4176644d1f1a2ae5bf) | `` pretix.plugins.passbook: 1.13.2 -> 1.13.3 ``                                     |
| [`42295074`](https://github.com/NixOS/nixpkgs/commit/422950740359e8144a3d61f9a3489ad55ace64a0) | `` pretix.plugins.mollie: 2.2.2 -> 2.3.0 ``                                         |
| [`5ffbe2c3`](https://github.com/NixOS/nixpkgs/commit/5ffbe2c3196d4038fc737463d838534d64d2d3da) | `` pretix: 2025.1.0 -> 2025.2.0 ``                                                  |
| [`ea700201`](https://github.com/NixOS/nixpkgs/commit/ea700201cca56dc77aaee31d3ce704aafa5b98e1) | `` qmk-udev-rules: 0.23.3 -> 0.27.13 (#385013) ``                                   |
| [`0e4a14a3`](https://github.com/NixOS/nixpkgs/commit/0e4a14a3c2017f0ca69126c1741f96b5d6e7c199) | `` xwayland: 24.1.5 -> 24.1.6 ``                                                    |
| [`073c03ba`](https://github.com/NixOS/nixpkgs/commit/073c03ba0e87bd343526a0ff854fbe1d484286e3) | `` python312Packages.ariadne: 0.25.2 -> 0.26.1 ``                                   |
| [`273183f0`](https://github.com/NixOS/nixpkgs/commit/273183f0f8da36ac6dba3102ead77824f3ad92d6) | `` python313Packages.geoip2: 4.8.1 -> 5.0.1 ``                                      |
| [`3148a0cf`](https://github.com/NixOS/nixpkgs/commit/3148a0cf6276d727c3a42b2a4d30ccb237bbac3d) | `` python313Packages.django-filter: 24.3 -> 25.1 ``                                 |
| [`4c01a754`](https://github.com/NixOS/nixpkgs/commit/4c01a754d4ea4d614ff93762ed11c3cfca21903f) | `` ghidra-extensions.kaiju: 241204 -> 250220 ``                                     |
| [`fc42951b`](https://github.com/NixOS/nixpkgs/commit/fc42951bdccb018c69f0ac9f92be77ee94ef9158) | `` aiken: 1.1.11 -> 1.1.12 ``                                                       |
| [`9721e7a3`](https://github.com/NixOS/nixpkgs/commit/9721e7a3e7524286c0bdbcff204312bf5ca0cc58) | `` api-linter: 1.69.0 -> 1.69.2 ``                                                  |
| [`4eb4006a`](https://github.com/NixOS/nixpkgs/commit/4eb4006a31e0d23e75020cc95ce1670e702afb01) | `` chromium,chromedriver: 133.0.6943.126 -> 133.0.6943.141 ``                       |