### PR TITLE
chore(flake/nixvim): `6f8d8f7a` -> `03065fd4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1740520037,
-        "narHash": "sha256-TpZMYjOre+6GhKDVHFwoW2iBWqpNQppQTuqIAo+OBV8=",
+        "lastModified": 1741098523,
+        "narHash": "sha256-gXDSXDr6tAb+JgxGMvcEjKC9YO8tVOd8hMMZHJLyQ6Q=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6f8d8f7aee84f377f52c8bb58385015f9168a666",
+        "rev": "03065fd4708bfdf47dd541d655392a60daa25ded",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`03065fd4`](https://github.com/nix-community/nixvim/commit/03065fd4708bfdf47dd541d655392a60daa25ded) | `` tests/none-ls: remove beautysh test (removed upstream) `` |
| [`98512462`](https://github.com/nix-community/nixvim/commit/98512462414c39ab404facb88a5bec061e8495b9) | `` tests: re-enable tests that work ``                       |