### PR TITLE
chore(flake/nixpkgs): `5135c594` -> `6313551c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740560979,
-        "narHash": "sha256-Vr3Qi346M+8CjedtbyUevIGDZW8LcA1fTG0ugPY/Hic=",
+        "lastModified": 1740695751,
+        "narHash": "sha256-D+R+kFxy1KsheiIzkkx/6L63wEHBYX21OIwlFV8JvDs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5135c59491985879812717f4c9fea69604e7f26f",
+        "rev": "6313551cd05425cd5b3e63fe47dbc324eabb15e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
| [`11a70a5b`](https://github.com/NixOS/nixpkgs/commit/11a70a5bfccb5dd430b8742907610b3b0cf0a665) | `` terraform: 1.10.5 -> 1.11.0 ``                                                                             |
| [`439d34ff`](https://github.com/NixOS/nixpkgs/commit/439d34ffd18d8c82180fb4ef61fbb11b3396b97b) | `` organicmaps: use finalAttrs pattern ``                                                                     |
| [`a609f05d`](https://github.com/NixOS/nixpkgs/commit/a609f05d15bb95d02469fcb56650c995b217ed11) | `` organicmaps: 2025.01.26-9 -> 2025.02.17-3 ``                                                               |
| [`4e2fa1f5`](https://github.com/NixOS/nixpkgs/commit/4e2fa1f58a4c0a951b8c3a19139fdd4591b55216) | `` vengi-tools: 0.0.34 -> 0.0.35 ``                                                                           |
| [`ecb5ffeb`](https://github.com/NixOS/nixpkgs/commit/ecb5ffeb8b518caafdf438722714a661372d4d7b) | `` nix-search-tv: 2.0.0 -> 2.1.0 ``                                                                           |
| [`c3df4c92`](https://github.com/NixOS/nixpkgs/commit/c3df4c92ef459dea4e20a0d64acfd8578c351a71) | `` ladybird: don't use `with qt6Packages;` ``                                                                 |
| [`421b5dd9`](https://github.com/NixOS/nixpkgs/commit/421b5dd9f4d86d4831a1842a68b99e9d16f68d86) | `` ladybird: move to pkgs/by-name ``                                                                          |
| [`0e8e9025`](https://github.com/NixOS/nixpkgs/commit/0e8e90254e90b74e4f274afeb7ef5e0ce01cede8) | `` ladybird: format with nixfmt ``                                                                            |
| [`36a3c6c1`](https://github.com/NixOS/nixpkgs/commit/36a3c6c11df8273fde7653f58ef094365507fefa) | `` nixos/paperless: move paperless-manage to proper systemPackage ``                                          |
| [`70edb92e`](https://github.com/NixOS/nixpkgs/commit/70edb92e41b102d0b74f4d27f265f586d5056acc) | `` claude-code: 0.2.14 -> 0.2.19 ``                                                                           |
| [`ac954e82`](https://github.com/NixOS/nixpkgs/commit/ac954e829508098bdd8c45926e7412678dfb0e96) | `` python312Packages.openai: 1.63.0 -> 1.65.0 ``                                                              |
| [`99ead951`](https://github.com/NixOS/nixpkgs/commit/99ead951906a83b5623f6fed87414b41c33fd259) | `` steamtinkerlaunch: add missing lsusb ``                                                                    |
| [`6d9c693d`](https://github.com/NixOS/nixpkgs/commit/6d9c693d233a160fc8a460670f6074915a6f6bfc) | `` open-webui: 0.5.17 -> 0.5.18 ``                                                                            |
| [`e81d326b`](https://github.com/NixOS/nixpkgs/commit/e81d326b9c1a54f0d9f384204621e80a88391285) | `` jetbrains-toolbox: 2.5.3.37797 -> 2.5.4.38621 ``                                                           |
| [`388b3c37`](https://github.com/NixOS/nixpkgs/commit/388b3c37ee8765ec6ed84c3fb5d21145c3ff56ae) | `` libredirect: fix typo ``                                                                                   |
| [`045211b4`](https://github.com/NixOS/nixpkgs/commit/045211b428da7449b35a376deeee2bad9bbd773a) | `` nixos/tests/nscd: fix typo ``                                                                              |
| [`b343f7a1`](https://github.com/NixOS/nixpkgs/commit/b343f7a126f0c197d4c18b7d51ad7c935273348e) | `` headscale: 0.25.0 -> 0.25.1, fix tests on darwin ``                                                        |
| [`33c162c0`](https://github.com/NixOS/nixpkgs/commit/33c162c0902736cd8911485438dfbb0abec8d481) | `` testers.testBuildFailure': inline let expression ``                                                        |
| [`d2a0e52d`](https://github.com/NixOS/nixpkgs/commit/d2a0e52d0979127183f90d067aa87825178c35c4) | `` testers.testBuildFailure': replace import with callPackage ``                                              |
| [`8d8d8cfd`](https://github.com/NixOS/nixpkgs/commit/8d8d8cfd28e40f43fdf1ea171acfb2312ce2345f) | `` rkpd2: 2.0.6 -> 2.0.7 ``                                                                                   |
| [`bdb17b5f`](https://github.com/NixOS/nixpkgs/commit/bdb17b5f23d259ba729700b10190fe6655143b46) | `` python312Packages.boto3-stubs: 1.36.26 -> 1.37.2 ``                                                        |
| [`15b46a9c`](https://github.com/NixOS/nixpkgs/commit/15b46a9c5aae323dab8ebafec8d2865a70cd6842) | `` dayon: 16.0.0 -> 16.0.1 ``                                                                                 |
| [`e5c85077`](https://github.com/NixOS/nixpkgs/commit/e5c850779dad4b97d52678d45c7b256973b28c8d) | `` zed-editor: 0.174.6 -> 0.175.5 ``                                                                          |
| [`f8cef065`](https://github.com/NixOS/nixpkgs/commit/f8cef0650371569474a4dd14c3cb67608d2effef) | `` python312Packages.stdlib-list: 0.11.0 -> 0.11.1 ``                                                         |
| [`9e422e63`](https://github.com/NixOS/nixpkgs/commit/9e422e63caff1774d6d71a986e4d1ca846ef7367) | `` testers.testBuildFailure': create local bindings for loop variables to prevent lexical scoping mistakes `` |
| [`25833baa`](https://github.com/NixOS/nixpkgs/commit/25833baaa4556f09f30a63b7ddbebfe6a8dfffd1) | `` testers.testBuildFailure': use default.nix and move recurseIntoAttrs into tests.nix ``                     |
| [`467cbf40`](https://github.com/NixOS/nixpkgs/commit/467cbf403b0f3497e856569ea4945d9bd39cf99f) | `` tests.testers.testBuildFailure': add negative tests for exit code check and log check ``                   |
| [`8ef0cbd1`](https://github.com/NixOS/nixpkgs/commit/8ef0cbd15be6caea67f5128973eb8cb20d248400) | `` testers.testBuildFailure': move tests to preScriptHooks ``                                                 |
| [`95c8770f`](https://github.com/NixOS/nixpkgs/commit/95c8770fa23b136472b8051ea12358b9e0c9da55) | `` testers.testBuildFailure': move to separate directory and use buildCommandPath ``                          |
| [`2ac21a13`](https://github.com/NixOS/nixpkgs/commit/2ac21a13756d179b2134f7265d41f034fc673915) | `` testers.testBuildFailure': use more strict bash for checks ``                                              |
| [`f71332b2`](https://github.com/NixOS/nixpkgs/commit/f71332b2ae893de049f2d1237b0ed8ddbf7fead0) | `` testers.testBuildFailure': output is created so long as checks succeed ``                                  |
| [`38745b13`](https://github.com/NixOS/nixpkgs/commit/38745b132d0e59ed110070c9c35256a16d716781) | `` testers.testBuildFailure': init ``                                                                         |
| [`cf1982ff`](https://github.com/NixOS/nixpkgs/commit/cf1982ff8e68c45ac9c20dd1226ff6c4f64eb891) | `` python312Packages.cleanlab: 2.7.0 -> 2.7.1 ``                                                              |
| [`4141a483`](https://github.com/NixOS/nixpkgs/commit/4141a48395dc601fef95b650d81f9ecdff444434) | `` python3Packages.systemdunitparser: init at 0.3 (#385337) ``                                                |
| [`672da88f`](https://github.com/NixOS/nixpkgs/commit/672da88f69ad5147cd9f10534d3c7338b73f7d7e) | `` lavacli: update maintainers to team cyberus ``                                                             |
| [`70178821`](https://github.com/NixOS/nixpkgs/commit/70178821bc801118303d384d7110a98e77619743) | `` vimPlugins.avante-nvim: 0.0.19 -> 0.0.21 ``                                                                |
| [`5bc67426`](https://github.com/NixOS/nixpkgs/commit/5bc674263ac93995073ef6dad4489b4fc3aa9ccc) | `` vimPlugins.avante-nvim: add jackres to maintainers ``                                                      |
| [`528982b2`](https://github.com/NixOS/nixpkgs/commit/528982b21daa1bf9f87e6eb78b420a50b508e87d) | `` maintainers: add jackres ``                                                                                |
| [`bb89d01e`](https://github.com/NixOS/nixpkgs/commit/bb89d01e2e2de55debfbbcfcb0c48e7c36b96bc6) | `` raycast: 1.92.1 -> 1.93.0 ``                                                                               |
| [`094a544d`](https://github.com/NixOS/nixpkgs/commit/094a544d13b5855d4cf131a30daf33ddb49c2c37) | `` mirrord: 3.132.1 -> 3.134.0 ``                                                                             |
| [`728b8e8e`](https://github.com/NixOS/nixpkgs/commit/728b8e8e8bcce960b46584db1e6f51df99cdfc6c) | `` python312Packages.plaid-python: 29.0.0 -> 29.1.0 ``                                                        |
| [`69850728`](https://github.com/NixOS/nixpkgs/commit/6985072845472bf2390d8c57b14096bb853be588) | `` ruff: 0.9.7 -> 0.9.8 ``                                                                                    |
| [`e36a2c14`](https://github.com/NixOS/nixpkgs/commit/e36a2c1442d6c49592fe19f77d20a2846012df69) | `` obs-studio-plugins.obs-composite-blur: 1.1.0 -> 1.5.0 ``                                                   |
| [`01444d70`](https://github.com/NixOS/nixpkgs/commit/01444d700dac69715a6092051b8277d08dbb5fe0) | `` python312Packages.tensordict: 0.7.1 -> 0.7.2 ``                                                            |
| [`26710437`](https://github.com/NixOS/nixpkgs/commit/26710437ae95d42ee0d4c2024792592f9287a544) | `` oculante: 0.9.1 → 0.9.2 (#385273) ``                                                                       |
| [`1a60c31e`](https://github.com/NixOS/nixpkgs/commit/1a60c31e13a587016086443c4602fb6311d07423) | `` k0sctl: 0.22.0 -> 0.23.0 ``                                                                                |
| [`c79093ae`](https://github.com/NixOS/nixpkgs/commit/c79093aec6994b5e4b91284a5a7bad4ac51fbfb4) | `` subfinder: 2.6.8 -> 2.7.0 ``                                                                               |
| [`41dd7bb8`](https://github.com/NixOS/nixpkgs/commit/41dd7bb803924266c3958fb6933fbf00ace9cdfd) | `` interactsh: 1.2.3 -> 1.2.4 ``                                                                              |
| [`eda85905`](https://github.com/NixOS/nixpkgs/commit/eda8590568ff8b06b440662debe93d7ec2b13848) | `` watchlog: 1.242.0 -> 1.244.0 ``                                                                            |
| [`2acc130f`](https://github.com/NixOS/nixpkgs/commit/2acc130f195bd48ed2fd99aa0a0a6c150d08e5e5) | `` checkov: 3.2.373 -> 3.2.377 ``                                                                             |
| [`1fc3c8d4`](https://github.com/NixOS/nixpkgs/commit/1fc3c8d4b68dcb450d3c67a8573d003c6aa1d9f2) | `` python313Packages.publicsuffixlist: 1.0.2.20250225 -> 1.0.2.20250227 ``                                    |
| [`6f7c7f4f`](https://github.com/NixOS/nixpkgs/commit/6f7c7f4fe7df0688576063ea1e0b17e136606462) | `` libreswan: 5.1 -> 5.2 ``                                                                                   |
| [`851f2391`](https://github.com/NixOS/nixpkgs/commit/851f239182261238c0d9cac9cc7fba745e111b9f) | `` open-webui: 0.5.16 -> 0.5.17 ``                                                                            |
| [`f9563d14`](https://github.com/NixOS/nixpkgs/commit/f9563d141d3f2cf9f08093a8d68d542fa88db98e) | `` python312Packages.azure-ai-documentintelligence: init at 1.0.0 ``                                          |
| [`7e487db9`](https://github.com/NixOS/nixpkgs/commit/7e487db9da440ce3e5acca17c60eda93e00b0c8b) | `` hey-mail: 1.2.16 -> 1.2.17 ``                                                                              |
| [`e5720061`](https://github.com/NixOS/nixpkgs/commit/e5720061623c7e0a5606300ad3497a1333bc0422) | `` exo: 0.0.10-alpha -> 0.0.14-alpha ``                                                                       |
| [`31799526`](https://github.com/NixOS/nixpkgs/commit/3179952600d9afb15beb0390a835f3c522d89ce1) | `` polypane: 23.1.0 -> 23.1.1 ``                                                                              |
| [`e1a7d136`](https://github.com/NixOS/nixpkgs/commit/e1a7d136a83a93a260f0da5d66c9a4907c5ba130) | `` nixos-anywhere: 1.7.0 -> 1.8.0 ``                                                                          |
| [`bf19c36d`](https://github.com/NixOS/nixpkgs/commit/bf19c36d1bd1024789bba19be23b4398dd84808d) | `` nixos-anywhere: add myself as a maintainer ``                                                              |
| [`1418c0d0`](https://github.com/NixOS/nixpkgs/commit/1418c0d0bec1ecf410f6bce844a044b12836e90e) | `` teleport_17: 17.2.8 -> 17.2.9 ``                                                                           |
| [`cc608b02`](https://github.com/NixOS/nixpkgs/commit/cc608b0240594fd87737c634cebb26c20c6382db) | `` libguestfs-with-appliance: relax version check & use provided libguestfsCompatible ``                      |
| [`9600480a`](https://github.com/NixOS/nixpkgs/commit/9600480a2f1249c37fa0c3cc3fc53c1503efad74) | `` libguestfs: nixfmt ``                                                                                      |
| [`98b6b67b`](https://github.com/NixOS/nixpkgs/commit/98b6b67b49c6b5b35a54ce83784137c5600dedb7) | `` cntb: 1.5.2 -> 1.5.3 ``                                                                                    |
| [`ee9e6fa9`](https://github.com/NixOS/nixpkgs/commit/ee9e6fa97d6e54fc524eaab6273279efae448027) | `` opentofu-ls: 0-unstable-2025-01-01 -> 0-unstable-2025-02-26 ``                                             |
| [`b7e14ed6`](https://github.com/NixOS/nixpkgs/commit/b7e14ed68e4a396e10d807b67ce43eeec583cc23) | `` redo-sh: 4.0.4 -> 4.0.6 ``                                                                                 |
| [`6ffa2a56`](https://github.com/NixOS/nixpkgs/commit/6ffa2a56d0f426001ed9f1bcf4e2b332e7d9aaad) | `` tinymist: 0.13.0 -> 0.13.2 ``                                                                              |
| [`3c6ef114`](https://github.com/NixOS/nixpkgs/commit/3c6ef11418ae28096d19a7e4ade681a8c7855a48) | `` gdmap: 0.8.1 -> 1.2.0 (switching to GTK 3 port / fork) ``                                                  |
| [`fe279f31`](https://github.com/NixOS/nixpkgs/commit/fe279f31c40a6bbc671ec7d727f1f11eda6ccb8b) | `` python312Packages.fsspec-xrootd: 0.4.0 -> 0.5.0 ``                                                         |
| [`668edce3`](https://github.com/NixOS/nixpkgs/commit/668edce3dd8c0ed8dd7b803c66c5f0b330af5ece) | `` python312Packages.cvxpy: 1.6.1 -> 1.6.2 ``                                                                 |
| [`408aaffc`](https://github.com/NixOS/nixpkgs/commit/408aaffcd7154e38dd74eceef93afd8f588ccee6) | `` polyglot: 3.6 -> 3.6.1 ``                                                                                  |
| [`693442b2`](https://github.com/NixOS/nixpkgs/commit/693442b29d332310b380a30c7ed8d1a31e543117) | `` baidupcs-go: add a lower-case shortcut ``                                                                  |
| [`93609c09`](https://github.com/NixOS/nixpkgs/commit/93609c09dbcf7f04e41c7e7e955d95a09e65152a) | `` rye: 0.43.0 -> 0.44.0 ``                                                                                   |
| [`dc5b1aa8`](https://github.com/NixOS/nixpkgs/commit/dc5b1aa80dc58fb61d133f3888cd32ba5261a65d) | `` python313Packages.awkward: disable failing test ``                                                         |
| [`a24e146d`](https://github.com/NixOS/nixpkgs/commit/a24e146d7bde2061f7a9e93470dee34ab77c9951) | `` maintainers/team-list: add snu to cyberus ``                                                               |
| [`7d443d37`](https://github.com/NixOS/nixpkgs/commit/7d443d378b07ad55686e9ba68faf16802c030025) | `` nixos/oci-containers: support rootless containers & healthchecks ``                                        |
| [`66399dc7`](https://github.com/NixOS/nixpkgs/commit/66399dc7bfba27c2063e6e8ce7b7327636a5e61a) | `` rabbitmqadmin-ng: init at 0.24.0 ``                                                                        |
| [`089a36d7`](https://github.com/NixOS/nixpkgs/commit/089a36d773664b4da43809d8ee3c5457cfe8915f) | `` applet-window-buttons6: 0.13.0 -> 0.14.0 ``                                                                |
| [`afb21d2e`](https://github.com/NixOS/nixpkgs/commit/afb21d2e6291c906a527b84cd98418251d04ff94) | `` jasmin-compiler: 2024.07.2 → 2024.07.3 ``                                                                  |
| [`dc315963`](https://github.com/NixOS/nixpkgs/commit/dc3159632c89018df794628d57146f603cfd90eb) | `` eza: 0.20.22 -> 0.20.23 ``                                                                                 |
| [`1c27c12e`](https://github.com/NixOS/nixpkgs/commit/1c27c12e19291e598de71533963d8f7907e93062) | `` typst: fix high cpu load when using `typst watch` ``                                                       |
| [`d60f75c3`](https://github.com/NixOS/nixpkgs/commit/d60f75c3467b44dc4ec1861bba54639a4b265970) | `` man-pages: 6.11 -> 6.12 ``                                                                                 |
| [`e5992c0f`](https://github.com/NixOS/nixpkgs/commit/e5992c0fa7f69d21312a9486b789c4b1969ab6be) | `` adminneo: 4.14 -> 4.15 ``                                                                                  |
| [`11310179`](https://github.com/NixOS/nixpkgs/commit/11310179398d1dc4c370a621b11756aa1fe74e99) | `` adminneo: change package name ``                                                                           |
| [`5cdc3567`](https://github.com/NixOS/nixpkgs/commit/5cdc35673200b7115a491157305bc4844e3c86b4) | `` llvmPackages_20: 20.1.0-rc2 -> 20.1.0-rc3 ``                                                               |
| [`a2f3625d`](https://github.com/NixOS/nixpkgs/commit/a2f3625d99124dcb88f7da0061d80052827797d5) | `` poppler-utils: rename from poppler_utils ``                                                                |
| [`ce71b208`](https://github.com/NixOS/nixpkgs/commit/ce71b208825139334a25afb14a6db2e1cfbff93e) | `` uwsm: 0.20.5 -> 0.21.1 ``                                                                                  |
| [`0e157f03`](https://github.com/NixOS/nixpkgs/commit/0e157f036f574fb459a38827a31457737a03295a) | `` bun: 1.2.3 -> 1.2.4 ``                                                                                     |
| [`7e79f544`](https://github.com/NixOS/nixpkgs/commit/7e79f544ef2e82ea37098424525dd30d550156fb) | `` python312Packages.pynmeagps: 1.0.44 -> 1.0.45 ``                                                           |
| [`d6fde23c`](https://github.com/NixOS/nixpkgs/commit/d6fde23c7a50cf47485e28fa0c51b8ed4cfdf1d7) | `` easycrypt: 2024.09 → 2025.02 ``                                                                            |
| [`fc4cf065`](https://github.com/NixOS/nixpkgs/commit/fc4cf06502a8d4582c4d0ed98db36ab69f298bde) | `` pnpm: 10.4.1 -> 10.5.2 ``                                                                                  |
| [`aa806797`](https://github.com/NixOS/nixpkgs/commit/aa806797ce0acf4b0326e5e78edb64d97398fa72) | `` python312Packages.model-bakery: 1.20.3 -> 1.20.4 ``                                                        |
| [`0f69e932`](https://github.com/NixOS/nixpkgs/commit/0f69e9322506ef0fe50c0a5a2e39754f226342c3) | `` ada: 3.1.0 -> 3.1.2 ``                                                                                     |
| [`1d729f64`](https://github.com/NixOS/nixpkgs/commit/1d729f64bf3a2f729fd1d3b7ffd68aaa45e03bcf) | `` python312Packages.pylacus: 1.12.1 -> 1.13.0 ``                                                             |
| [`6a0ba680`](https://github.com/NixOS/nixpkgs/commit/6a0ba68039594c1382d503f68e71a5217b3eb1b9) | `` Revert "Fix Xf86videointel driver immediate crash on NixOS (Mesa Patch Backport)" ``                       |
| [`b2415b8e`](https://github.com/NixOS/nixpkgs/commit/b2415b8e968b59787b396f8139bb07d133857f6e) | `` izrss: 0.1.0 -> 0.1.2 ``                                                                                   |
| [`37f9a3e8`](https://github.com/NixOS/nixpkgs/commit/37f9a3e87f44dccd98dcdc8ca3943fc7cb868ab2) | `` libdeltachat: 1.155.6 -> 1.156.0 ``                                                                        |
| [`f544aafe`](https://github.com/NixOS/nixpkgs/commit/f544aafeebdf37bc28e71f209987c4df3296d6b8) | `` python312Packages.pyeconet: 0.1.27 -> 0.1.28 ``                                                            |
| [`086d848f`](https://github.com/NixOS/nixpkgs/commit/086d848f8103d2d638a05f26f879a34ad7697bab) | `` stackql: 0.6.65 -> 0.6.95 ``                                                                               |