### PR TITLE
chore(flake/nixvim): `03065fd4` -> `3a3abf11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1741098523,
-        "narHash": "sha256-gXDSXDr6tAb+JgxGMvcEjKC9YO8tVOd8hMMZHJLyQ6Q=",
+        "lastModified": 1741709061,
+        "narHash": "sha256-G1YTksB0CnVhpU1gEmvO3ugPS5CAmUpm5UtTIUIPnEI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "03065fd4708bfdf47dd541d655392a60daa25ded",
+        "rev": "3a3abf11700f76738d8ad9d15054ceaf182d2974",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`3a3abf11`](https://github.com/nix-community/nixvim/commit/3a3abf11700f76738d8ad9d15054ceaf182d2974) | `` ci: bump cachix/install-nix-action from 30 to 31 ``         |
| [`268c2680`](https://github.com/nix-community/nixvim/commit/268c2680a3bda31d3594950abd348559bd3a24bb) | `` ci: add dependabot and track github-actions dependencies `` |
| [`bc340997`](https://github.com/nix-community/nixvim/commit/bc34099731a7e3799c0d52ccdf4599409a2ef9b9) | `` ci/documentation: bump cachix action to v16 ``              |