### PR TITLE
chore(flake/nixpkgs): `e3e32b64` -> `6607cf78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741513245,
-        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "lastModified": 1741851582,
+        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`db5bf85d`](https://github.com/NixOS/nixpkgs/commit/db5bf85d701272462b39059f852cb2884acba9ab) | `` wofi-emoji: 1.0.0 -> 1.1.0 ``                                           |
| [`8eb34667`](https://github.com/NixOS/nixpkgs/commit/8eb34667207004c8bd5d4a3a8b24ff8d23340fbe) | `` shen-sbcl: add hakujin as maintainer ``                                 |
| [`92638efd`](https://github.com/NixOS/nixpkgs/commit/92638efdc4e96a2d004477f6fdd02d475d24ea31) | `` shen-sbcl: 3.0.3 -> 39.1 ``                                             |
| [`c71a0f71`](https://github.com/NixOS/nixpkgs/commit/c71a0f716812b40a97ae3416e7ad210b19358118) | `` htop: make postPatch linux only to match dependency ``                  |
| [`2fb6e13d`](https://github.com/NixOS/nixpkgs/commit/2fb6e13d7626459b2e31c7dd96b7eebf3eafbb6a) | `` all-the-package-names: 2.0.2070 -> 2.0.2095 ``                          |
| [`af13b958`](https://github.com/NixOS/nixpkgs/commit/af13b958e64f8c5bc1c2ace63f6eaa875a54bbd9) | `` python312Packages.localstack-ext: 4.1.1 -> 4.2.0 ``                     |
| [`ca1ed1cf`](https://github.com/NixOS/nixpkgs/commit/ca1ed1cf06d7718f68ac1f5152d25d9480ec89d4) | `` sbom4python: 0.12.1 -> 0.12.2 ``                                        |
| [`daca9f89`](https://github.com/NixOS/nixpkgs/commit/daca9f8900f5324ba67848bdd87c07a83a989e23) | `` nixos/tests/{floorp,librewolf}: fix eval ``                             |
| [`1e515ed7`](https://github.com/NixOS/nixpkgs/commit/1e515ed77300a646663fcbd9e8e5d32e14c4fc72) | `` appflowy: 0.7.1 -> 0.8.6 (#351509) ``                                   |
| [`ae560747`](https://github.com/NixOS/nixpkgs/commit/ae56074717c9cc4d628cb1d418837847a9027671) | `` vimPlugins.neotest-mocha: plugin updater changes ``                     |
| [`ae7ad154`](https://github.com/NixOS/nixpkgs/commit/ae7ad1546d921a43d19e8b1d5ba6250ea093432d) | `` vimPlugins.blink-cmp-avante: init at 2025-02-19 ``                      |
| [`eb794393`](https://github.com/NixOS/nixpkgs/commit/eb7943930b19b034844f595844a35996c637c9be) | `` telegraf: 1.33.2 -> 1.34.0 ``                                           |
| [`7435729e`](https://github.com/NixOS/nixpkgs/commit/7435729ef78d01c32e1f6d853a0d40c3e4b13b96) | `` nixosTests.telegraf: switch to runTest ``                               |
| [`d7e20d87`](https://github.com/NixOS/nixpkgs/commit/d7e20d87d93e9b3b9dc9f127713fd113c3fc1c9f) | `` element-desktop: 1.11.91 -> 1.11.95 ``                                  |
| [`b5d4ea29`](https://github.com/NixOS/nixpkgs/commit/b5d4ea29d028c77a9d0fe5408694f18be1a67cbb) | `` element-desktop.keytar: 7.9.0 -> 7.10.0 ``                              |
| [`80d1d97d`](https://github.com/NixOS/nixpkgs/commit/80d1d97d263c098dd389a8acded435eaf72e520d) | `` element-desktop: use electron_34, follow upstream ``                    |
| [`2656b89b`](https://github.com/NixOS/nixpkgs/commit/2656b89baa4257008ac0cd992488f8eb414dd873) | `` element-web: 1.11.91 -> 1.11.95 ``                                      |
| [`51e6465d`](https://github.com/NixOS/nixpkgs/commit/51e6465d7b525045c0087379b95078077deb212d) | `` python312Packages.asyncstdlib: 3.13.0 -> 3.13.1 ``                      |
| [`bc5df0ff`](https://github.com/NixOS/nixpkgs/commit/bc5df0ff51100db47b7cb192d5dbfa487a10fa0c) | `` python313Packages.acquire: 3.17 -> 3.18 ``                              |
| [`71e7b77f`](https://github.com/NixOS/nixpkgs/commit/71e7b77f160a28abf15446c6542cca8b1eebb3a6) | `` terraform: 1.11.1 -> 1.11.2 ``                                          |
| [`9d1809c3`](https://github.com/NixOS/nixpkgs/commit/9d1809c348395f23f205b1e526e93883c29d2617) | `` python313Packages.dissect: 3.17.1 -> 3.18 ``                            |
| [`35d0667c`](https://github.com/NixOS/nixpkgs/commit/35d0667c068cb2eb83532c2d1104a9acb23b1cb8) | `` python312Packages.globus-sdk: 3.50.0 -> 3.51.0 ``                       |
| [`dd62d5bd`](https://github.com/NixOS/nixpkgs/commit/dd62d5bd4790e852a29ac307665c2b7d517cc87f) | `` python313Packages.boto3-stubs: 1.37.10 -> 1.37.11 ``                    |
| [`d7a2bb57`](https://github.com/NixOS/nixpkgs/commit/d7a2bb573abffcb86b414d959bc3220fe7f286b3) | `` python313Packages.botocore-stubs: 1.37.10 -> 1.37.11 ``                 |
| [`7ce7d5d2`](https://github.com/NixOS/nixpkgs/commit/7ce7d5d229760d2c6922f853db7bd99c8c066482) | `` solana-cli: remove Cargo.lock ``                                        |
| [`b2b20b42`](https://github.com/NixOS/nixpkgs/commit/b2b20b42420e9a157a59b7a951b2329457cd67db) | `` python312Packages.mypy-boto3-medialive: 1.37.10 -> 1.37.11 ``           |
| [`1b9ea06a`](https://github.com/NixOS/nixpkgs/commit/1b9ea06ae8b39e2e13d0a0e956073e832e8ba362) | `` python312Packages.mypy-boto3-inspector2: 1.37.0 -> 1.37.11 ``           |
| [`edf84ad3`](https://github.com/NixOS/nixpkgs/commit/edf84ad32c35baf4c855738139fa53f2c7a72387) | `` python312Packages.mypy-boto3-ecs: 1.37.0 -> 1.37.11 ``                  |
| [`9361b0e5`](https://github.com/NixOS/nixpkgs/commit/9361b0e5f311bcee8de34e928e5c603822a734d8) | `` python312Packages.mypy-boto3-ecr: 1.37.0 -> 1.37.11 ``                  |
| [`74ece770`](https://github.com/NixOS/nixpkgs/commit/74ece77052ade2f75f802cb1660df9a08f1bf42d) | `` python312Packages.mypy-boto3-ec2: 1.37.9 -> 1.37.11 ``                  |
| [`d16af290`](https://github.com/NixOS/nixpkgs/commit/d16af290cc6f161f6cc45f906b91f713ab2c41ae) | `` python312Packages.cf-xarray: 0.10.1 -> 0.10.2 ``                        |
| [`d8d26407`](https://github.com/NixOS/nixpkgs/commit/d8d26407b1635c68eed7b62941a4d5102b14579a) | `` worker-build: 0.0.18 -> 0.5.0 ``                                        |
| [`e9cd85e4`](https://github.com/NixOS/nixpkgs/commit/e9cd85e422b1fde93c1bfc2c5f2b76ae8a09da4c) | `` gfold: 4.6.0 -> 2025.2.1 ``                                             |
| [`00c41e5a`](https://github.com/NixOS/nixpkgs/commit/00c41e5a42f564931dc3e901b5d25559a1e5250a) | `` cobalt: 0.19.6 -> 0.19.8 ``                                             |
| [`93c8fa15`](https://github.com/NixOS/nixpkgs/commit/93c8fa15753922a5f2612d8c524b6e8e0aa610f5) | `` zed-editor: 1.176.3 -> 1.177.7 ``                                       |
| [`0995ff0a`](https://github.com/NixOS/nixpkgs/commit/0995ff0af747d98171442a83c6b623ab29ee60d3) | `` python312Packages.google-nest-sdm: 7.1.4 -> 7.1.5 ``                    |
| [`c26bf39d`](https://github.com/NixOS/nixpkgs/commit/c26bf39dfb47babb92525c326ee70e93357c3cde) | `` flashspace: init at 2.3.29 ``                                           |
| [`3bfac80d`](https://github.com/NixOS/nixpkgs/commit/3bfac80d11f26dda94648ec755c3c1f1a665c601) | `` talosctl: 1.9.4 -> 1.9.5 ``                                             |
| [`f6a2d8e6`](https://github.com/NixOS/nixpkgs/commit/f6a2d8e6c39a59808961e21a009427615162b865) | `` windmill: use vendor cargo lock ``                                      |
| [`7ffe0a09`](https://github.com/NixOS/nixpkgs/commit/7ffe0a09fe186795b98fa6d0b581c1f7648b2846) | `` python312Packages.pyperf: 2.8.1 -> 2.9.0 ``                             |
| [`1c5cd8ff`](https://github.com/NixOS/nixpkgs/commit/1c5cd8ffd0a887b0fc2fae528382f523069a8a69) | `` wifi-qr: 0.3-unstable-2023-09-30 -> 0.4 ``                              |
| [`99bb6e10`](https://github.com/NixOS/nixpkgs/commit/99bb6e103b0a068078e3a42133722c2d9887bfed) | `` werf: 2.24.0 -> 2.31.1 ``                                               |
| [`e2549105`](https://github.com/NixOS/nixpkgs/commit/e25491052d02cc5ce7798e9f3d3d9c47ab8712a5) | `` python312Packages.publicsuffixlist: 1.0.2.20250307 -> 1.0.2.20250312 `` |
| [`79ef8940`](https://github.com/NixOS/nixpkgs/commit/79ef89406081b33f30fcd2b01ec404089ab76e9f) | `` cargo-shuttle: 0.52.0 -> 0.53.0 ``                                      |
| [`df710595`](https://github.com/NixOS/nixpkgs/commit/df710595afafd7944e7ad8eda4f21ff96aaf315b) | `` vscode-extensions.saoudrizwan.claude-dev: 3.4.0 -> 3.6.9 ``             |
| [`0164d003`](https://github.com/NixOS/nixpkgs/commit/0164d003791e0d30a408877dcf6a99a97bce7d91) | `` candy-icons: 0-unstable-2025-02-23 -> 0-unstable-2025-03-10 ``          |
| [`82e07439`](https://github.com/NixOS/nixpkgs/commit/82e0743910c0818bc5a15da998222f934ddf8eb9) | `` usql: 0.19.17 -> 0.19.19 ``                                             |
| [`ac4d5df0`](https://github.com/NixOS/nixpkgs/commit/ac4d5df015a5646346edd73971ebac08a5cc62d1) | `` vimPlugins.blink-cmp-conventional-commits: init at 2025-02-18 ``        |
| [`402c86bc`](https://github.com/NixOS/nixpkgs/commit/402c86bcad19b1fc7a2c32cfcf4eacae62c53b9e) | `` go-tools: 2025.1 -> 2025.1.1 ``                                         |
| [`73619328`](https://github.com/NixOS/nixpkgs/commit/73619328fdcd7d29cf47c38e1785371933044c93) | `` vimPlugins.blink-nerdfont-nvim: init at 2025-02-06 ``                   |
| [`11e9d686`](https://github.com/NixOS/nixpkgs/commit/11e9d68659da946c7e33d9a576fc722c87106fdf) | `` libjaylink: Switch over to Meson build system ``                        |
| [`4d8d5f57`](https://github.com/NixOS/nixpkgs/commit/4d8d5f5782be9f86847e47f87d50fca0763061fe) | `` nixos/libjaylink: init module ``                                        |
| [`dae9d1fa`](https://github.com/NixOS/nixpkgs/commit/dae9d1fa3ad6407ac0cc66362e6c023e0ccce19c) | `` libjaylink: Grant read-write access to members of jlink group ``        |
| [`64ed5329`](https://github.com/NixOS/nixpkgs/commit/64ed532994bdd066a3136878dd82f0958c211995) | `` qlog: 0.42.1 -> 0.42.2 ``                                               |
| [`2b3bf274`](https://github.com/NixOS/nixpkgs/commit/2b3bf2743721e4c64586927f8673ebf62104134e) | `` uv: 0.6.5 -> 0.6.6 ``                                                   |
| [`db302ff3`](https://github.com/NixOS/nixpkgs/commit/db302ff3cfc7333116baf4167c9a2d8746ccff6e) | `` exegol: 4.3.9 -> 4.3.10 ``                                              |
| [`80b3fd57`](https://github.com/NixOS/nixpkgs/commit/80b3fd57b9bba818f2c5507ba29759ac92a288d9) | `` phpExtensions.phalcon: 5.8.0 -> 5.9.0 ``                                |
| [`96de2f97`](https://github.com/NixOS/nixpkgs/commit/96de2f977826ec94806041d44266d32c56d452cc) | `` python312Packages.gcsfs: fix hash ``                                    |
| [`866d932d`](https://github.com/NixOS/nixpkgs/commit/866d932dc82b5eab35156d368c2fb0a1dbff77e5) | `` anchor: add Denommus as maintainer ``                                   |
| [`4199c6f8`](https://github.com/NixOS/nixpkgs/commit/4199c6f8c20464e1f6a7d771e60b0f405391d19e) | `` phpExtensions.tideways: 5.18.2 -> 5.19.0 ``                             |
| [`808a3b2d`](https://github.com/NixOS/nixpkgs/commit/808a3b2df9d47723cf2da51912e145a8eff01af5) | `` tfswitch: 1.4.0 -> 1.4.1 ``                                             |
| [`9b533528`](https://github.com/NixOS/nixpkgs/commit/9b533528a4b2947ff3903c395fd50068ad265ddf) | `` vimPlugins.YankRing-vim: remove sourceRoot to fix build ``              |
| [`79ea09f2`](https://github.com/NixOS/nixpkgs/commit/79ea09f21feb440ac22cd03753e07e18c674b153) | `` python2Packages.hypothesis: remove enum34 ``                            |
| [`d446f488`](https://github.com/NixOS/nixpkgs/commit/d446f488efdd1049acf2ec4892626cc0c7ec1173) | `` phpExtensions.xdebug: 3.4.1 -> 3.4.2 ``                                 |
| [`e082a011`](https://github.com/NixOS/nixpkgs/commit/e082a011fd5f22082c04439a058f8b3dde767f2d) | `` trenchbroom: fix build ``                                               |
| [`1cd30080`](https://github.com/NixOS/nixpkgs/commit/1cd300809bab05de5b9d66694ae525588ca3408e) | `` wgpu-native: 24.0.0.1 -> 24.0.0.2 ``                                    |
| [`8197567a`](https://github.com/NixOS/nixpkgs/commit/8197567ac952f5b22db4274a93ffefb10a39f27e) | `` kdePackages: use ninja to speed things a little up ``                   |
| [`a3aedd5d`](https://github.com/NixOS/nixpkgs/commit/a3aedd5d3046b6678c54dbed9a8b9fdbed5afd5a) | `` phpPackages.phpstan: 2.1.6 -> 2.1.8 ``                                  |
| [`0631b5d4`](https://github.com/NixOS/nixpkgs/commit/0631b5d4c6a692a2a5452ff28c4f654616587b39) | `` phpExtensions.mongodb: 1.20.1 -> 1.21.0 ``                              |
| [`1949dc49`](https://github.com/NixOS/nixpkgs/commit/1949dc49aa61f665d71b9084c9c7bde0b6a889a1) | `` phpPackages.castor: 0.22.1 -> 0.23.0 ``                                 |
| [`9f1e0d3d`](https://github.com/NixOS/nixpkgs/commit/9f1e0d3d1e84a67ac4379da39b42362c54b88918) | `` syncthing-relay: 1.29.2 -> 1.29.3 ``                                    |
| [`7452000c`](https://github.com/NixOS/nixpkgs/commit/7452000c6f01ca711c73161608474138fba6d2a0) | `` vscode-extensions.astro-build.astro-vscode: fix hash ``                 |
| [`4cacc74b`](https://github.com/NixOS/nixpkgs/commit/4cacc74b83fd08a3c84c6567218905ca0b3c6e51) | `` exegol: 4.3.9 -> 4.3.10 ``                                              |
| [`76d030d0`](https://github.com/NixOS/nixpkgs/commit/76d030d07911073b87943b2dfc8f8069c4b85167) | `` syncthing-discovery: 1.29.2 -> 1.29.3 ``                                |
| [`7486be3b`](https://github.com/NixOS/nixpkgs/commit/7486be3b3fefb694a6c22fcbd52035f67d8485ee) | `` spytrap-adb: 0.3.3 -> 0.3.4 ``                                          |
| [`e84afc19`](https://github.com/NixOS/nixpkgs/commit/e84afc195e8c9d7b46766ae556958e496f4ce813) | `` xk6: init at 0.14.3 ``                                                  |
| [`cdf14029`](https://github.com/NixOS/nixpkgs/commit/cdf14029a155aacb0d897b12c24934b90d94767d) | `` maintainers: added szkiba ``                                            |
| [`bd939c14`](https://github.com/NixOS/nixpkgs/commit/bd939c141d70b958cb1a6708d069276fca35fa0c) | `` docker-credential-helpers: 0.9.0 -> 0.9.2 ``                            |
| [`5d5877d9`](https://github.com/NixOS/nixpkgs/commit/5d5877d9babb9cb02e7ee2b6f13059cfdf159eb6) | `` rush-parallel: 0.6.0 -> 0.6.1 ``                                        |
| [`f3492215`](https://github.com/NixOS/nixpkgs/commit/f349221537d3991e1ae0cd4ff0617aa28e862b63) | `` seqkit: 2.9.0 -> 2.10.0 ``                                              |
| [`59163eef`](https://github.com/NixOS/nixpkgs/commit/59163eefa3fe2788e41e01566a7e5b4f6ef07590) | `` anchor: 0.30.1 -> 0.31.0 ``                                             |
| [`46c54cea`](https://github.com/NixOS/nixpkgs/commit/46c54cea472b06295c911ce9f9f48c4c9710daee) | `` python312Packages.planetary-computer: 1.0.0 -> 1.0.0.post0 ``           |
| [`2cd18ead`](https://github.com/NixOS/nixpkgs/commit/2cd18eadd653d8b0334b82f5d3823f8f65bf9eff) | `` home-assistant-custom-components.moonraker: 1.6.0 -> 1.7.0 (#389212) `` |
| [`03e530e9`](https://github.com/NixOS/nixpkgs/commit/03e530e9534ed45faa4678d6a29ee91d9c1f3506) | `` ogen: 1.10.0 -> 1.10.1 ``                                               |
| [`1d1e2666`](https://github.com/NixOS/nixpkgs/commit/1d1e26669a96f40164b5466ba81dd11caafb34b0) | `` exegol: 4.3.9 -> 4.3.10 ``                                              |
| [`ed395983`](https://github.com/NixOS/nixpkgs/commit/ed395983254d433fe859ba6ffe463b774ddc7fd7) | `` python312Packages.drf-yasg: 1.21.9 -> 1.21.10 ``                        |
| [`9c4ddcbf`](https://github.com/NixOS/nixpkgs/commit/9c4ddcbfd7cf41693abe455d81a11f8f5c9e1b49) | `` nhost-cli: 1.29.3 -> 1.29.4 ``                                          |
| [`b5e3464d`](https://github.com/NixOS/nixpkgs/commit/b5e3464d486e2f0f71fc57163f222058eb703ebd) | `` moosefs: 4.56.6 -> 4.57.5 ``                                            |
| [`71d3a696`](https://github.com/NixOS/nixpkgs/commit/71d3a69606c4600e7d6b59c0d5af2071d4f01f2c) | `` cargo-information: remove, due to beeing merged into ``                 |
| [`165e81eb`](https://github.com/NixOS/nixpkgs/commit/165e81ebf7df4031627e9efd0a1343cf8dd1d91e) | `` mate.eom: Apply hack for GCC symlink changes ``                         |
| [`38825a2b`](https://github.com/NixOS/nixpkgs/commit/38825a2beacf6a7df20ae4e1236f14ed190250f1) | `` gfs2-utils: 3.6.0 -> 3.6.1 ``                                           |
| [`a1bbcd6d`](https://github.com/NixOS/nixpkgs/commit/a1bbcd6dd57575080540fea6317070726e75f623) | `` kdePackages.kwin: 6.3.3 -> 6.3.3.1 ``                                   |
| [`8f030558`](https://github.com/NixOS/nixpkgs/commit/8f030558231a8769b997086c7c1692f25d4d484c) | `` bosh-cli: 7.9.3 -> 7.9.4 ``                                             |
| [`f46564fd`](https://github.com/NixOS/nixpkgs/commit/f46564fdea61cb9bec95f9210335c4080d56b8a6) | `` excalifont: init at 0.18.0 ``                                           |
| [`8ede9a62`](https://github.com/NixOS/nixpkgs/commit/8ede9a628189fccc8db5e2efc8ae49e523146226) | `` fg-virgil: 0.17.3 -> 0.18.0 ``                                          |
| [`071239d7`](https://github.com/NixOS/nixpkgs/commit/071239d74f23defb33c919549b4402a090776c21) | `` dnf5: 5.2.10.0 -> 5.2.11.0 ``                                           |
| [`b444c9fa`](https://github.com/NixOS/nixpkgs/commit/b444c9fa3d9d3ab5aa03d410f271ec569ae3003b) | `` gogup: 0.27.7 -> 0.27.8 ``                                              |
| [`a3860b09`](https://github.com/NixOS/nixpkgs/commit/a3860b09b33972ae20b97859fe11accbdab332fb) | `` dnf-plugins-core: 4.10.0 -> 4.10.1 ``                                   |
| [`5a928685`](https://github.com/NixOS/nixpkgs/commit/5a9286853332f9cc2c89ee4ed6af00dc6de8b414) | `` nix-search-tv: 2.1.0 -> 2.1.2 ``                                        |
| [`690459aa`](https://github.com/NixOS/nixpkgs/commit/690459aa29713190d04dd2f80fa58b4a89b691ad) | `` urlfinder: 0.0.2 -> 0.0.3 ``                                            |
| [`c8d0a944`](https://github.com/NixOS/nixpkgs/commit/c8d0a944f594d0b57726ad0b0b497f9a5f341d24) | `` nixos/release-notes: mention new startx options ``                      |