### PR TITLE
chore(flake/nixvim): `1ca0ec3d` -> `d79c291d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1742341882,
-        "narHash": "sha256-ftbTPOg53Ez5smPgQhj4aut4c2QBKuNqlqyr1k2iFpM=",
+        "lastModified": 1742396414,
+        "narHash": "sha256-e9Uv44rVDAG2ohNejttl9Pq5r4dxIzWxt+1hvKTQK5E=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1ca0ec3d798ddc5b37d68bca86119d258a02a17b",
+        "rev": "d79c291d5d80d587d518e0f530cc55adb0638c80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`d79c291d`](https://github.com/nix-community/nixvim/commit/d79c291d5d80d587d518e0f530cc55adb0638c80) | `` tests/none-ls: re-enable terragrunt tests `` |
| [`bd99575a`](https://github.com/nix-community/nixvim/commit/bd99575a1f407dd0765069c4218b5ebdf7fddeb5) | `` flake/dev/flake.lock: Update ``              |
| [`afe93ad3`](https://github.com/nix-community/nixvim/commit/afe93ad385d880ae70f25619d7ee75ae732a5287) | `` flake.lock: Update ``                        |
| [`fab8f811`](https://github.com/nix-community/nixvim/commit/fab8f811218541932edf76120ebb28041eea49e9) | `` plugins/typst-preview: init ``               |
| [`f78adb09`](https://github.com/nix-community/nixvim/commit/f78adb09182dc6edf3f2a443c548ae4e0bf789f1) | `` plugins/lsp: enable dolmenls and ocamllsp `` |