### PR TITLE
chore(flake/nixpkgs): `d69ab0d7` -> `10069ef4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741173522,
-        "narHash": "sha256-k7VSqvv0r1r53nUI/IfPHCppkUAddeXn843YlAC5DR0=",
+        "lastModified": 1741246872,
+        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d69ab0d71b22fa1ce3dbeff666e6deb4917db049",
+        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`4f4891ec`](https://github.com/NixOS/nixpkgs/commit/4f4891ecf95017e51ceb91cc5a037d8e5806a16d) | `` calamares: add .tests ``                                                                  |
| [`469fa07b`](https://github.com/NixOS/nixpkgs/commit/469fa07be0aff059259376d05db752516191e549) | `` Revert "calamares: 3.3.13 -> 3.3.14" ``                                                   |
| [`bf274024`](https://github.com/NixOS/nixpkgs/commit/bf27402467bb50350cbde6f257e9daaf86e8a111) | `` addwater: 1.2.5 -> 1.2.6 ``                                                               |
| [`ca348247`](https://github.com/NixOS/nixpkgs/commit/ca3482476eca711ff25017174ef3da082d82d289) | `` xf86-video-vmware: drop the now useless mesa dependency ``                                |
| [`afe2ba39`](https://github.com/NixOS/nixpkgs/commit/afe2ba39e434c7a0cabda09d893d1e489ac2d6a6) | `` mesa: output cleanup, part 1 ``                                                           |
| [`a103c836`](https://github.com/NixOS/nixpkgs/commit/a103c8363af282437fd514cfacf2cf55b6380e89) | `` mutter46: use mesa-gl-headers ``                                                          |
| [`9dc26d95`](https://github.com/NixOS/nixpkgs/commit/9dc26d95a5f9694c52bd44c62e5d28e494dd18d7) | `` mutter: use mesa-gl-headers ``                                                            |
| [`70247ee7`](https://github.com/NixOS/nixpkgs/commit/70247ee7bca0c47d7b0c1dfa4f6c43d6c5c0a6e9) | `` muffin: use mesa-gl-headers ``                                                            |
| [`3badb3f2`](https://github.com/NixOS/nixpkgs/commit/3badb3f2570c6b44774b0dd225fa70851cfc7de2) | `` magpie: use mesa-gl-headers ``                                                            |
| [`9a16c2b2`](https://github.com/NixOS/nixpkgs/commit/9a16c2b268a664efd07e3d1f378f6265afaa95bf) | `` kodi: use mesa-gl-headers ``                                                              |
| [`e3d25313`](https://github.com/NixOS/nixpkgs/commit/e3d253138dbbec8d6981ce17672ac8a35e292970) | `` enlightenment.efl: use mesa-gl-headers ``                                                 |
| [`ed656d02`](https://github.com/NixOS/nixpkgs/commit/ed656d02fa588119a66e2e8a9fe9f06c03be368f) | `` cogl: use mesa-gl-headers ``                                                              |
| [`0c746c8c`](https://github.com/NixOS/nixpkgs/commit/0c746c8c0aa03c15c8cf91306f7b3f3ef1cd544c) | `` mesa-gl-headers: init at 25.0.1 ``                                                        |
| [`b3d0fa24`](https://github.com/NixOS/nixpkgs/commit/b3d0fa247fdab20bf64a7d98a439e088f2d38068) | `` wine: build without osmesa ``                                                             |
| [`cdbf9dc0`](https://github.com/NixOS/nixpkgs/commit/cdbf9dc01fd0c9cd0efb536bf160f08dedb8e8de) | `` qqmusic: remove unused Mesa input ``                                                      |
| [`888487a7`](https://github.com/NixOS/nixpkgs/commit/888487a7463b3e9c4470fa795ae9a371a89595ec) | `` python312Packages.horizon-eda: build without osmesa ``                                    |
| [`d8b8fcb3`](https://github.com/NixOS/nixpkgs/commit/d8b8fcb32363c0af74dacb7dbdd9b52a9a20e4b2) | `` primus: remove spurious Mesa reference ``                                                 |
| [`d3631853`](https://github.com/NixOS/nixpkgs/commit/d3631853bd708955edfe71dca94171efb5749711) | `` orca-slicer: get rid of osmesa dependency, clean up other mesa-related things ``          |
| [`1db9e2a4`](https://github.com/NixOS/nixpkgs/commit/1db9e2a4f55c2cdba53cea455d66868661952edf) | `` hey-mail: mesa -> libgbm ``                                                               |
| [`5ae0d557`](https://github.com/NixOS/nixpkgs/commit/5ae0d557c0396c5576564584d68e789793cec973) | `` arrayfire: mark broken ``                                                                 |
| [`4e009205`](https://github.com/NixOS/nixpkgs/commit/4e009205b7716097d516f9dd9b0bd18d510ed1e1) | `` mesa: 24.3.4 -> 25.0.1 ``                                                                 |
| [`235acafb`](https://github.com/NixOS/nixpkgs/commit/235acafb2402d2dc68229eaaabdc6484ddabd666) | `` affine: 0.20.3 -> 0.20.4 ``                                                               |
| [`25050c9c`](https://github.com/NixOS/nixpkgs/commit/25050c9c2a7f603396857cdec1118edd2827db0c) | `` vscode-extensions.illixion.vscode-vibrancy-continued: init at 1.1.44 ``                   |
| [`aa0652c9`](https://github.com/NixOS/nixpkgs/commit/aa0652c925726e4783672d391ff849d4c08c2f1d) | `` maintainers: add _2hexed ``                                                               |
| [`bc9c870b`](https://github.com/NixOS/nixpkgs/commit/bc9c870bc5d16516b402188e1c9aa98e639fe57c) | `` htgettoken: 2.0-2 -> 2.1 ``                                                               |
| [`79b15f8b`](https://github.com/NixOS/nixpkgs/commit/79b15f8b095105e8f66b788f04036ad5b4cb2024) | `` vscode: 1.97.2 -> 1.98.0 ``                                                               |
| [`d4a1f410`](https://github.com/NixOS/nixpkgs/commit/d4a1f41003ed01e7013a8e9e2ed6d1c53631a3f0) | `` home-assistant-lovelace-modules.advanced-camera-card: init at 7.3.2 ``                    |
| [`44bf7f87`](https://github.com/NixOS/nixpkgs/commit/44bf7f8725bd657606e89de44dd53b02c941332c) | `` home-assistant-custom-components.smartir: 1.17.9 -> 1.18.0 ``                             |
| [`ff5268a8`](https://github.com/NixOS/nixpkgs/commit/ff5268a8298d6a07687f75784b1db96ed325c338) | `` home-assistant-custom-components.frigate: 5.4.0 -> 5.8.0 ``                               |
| [`d663db8a`](https://github.com/NixOS/nixpkgs/commit/d663db8ad8673bc9ddd1d6664dd7b7f98931607e) | `` home-assistant.python.pkgs.hass-web-proxy-lib: init at 0.0.7 ``                           |
| [`3248fab8`](https://github.com/NixOS/nixpkgs/commit/3248fab8237359fca37a19cff30140425b36bdda) | `` servo: 0-unstable-2025-03-01 -> 0-unstable-2025-03-05 ``                                  |
| [`263e8872`](https://github.com/NixOS/nixpkgs/commit/263e887202f191b0888370cae9b75267e9280837) | `` 1password-gui-beta: 8.10.60-4.BETA -> 8.10.68-12.BETA ``                                  |
| [`df85f5d2`](https://github.com/NixOS/nixpkgs/commit/df85f5d23586bb39cb2ca8e96f17734cab8b3855) | `` python312Packages.scikit-hep-testdata: 0.5.2 -> 0.5.3 ``                                  |
| [`19fff691`](https://github.com/NixOS/nixpkgs/commit/19fff691ae56eca8b5bfa1b884bc5ac7c8340ec1) | `` home-assistant-custom-lovelace-modules.clock-weather-card: 2.8.9 -> 2.8.10 ``             |
| [`3614af95`](https://github.com/NixOS/nixpkgs/commit/3614af95650422f6ea15b8dc7ff3e25089a2592f) | `` home-assistant-custom-components.yoto_ha: 1.23.0 -> 1.23.2 ``                             |
| [`36af8c6f`](https://github.com/NixOS/nixpkgs/commit/36af8c6fd1008abef74c0d15d33251718364742e) | `` home-assistant-custom-components.xiaomi_miot: 1.0.12 -> 1.0.13 ``                         |
| [`06f80f51`](https://github.com/NixOS/nixpkgs/commit/06f80f51080e9f5636ac63c6c0cad13e462bb83e) | `` home-assistant-custom-components.localtuya: 2025.3.0 -> 2025.3.1 ``                       |
| [`667b1f61`](https://github.com/NixOS/nixpkgs/commit/667b1f61ff7a9b5691a44d50d796e76c9b16ad71) | `` home-assistant-custom-components.daikin_onecta: 4.2.2 -> 4.2.3 ``                         |
| [`a4b4eebe`](https://github.com/NixOS/nixpkgs/commit/a4b4eebe8b4cbf8c146a0aae5814aa4936e07e59) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.214 -> 0.13.220 `` |
| [`e20c0f2d`](https://github.com/NixOS/nixpkgs/commit/e20c0f2d0922281837aa257b86f687a290567bbe) | `` python313Packages.homeassistant-stubs: 2025.2.5 -> 2025.3.0 ``                            |
| [`ce62a116`](https://github.com/NixOS/nixpkgs/commit/ce62a1161fb338860874468db35cd3e05a6b51eb) | `` snakemake: 8.29.0 -> 8.29.2 ``                                                            |
| [`e9d2cb89`](https://github.com/NixOS/nixpkgs/commit/e9d2cb8925f2a1c44856c61038de9de151ae9ef9) | `` vscode-extensions.ms-python.python: 2025.1.2025022501 -> 2025.2.0 ``                      |
| [`274ea258`](https://github.com/NixOS/nixpkgs/commit/274ea258ee704724977160757ac4228ecb6eb31f) | `` orca-slicer: Don't show update dialog by default (#378396) ``                             |
| [`2127c8d7`](https://github.com/NixOS/nixpkgs/commit/2127c8d7791233cd860bcf8214bc5bb61c73a68a) | `` music-assistant: 2.3.6 -> 2.4.2 ``                                                        |
| [`fed188c3`](https://github.com/NixOS/nixpkgs/commit/fed188c3516b8f0111653375ce1870aac4731d31) | `` python312Packages.aioaudiobookshelf: init at 0.1.4 ``                                     |
| [`b5930cb6`](https://github.com/NixOS/nixpkgs/commit/b5930cb68f5c37383a892307cf4c3b26c6dbbc34) | `` python312Packages.deezer-python-async: init at 0.3.0 ``                                   |
| [`30ad414f`](https://github.com/NixOS/nixpkgs/commit/30ad414f52814b97168246f2befee144e09f6726) | `` python312Packages.duration-parser: init at 1.0.1 ``                                       |
| [`8e590dd6`](https://github.com/NixOS/nixpkgs/commit/8e590dd68c874faab2b0f07dbb4b6b8f4b5f10a1) | `` python313Packages.aiorun: 2024.8.1 -> 2025.1.1 ``                                         |
| [`f21847f0`](https://github.com/NixOS/nixpkgs/commit/f21847f019c57ed1afe9776493bf0bd438e6ad31) | `` granted: remove withFish flag completely (#387013) ``                                     |
| [`84b8c066`](https://github.com/NixOS/nixpkgs/commit/84b8c066959156b1a1c408d73669592b3ab10a9c) | `` python3Packages.pycairo: mark support for FreeBSD ``                                      |
| [`f094dbd7`](https://github.com/NixOS/nixpkgs/commit/f094dbd787f1590a969d74f7e43262dd72798723) | `` openblas: enable support for x86_64-freebsd ``                                            |
| [`406efa04`](https://github.com/NixOS/nixpkgs/commit/406efa04433b53a09a2b88a34431bbc44cf4bafa) | `` opencv: mark support for FreeBSD ``                                                       |
| [`8dd49365`](https://github.com/NixOS/nixpkgs/commit/8dd49365b599ae6b015ee2af09ba073c8a807b0d) | `` libdvdread: mark support for FreeBSD ``                                                   |
| [`26fabe77`](https://github.com/NixOS/nixpkgs/commit/26fabe77ea5839b295fc2e22d465288a48a1ecf3) | `` libdvdcss: mark support for FreeBSD ``                                                    |
| [`5708672a`](https://github.com/NixOS/nixpkgs/commit/5708672a33ed7984d08cb87e78cfa9f5f17c398b) | `` ffmpeg: fix build for FreeBSD ``                                                          |
| [`74c80cec`](https://github.com/NixOS/nixpkgs/commit/74c80cecbaac100d76bf1afe03f5ed5448a50e73) | `` calamares-nixos-extensions: 0.3.21 -> 0.3.22 ``                                           |
| [`eaaea8bd`](https://github.com/NixOS/nixpkgs/commit/eaaea8bdc02bdb4a42897aa3ceded62ea8444d53) | `` xavs: mark support for FreeBSD ``                                                         |
| [`2138f8e8`](https://github.com/NixOS/nixpkgs/commit/2138f8e870334fa7ac16ea6875e365f8855f4b6e) | `` x265: fix build for FreeBSD ``                                                            |
| [`94c6912c`](https://github.com/NixOS/nixpkgs/commit/94c6912c793ee40fe11dcf06ac6c744b964a2353) | `` socat: fix build for FreeBSD ``                                                           |
| [`9052f522`](https://github.com/NixOS/nixpkgs/commit/9052f5223a595a28d6e5f5aea0162776698d223e) | `` quirc: fix build for FreeBSD ``                                                           |
| [`4ab80fec`](https://github.com/NixOS/nixpkgs/commit/4ab80fec2f91c658d4887f82579f3ae26e4100cb) | `` libvisual: mark support for FreeBSD ``                                                    |
| [`cfcdb0e1`](https://github.com/NixOS/nixpkgs/commit/cfcdb0e1bd69f80a56eec8b5adf3734208dcb7ca) | `` libcamera: mark as linux-only ``                                                          |
| [`ef449060`](https://github.com/NixOS/nixpkgs/commit/ef4490603d3c104ebe9c97cf1036d0140da4597e) | `` frei0r: mark support for FreeBSD ``                                                       |
| [`f8c7dd4d`](https://github.com/NixOS/nixpkgs/commit/f8c7dd4d0bfd5bdcca1bcbf636c81edcfbf395b6) | `` imagemagick: Mark support for FreeBSD ``                                                  |
| [`38f5f81a`](https://github.com/NixOS/nixpkgs/commit/38f5f81af720dcfdfe2753bf6960b65f6d0f9266) | `` {alsa-lib,alsa-topology-conf,alsa-ucm-conf}: fix build for FreeBSD ``                     |
| [`4dc9948c`](https://github.com/NixOS/nixpkgs/commit/4dc9948c81ef1a72504f98d23ec84a0a142d933a) | `` opencv: format ``                                                                         |
| [`f84d86e9`](https://github.com/NixOS/nixpkgs/commit/f84d86e9141b08385688d36fffd98febf1e780f2) | `` ffmpeg: format ``                                                                         |
| [`c84d678e`](https://github.com/NixOS/nixpkgs/commit/c84d678e7dbb42dcb04bd834c88a7b69914c37b8) | `` imagemagick: format ``                                                                    |
| [`d8409e84`](https://github.com/NixOS/nixpkgs/commit/d8409e84dade703d7bd20b9923a18591113118cf) | `` rosa: 1.2.50 -> 1.2.51 ``                                                                 |
| [`b00d8d58`](https://github.com/NixOS/nixpkgs/commit/b00d8d5812a9634ee4927156b868a93f2d6d572c) | `` python313Packages.python-picnic-api: drop ``                                              |
| [`9d43dae2`](https://github.com/NixOS/nixpkgs/commit/9d43dae293e8e3ca998af2043d29679d6941b301) | `` python313Packages.paho-mqtt_1: drop ``                                                    |
| [`04598d1b`](https://github.com/NixOS/nixpkgs/commit/04598d1b3f2608ad54e2bd7cc0ab89913e445f08) | `` home-assistant: 2025.2.5 -> 2025.3.0 ``                                                   |
| [`ea1a70df`](https://github.com/NixOS/nixpkgs/commit/ea1a70df8124f4239c5aec6d94eabc0d27824876) | `` home-assistant.python.pkgs.home-assistant-intents: 2025.2.5 -> 2025.3.5 ``                |
| [`bcf137c1`](https://github.com/NixOS/nixpkgs/commit/bcf137c149c497e59db8751c65319e860a831a19) | `` home-assistant.python.pkgs.home-assistant-frontend: 20250221.0 -> 20250305.0 ``           |
| [`b983ba6b`](https://github.com/NixOS/nixpkgs/commit/b983ba6b1970d3cfa91690ccacbfd47b6c54bd16) | `` python313Packages.pyfronius: 0.7.5 -> 0.7.6 ``                                            |
| [`84cbf1bc`](https://github.com/NixOS/nixpkgs/commit/84cbf1bcf478b7b43e9132eff5c6793de83856ff) | `` python313Packages.pybalboa: 1.0.2 -> 1.1.3 ``                                             |
| [`4a754ccf`](https://github.com/NixOS/nixpkgs/commit/4a754ccf50bbd09b70e2ae46e0439a09c6230b8b) | `` python312Packages.evohome-async: 0.4.21 -> 1.0.2 ``                                       |
| [`54250e5d`](https://github.com/NixOS/nixpkgs/commit/54250e5db6fd251d64b3e7fdf909dbeec8e1ae61) | `` python313Packages.thinqconnect: 1.0.3 -> 1.0.4 ``                                         |
| [`bab88cc0`](https://github.com/NixOS/nixpkgs/commit/bab88cc0c7559190eac76756d473c62715e6744a) | `` python313Packages.zigpy: 0.76.1 -> 0.76.2 ``                                              |
| [`d8de3c8b`](https://github.com/NixOS/nixpkgs/commit/d8de3c8bcc12fe622bd2f508944dde31b63abc72) | `` python312Packages.zha-quirks: 0.0.133 -> 0.0.134 ``                                       |
| [`23b334e3`](https://github.com/NixOS/nixpkgs/commit/23b334e33ae0ba8504cc50cae22732c6ae651f01) | `` python313Packages.zha: 0.0.49 -> 0.0.51 ``                                                |
| [`30662649`](https://github.com/NixOS/nixpkgs/commit/30662649369a34d058c9fe9d2721b8cc4da3701a) | `` python312Packages.zeroconf: 0.144.1 -> 0.145.1 ``                                         |
| [`3435b8e4`](https://github.com/NixOS/nixpkgs/commit/3435b8e4286defa21efb076a4142d1a2bded70a9) | `` python313Packages.weheat: 2025.2.13 -> 2025.2.27 ``                                       |
| [`20023d0c`](https://github.com/NixOS/nixpkgs/commit/20023d0c06b00b41802d8a5303a4e1029ce67cd6) | `` python313Packages.upb-lib: 0.5.9 -> 0.6.0 ``                                              |
| [`a7e88a4a`](https://github.com/NixOS/nixpkgs/commit/a7e88a4aa5e24ae87dc3bc0de8c52adc99c55476) | `` python313Packages.tesla-fleet-api: 0.9.10 -> 0.9.12 ``                                    |
| [`b116c2a6`](https://github.com/NixOS/nixpkgs/commit/b116c2a68e08248fb2a6ad788a467218d0b9833f) | `` python313Packages.stookwijzer: 1.5.4 -> 1.6.1 ``                                          |
| [`07065a9d`](https://github.com/NixOS/nixpkgs/commit/07065a9d847ee7be85189150117d21a4640735f9) | `` python312Packages.soco: 0.30.8 -> 0.30.9 ``                                               |
| [`f67ec8b4`](https://github.com/NixOS/nixpkgs/commit/f67ec8b4b4c8e34b047edde154e7d00f55078f86) | `` python313Packages.sensorpush-ha init at 1.3.2 ``                                          |
| [`d8bed5f0`](https://github.com/NixOS/nixpkgs/commit/d8bed5f0c290047e4d0aa2375a3fcd3ff62fbd4b) | `` python313Packages.sensorpush-api init at 2.1.1 ``                                         |
| [`44c787a4`](https://github.com/NixOS/nixpkgs/commit/44c787a4ec6b272b2a7a5bf1eb810c4a9b68e0ac) | `` python313Packages.securetar: 2025.1.4 -> 2025.2.1 ``                                      |
| [`5d94c4cb`](https://github.com/NixOS/nixpkgs/commit/5d94c4cbe6c070b4790623fd9fdbf14d1e311f13) | `` python313Packages.pytouchline-extended: init at 0.4.5 ``                                  |
| [`7615a716`](https://github.com/NixOS/nixpkgs/commit/7615a716b0b9cb3482aa068dd2d9a442d4290027) | `` python313Packages.python-technove: 1.3.1 -> 2.0.0 ``                                      |
| [`902208b3`](https://github.com/NixOS/nixpkgs/commit/902208b355956504d26c3f700420fe06da09420d) | `` python313Packages.python-snoo: init at 0.6.0 ``                                           |
| [`6e517f39`](https://github.com/NixOS/nixpkgs/commit/6e517f395224a50c6875e8810d54bfa5f58be45b) | `` python313Packages.python-picnic-api2: init at 1.2.2 ``                                    |
| [`11b74221`](https://github.com/NixOS/nixpkgs/commit/11b74221096053edf1fd23452f34bb13afce5e2c) | `` python313Packages.pysmlight: 0.1.7 -> 0.2.3 ``                                            |
| [`3d5131d8`](https://github.com/NixOS/nixpkgs/commit/3d5131d8dca28bd25a910cef061fdf010c35d5f1) | `` python313Packages.pysmhi: init at 1.0.0 ``                                                |
| [`410d05c4`](https://github.com/NixOS/nixpkgs/commit/410d05c41aeed1feb63e5ff99210405d04a5ff1d) | `` python313Packages.pysmartthings: 0.7.8 -> 2.5.0 ``                                        |
| [`6e1f5fc9`](https://github.com/NixOS/nixpkgs/commit/6e1f5fc925b299b850062c2c1e31562fbb7684b7) | `` python313Packages.pyrisco: 0.6.6 -> 0.6.7 ``                                              |
| [`44551980`](https://github.com/NixOS/nixpkgs/commit/4455198015741b4757755daba5ee3fc446c90f8f) | `` python313Packages.pypglab: init at 0.0.3 ``                                               |
| [`0192f3d5`](https://github.com/NixOS/nixpkgs/commit/0192f3d50ceb6c4c251855ce011f7d7118926019) | `` python313Packages.py-synologydsm-api: 2.6.3 -> 2.7.0 ``                                   |
| [`4974c86d`](https://github.com/NixOS/nixpkgs/commit/4974c86dac1bc7036e8ce4e5e48813efd7f86bce) | `` python312Packages.plugwise: 1.6.4 -> 1.7.2 ``                                             |
| [`efa69a18`](https://github.com/NixOS/nixpkgs/commit/efa69a186ca8540b91e664f22ff8a07df2cab61d) | `` python313Packages.onedrive-personal-sdk: 0.0.11 -> 0.0.13 ``                              |
| [`e0fb8693`](https://github.com/NixOS/nixpkgs/commit/e0fb86930b2961920236699f726d03a30b3cd3ad) | `` python313Packages.ohme: 1.2.9 -> 1.3.2 ``                                                 |
| [`8c031f54`](https://github.com/NixOS/nixpkgs/commit/8c031f54bcf69efe04c0fd226a65f5be2e184ba9) | `` python313Packages.nhc: 0.3.9 -> 0.4.10 ``                                                 |
| [`9226e4e2`](https://github.com/NixOS/nixpkgs/commit/9226e4e2196cceb4f97a44b9b46717966ffa79c5) | `` python313Packages.nexia: 2.1.0 -> 2.2.1 ``                                                |
| [`d6d13568`](https://github.com/NixOS/nixpkgs/commit/d6d1356895ca077a1e1f48ac2d563b4c05a01640) | `` python313Packages.music-assistant-models: 1.1.3 -> 1.1.30 ``                              |
| [`8b0a7020`](https://github.com/NixOS/nixpkgs/commit/8b0a7020e30b127c30152713bd77095e4cb7d46f) | `` python313Packages.music-assistant-client: 1.0.8 -> 1.1.1 ``                               |
| [`e6f8c5dd`](https://github.com/NixOS/nixpkgs/commit/e6f8c5dd96b1dab615b7df5113e02c991306ea8c) | `` python313Packages.iometer: init at 0.1.0 ``                                               |
| [`02773913`](https://github.com/NixOS/nixpkgs/commit/027739139b95dc1039024180bf222550ccd72266) | `` python313Packages.home-assistant-bluetooth: 1.13.0 -> 1.13.1 ``                           |
| [`5e4871ac`](https://github.com/NixOS/nixpkgs/commit/5e4871acfdbacb38905449068845f44f48580419) | `` python313Packages.habluetooth: 3.21.1 -> 3.24.1 ``                                        |
| [`f902b346`](https://github.com/NixOS/nixpkgs/commit/f902b3468d17c2d3c88fb5127c3bf44783c768b6) | `` python313Packages.google-nest-sdm: 7.1.3 -> 7.1.4 ``                                      |
| [`8bc6f320`](https://github.com/NixOS/nixpkgs/commit/8bc6f3203339a968363ae598f20b2cf771850209) | `` python313Packages.google-genai: init at 1.4.0 ``                                          |
| [`28fc8865`](https://github.com/NixOS/nixpkgs/commit/28fc88650324579f09a4ace6ddfbc23ee6e868ca) | `` python313Packages.fnv-hash-fast: 1.2.3 -> 1.2.6 ``                                        |
| [`7b15a656`](https://github.com/NixOS/nixpkgs/commit/7b15a656293f85bac8e47e894dcffa8a537a96a9) | `` python313Packages.eq3btsmart: update dependencies ``                                      |
| [`6ce8685c`](https://github.com/NixOS/nixpkgs/commit/6ce8685c8810dfba62d3c9738fd9c67bfa43180b) | `` python313Packages.deebot-client: 12.2.0 -> 12.3.1 ``                                      |
| [`943f3a63`](https://github.com/NixOS/nixpkgs/commit/943f3a63de137c9987b6d067eaddd3af4ee3674d) | `` python313Packages.cached-ipaddress: 0.8.0 -> 0.9.2 ``                                     |
| [`ea1b27d7`](https://github.com/NixOS/nixpkgs/commit/ea1b27d7bf8ddcc2f57d0a29ff0de1183cdcd5e2) | `` python312Packages.bluetooth-auto-recovery: 1.4.2 -> 1.4.4 ``                              |
| [`52e010bf`](https://github.com/NixOS/nixpkgs/commit/52e010bf6b8717dc4f99aaa94bc348e41fc1bdc8) | `` python313Packages.bluetooth-auto-recovery: run all tests ``                               |
| [`3e2a9d57`](https://github.com/NixOS/nixpkgs/commit/3e2a9d575326da7c5858a35976814526d5a7d5a6) | `` python313Packages.bleak-esphome: 2.7.1 -> 2.9.0 ``                                        |
| [`a52e0f50`](https://github.com/NixOS/nixpkgs/commit/a52e0f507cd3016c400d5e6ff4bc97e6577518e9) | `` python313Packages.bleak-retry-connector: 3.8.1 -> 3.9.0 ``                                |
| [`63b6c596`](https://github.com/NixOS/nixpkgs/commit/63b6c596b1363afc528deaf29232887e8a496966) | `` python313Packages.async-interrupt: 1.2.0 -> 1.2.2 ``                                      |
| [`5a778846`](https://github.com/NixOS/nixpkgs/commit/5a778846501d7fee618c489b258e9caf457f1322) | `` python313Packages.arcam-fmj: 1.8.0 -> 1.8.1 ``                                            |
| [`2be582a1`](https://github.com/NixOS/nixpkgs/commit/2be582a1f3deec6e98d66d7b9dbd728787708c1e) | `` python313Packages.aioshelly: 12.4.2 -> 13.1.0 ``                                          |
| [`cec4cda4`](https://github.com/NixOS/nixpkgs/commit/cec4cda45a6a6392c332a5e7f06e02f165884d08) | `` python312Packages.aiowebostv: 0.6.2 -> 0.7.3 ``                                           |
| [`35fadddc`](https://github.com/NixOS/nixpkgs/commit/35fadddcd452bd2c1cd89def4e2cefc8657188fb) | `` python313Packages.aiowebdav2: init at 0.3.1 ``                                            |
| [`4888b63f`](https://github.com/NixOS/nixpkgs/commit/4888b63ff8f06d64b5c2820c473c50980151d802) | `` python313Packages.aiohue: 4.7.3 -> 4.7.4 ``                                               |
| [`f015b82c`](https://github.com/NixOS/nixpkgs/commit/f015b82c5bb03e1b5494b449f372fc0be494dcbc) | `` python313Packages.aiohomeconnect: 0.16.0 -> 0.16.2 ``                                     |
| [`3d579b9c`](https://github.com/NixOS/nixpkgs/commit/3d579b9c90e2f79b5c5c61239c983ea2c5570705) | `` python313Packages.aioesphomeapi: 29.2.0 -> 29.3.1 ``                                      |
| [`25da483d`](https://github.com/NixOS/nixpkgs/commit/25da483d0df373f6f8f079978b8615c73262ee30) | `` python313Packages.aioecowitt: 2024.2.2 -> 2025.3.1 ``                                     |
| [`8033eebe`](https://github.com/NixOS/nixpkgs/commit/8033eebe36fc6a3fe507d6ea9145f8ab86d777e1) | `` python313Packages.aiodiscover: 2.2.0 -> 2.6.1 ``                                          |
| [`2e6af89c`](https://github.com/NixOS/nixpkgs/commit/2e6af89cf689582c38e6c5553419398f40bb8e60) | `` vscode-extensions.ms-python.debugpy: 2025.0.1 -> 2025.4.0 ``                              |
| [`90ad157c`](https://github.com/NixOS/nixpkgs/commit/90ad157c1fb4c598ca5d80e679c8f729a6af6c6f) | `` vscode-extensions.ms-python.black-formatter: 2024.6.0 -> 2025.2.0 ``                      |
| [`76a5bd7b`](https://github.com/NixOS/nixpkgs/commit/76a5bd7ba50d27c6e07479d61a5da7335a6fe2d4) | `` vscode-extensions.ms-python.pylint: 2024.2.0 -> 2025.2.0 ``                               |
| [`297427a3`](https://github.com/NixOS/nixpkgs/commit/297427a398e9a949e745643fa42a3b49d1ec931c) | `` vscode-extensions.ms-python.flake8: 2025.1.10441012 -> 2025.2.0 ``                        |
| [`f35c2002`](https://github.com/NixOS/nixpkgs/commit/f35c200215e202e1b63dedefe151efb37d7ace6d) | `` vscode-extensions.ms-python.mypy-type-checker: 2025.1.10451009 -> 2025.2.0 ``             |
| [`cbf8fb2f`](https://github.com/NixOS/nixpkgs/commit/cbf8fb2f3fe869582739b96e41739f3deb13fb3e) | `` garage: 1.0.1 -> 1.1.0 ``                                                                 |
| [`d542aaf9`](https://github.com/NixOS/nixpkgs/commit/d542aaf9c3ca3d29a4fc83a99f825929c13d43eb) | `` protonmail-desktop: 1.7.0 -> 1.7.1 ``                                                     |
| [`db4f4679`](https://github.com/NixOS/nixpkgs/commit/db4f467976b4bfc2bed4679e2bbe88b8adbf2c72) | `` platformio: 6.1.16 -> 6.1.17 ``                                                           |
| [`c1c82774`](https://github.com/NixOS/nixpkgs/commit/c1c82774aecdefa3c43d6d032dfab8ca3ef1ade6) | `` yarnConfigHook: add yarn.lock consistency check (#387316) ``                              |
| [`1a603341`](https://github.com/NixOS/nixpkgs/commit/1a603341810121a5f53b743019f040df9ed50e9c) | `` pspg: 5.8.7 -> 5.8.8 ``                                                                   |
| [`42828733`](https://github.com/NixOS/nixpkgs/commit/42828733089842225887a1d6800d133df3b9b211) | `` mako: replace systemd with systemdMinimal ``                                              |
| [`6bde446b`](https://github.com/NixOS/nixpkgs/commit/6bde446b32cb8ee3d4355d2d5a13af3a6fd362eb) | `` ghostfolio: 2.139.1 -> 2.143.0 ``                                                         |
| [`790fc202`](https://github.com/NixOS/nixpkgs/commit/790fc20209939c8a7128a6c2df6140b651d07e9e) | `` jsoncons: 1.2.0 -> 1.3.0 ``                                                               |
| [`704b9848`](https://github.com/NixOS/nixpkgs/commit/704b9848fefa2a713e6c0dcdd40e0fb17ed3a023) | `` kdePackages.kwin: backport fix recommended by upstream ``                                 |
| [`7c38e713`](https://github.com/NixOS/nixpkgs/commit/7c38e713a5410c3928a13b5b2ef2a1cef22ed1b3) | `` python312Packages.openai: 1.65.2 -> 1.65.3 ``                                             |
| [`ade3d408`](https://github.com/NixOS/nixpkgs/commit/ade3d408f27076e84340fad59ab22143cff4ee3b) | `` signalbackup-tools: 20250304-1 -> 20250305-2 ``                                           |
| [`67ed9abb`](https://github.com/NixOS/nixpkgs/commit/67ed9abb8500d69510872a6af9c25e3a63641229) | `` allure: 2.32.2 -> 2.33.0 ``                                                               |
| [`4c098032`](https://github.com/NixOS/nixpkgs/commit/4c098032d0c4bb29a47c5d83c6ff76be219993d0) | `` oci-cli: 3.51.8 -> 3.52.0 ``                                                              |
| [`b9970c8e`](https://github.com/NixOS/nixpkgs/commit/b9970c8ef7c915fe7cd980516528daeceab50b9e) | `` nix-heuristic-gc: 0.6.0 -> 0.6.1 ``                                                       |
| [`1e0217b0`](https://github.com/NixOS/nixpkgs/commit/1e0217b0c5fdb7542aa75503903872ed08fc6378) | `` nixos/soft-serve: restart trigger added (#384829) ``                                      |
| [`4f5cd112`](https://github.com/NixOS/nixpkgs/commit/4f5cd112122006e30cdea57de2e9026c1a15da51) | `` mangohud: use `--replace-fail` ``                                                         |
| [`91a4324c`](https://github.com/NixOS/nixpkgs/commit/91a4324c2c6c4337ae29f766659dcc797ad0728d) | `` mangohud: 0.8.0 -> 0.8.1 ``                                                               |