### PR TITLE
chore(flake/git-hooks): `9364dc02` -> `25d4946d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737465171,
-        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
+        "lastModified": 1740870877,
+        "narHash": "sha256-LWDIJvKWMW0tiih1jTcAK0ncTi3S9IF3gOhpCT1ydik=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
+        "rev": "25d4946dfc2021584f5bde1fbd2aa97353384a95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`3adca9e8`](https://github.com/cachix/git-hooks.nix/commit/3adca9e8ed94feefb52765a0645e65a8ced04c2c) | `` Exposes configPath to the run wrapper ``                |
| [`741fee02`](https://github.com/cachix/git-hooks.nix/commit/741fee02daf336cbca92e2887fbfb6d36050d305) | `` feat: add proselint (#555) ``                           |
| [`c9d05edf`](https://github.com/cachix/git-hooks.nix/commit/c9d05edf105495791fd154dd6f4ca626bfee0d3d) | `` dev: drop shellcheck from our dev checks ``             |
| [`3234ee65`](https://github.com/cachix/git-hooks.nix/commit/3234ee65344afdeada9c97408ee310647b801e44) | `` Update modules/hooks.nix ``                             |
| [`9a456ab1`](https://github.com/cachix/git-hooks.nix/commit/9a456ab1a5a25788915e8a0ecaec35970f163bfb) | `` feat: add mdformat hook ``                              |
| [`d8bf272f`](https://github.com/cachix/git-hooks.nix/commit/d8bf272fdf5afb4efe9b45c6cebde91d5776422b) | `` feat: add dart format and dart analyze hook ``          |
| [`ba017b20`](https://github.com/cachix/git-hooks.nix/commit/ba017b20949d15ee5989e37cd283c9abf4ef39a5) | `` feat: add gitlint hook ``                               |
| [`0dcaa895`](https://github.com/cachix/git-hooks.nix/commit/0dcaa8952727eedd9d140a61e68a46113dae1ae9) | `` feat: openapi-spec-validator ``                         |
| [`f2fcd043`](https://github.com/cachix/git-hooks.nix/commit/f2fcd0436f5ff0bceaaa1832edc5354bd830c55b) | `` Improve error message ``                                |
| [`46930280`](https://github.com/cachix/git-hooks.nix/commit/46930280dc37703b7c28dfc4d4b12fa82f598852) | `` Run all validations and exit 1 if one of them failed `` |
| [`4ec8f406`](https://github.com/cachix/git-hooks.nix/commit/4ec8f406ac9d59eaf79303a26192e780468289d4) | `` Print file path ``                                      |
| [`27cf82e6`](https://github.com/cachix/git-hooks.nix/commit/27cf82e6e0ead266e516715c2fa3c5823360d90b) | `` Add missing parenthesis ``                              |
| [`8b60f8b8`](https://github.com/cachix/git-hooks.nix/commit/8b60f8b8aae2ec80395df1f81148ca412c61792b) | `` Loop over all files that changed ``                     |
| [`18e58987`](https://github.com/cachix/git-hooks.nix/commit/18e5898730572dfcb17d22e56407b991e81d45ef) | `` Update file filter ``                                   |
| [`c2fbe2db`](https://github.com/cachix/git-hooks.nix/commit/c2fbe2dbf51f219020042f87e9fb81dcd0c0e927) | `` Look for changes on all files inside .circleci ``       |
| [`231e0ee0`](https://github.com/cachix/git-hooks.nix/commit/231e0ee07565895df670946642fd6ab3099b10da) | `` feat: Add CircleCI hook ``                              |
| [`324069d7`](https://github.com/cachix/git-hooks.nix/commit/324069d7531266ce3a3a49e3c199b2a739d5c5d2) | `` pretty-format-json: expose tool options in settings ``  |
| [`129cb475`](https://github.com/cachix/git-hooks.nix/commit/129cb475213bdb9bd6e34442aa77eaeebd4ad424) | `` yamlfmt: allow formatting during hook run ``            |
| [`8dd173fe`](https://github.com/cachix/git-hooks.nix/commit/8dd173fea096445d8e61c342827bb4a223231778) | `` fix: add configFile option ``                           |
| [`bf798609`](https://github.com/cachix/git-hooks.nix/commit/bf798609c796fb8e9945c5b87dc014c9b7a3058d) | `` feat: update pre-commit.nix to be "run" customizable `` |