### PR TITLE
chore(flake/nixpkgs): `c80f6a7e` -> `b6eaf97c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742069588,
-        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
+        "lastModified": 1742288794,
+        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`b6eaf97c`](https://github.com/NixOS/nixpkgs/commit/b6eaf97c6960d97350c584de1b6dcff03c9daf42) | `` liblouis: 3.32.0 -> 3.33.0 ``                                                    |
| [`b82dbaf3`](https://github.com/NixOS/nixpkgs/commit/b82dbaf3abfe30ba7625b0094c7ccf12ca6a02fc) | `` nixos-generate-config: Fix unspecified root ``                                   |
| [`98f7ced0`](https://github.com/NixOS/nixpkgs/commit/98f7ced0d7adfdc2d45239f394d649d646120973) | `` python312Packages.pydmd: 2025.01.01 -> 2025.03.01 ``                             |
| [`52a0e458`](https://github.com/NixOS/nixpkgs/commit/52a0e458e4ff1472d2ba2f8aa551de2936bc7a40) | `` python312Packages.ezyrb: cleanup, fix build ``                                   |
| [`65dac76f`](https://github.com/NixOS/nixpkgs/commit/65dac76fd461d4d42beb32e320d38ab4cf56130d) | `` glycin-loaders: enable strictDeps ``                                             |
| [`88fb09ab`](https://github.com/NixOS/nixpkgs/commit/88fb09abb6f24bdccce0be7f9badba316e4b40aa) | `` python312Packages.coffea: 2025.1.1 -> 2025.3.0 ``                                |
| [`5d928bf4`](https://github.com/NixOS/nixpkgs/commit/5d928bf499dd9e26deb1592e53dae4152dd6cdc7) | `` coqPackages.jasmin: 2024.07.3 → 2025.02.0 ``                                     |
| [`12cce16d`](https://github.com/NixOS/nixpkgs/commit/12cce16d8a162d7e84d628286a53cbf6781c6884) | `` coqPackages.jasmin: 2024.07.2 → 2024.07.3 ``                                     |
| [`502d5ef9`](https://github.com/NixOS/nixpkgs/commit/502d5ef9f3cf8d9de3c63b687b3e56473785307c) | `` Revert "coqPackages.jasmin: 2024.07.2 -> 2025.02.0" ``                           |
| [`9e270b23`](https://github.com/NixOS/nixpkgs/commit/9e270b233778adb93693d967f3d6ba913d8b68cd) | `` acgtk: 2.0.0 → 2.1.0 ``                                                          |
| [`2b379578`](https://github.com/NixOS/nixpkgs/commit/2b3795787eba0066a2bc8bba7362422e5713840f) | `` manta: drop ``                                                                   |
| [`1963bc7d`](https://github.com/NixOS/nixpkgs/commit/1963bc7ddc7a8f778ed7ffa5b4716475c4874ff4) | `` gnomeExtensions: auto-update ``                                                  |
| [`28550306`](https://github.com/NixOS/nixpkgs/commit/285503065985a52292146b854431266666b05622) | `` nixos/release-combined: migrate to graphical ISO in tested set ``                |
| [`3e7592be`](https://github.com/NixOS/nixpkgs/commit/3e7592beaf80da04ac480291c79db9a22704f49f) | `` qt6Packages.waylib: 0.6.12 -> 0.6.13 ``                                          |
| [`46380bea`](https://github.com/NixOS/nixpkgs/commit/46380beac3bb53f87eaafd64c9bea2ae4b047f26) | `` libosmium: 2.21.0 -> 2.22.0 ``                                                   |
| [`f729dd3b`](https://github.com/NixOS/nixpkgs/commit/f729dd3bdbb981e859948bed20cd3f79359a5aa6) | `` ynetd: add hardened ctf-centric fork ``                                          |
| [`d482add7`](https://github.com/NixOS/nixpkgs/commit/d482add721111ca3637f113243a71a47a936253f) | `` python312Packages.firecrawl-py: 1.5.0 -> 1.6.0 ``                                |
| [`6bb007e0`](https://github.com/NixOS/nixpkgs/commit/6bb007e03c71829da5415a9bc2a79fb837d57766) | `` ynetd: init at 2024.02.17 ``                                                     |
| [`415f4326`](https://github.com/NixOS/nixpkgs/commit/415f4326bd8d4a2563c416c2c4f0d3fbb9d22701) | `` vscode-extensions.tekumara.typos-vscode: 0.1.26 -> 0.1.35 ``                     |
| [`06f6ef5c`](https://github.com/NixOS/nixpkgs/commit/06f6ef5cc4701e8ea1d02c45d88db679e69bb435) | `` typos-lsp: 0.1.34 -> 0.1.35 ``                                                   |
| [`d872a2a5`](https://github.com/NixOS/nixpkgs/commit/d872a2a57e6c563802025f2c5397a2655b65b403) | `` graphql-language-service-cli: init at 3.5.0 ``                                   |
| [`fa3fe52f`](https://github.com/NixOS/nixpkgs/commit/fa3fe52fa525f6a7fd15f930010d836095929bcb) | `` vscode-extensions.shd101wyy.markdown-preview-enhanced: 0.8.15 -> 0.8.18 ``       |
| [`abcb6b77`](https://github.com/NixOS/nixpkgs/commit/abcb6b77b41568737b718beaa481ba20f71cc0f7) | `` cfonts: 1.1.3 -> 1.2.0 ``                                                        |
| [`d300c738`](https://github.com/NixOS/nixpkgs/commit/d300c7382dcb008d4a37a249b321b9254078bde6) | `` python312Packages.orbax-checkpoint: 0.11.8 -> 0.11.9 ``                          |
| [`d5cd78b9`](https://github.com/NixOS/nixpkgs/commit/d5cd78b95c90d6d9b9944479ca38cf957270bb3c) | `` vscode-extensions.ms-python.debugpy: 2025.4.0 -> 2025.4.1 ``                     |
| [`da737021`](https://github.com/NixOS/nixpkgs/commit/da737021af3d836172c85ca8631e5028cf311b28) | `` drawio: add 'draw.io' to description to improve search discoverability ``        |
| [`2a3b9535`](https://github.com/NixOS/nixpkgs/commit/2a3b95357c0f3a38727085cbdabcc75ae4eb5682) | `` ztools: init at 7/3.1 ``                                                         |
| [`f137791c`](https://github.com/NixOS/nixpkgs/commit/f137791c52f8d462709dbeedfd59370f5b967031) | `` maintainers: add haylin ``                                                       |
| [`007eb230`](https://github.com/NixOS/nixpkgs/commit/007eb230fa8b2600560bc239d06fd65cfc39cfe6) | `` dpms-off: init at 0.2.1 ``                                                       |
| [`af6c9519`](https://github.com/NixOS/nixpkgs/commit/af6c95198792ca8929406349e78f51fd5f2b1266) | `` ayugram-desktop: 5.11.1 -> 5.12.3 ``                                             |
| [`9dc7db33`](https://github.com/NixOS/nixpkgs/commit/9dc7db332208472c79451251b64bc166ebacde18) | `` emacs.pkgs.shell-quasiquote: 0.0.20221221.82030 -> 0.0.20250316.162215 ``        |
| [`6c56e1d6`](https://github.com/NixOS/nixpkgs/commit/6c56e1d692868c4a4378bcc0fe9915870a4097a0) | `` television: 0.10.8 -> 0.10.9 ``                                                  |
| [`1a830fe9`](https://github.com/NixOS/nixpkgs/commit/1a830fe9d96db50992f1c9d141875dfb9ba0cbba) | `` nixos/limine: fix the install script ``                                          |
| [`2cc1d334`](https://github.com/NixOS/nixpkgs/commit/2cc1d334891ebebd9e4ac9641e08f9e816c47fac) | `` nixos/limine: cast partition index to string (#390732) ``                        |
| [`7048529f`](https://github.com/NixOS/nixpkgs/commit/7048529f923dfd44441f1ab0441a517d72424f2d) | `` limine: migrate to finalAttrs pattern ``                                         |
| [`80da4f45`](https://github.com/NixOS/nixpkgs/commit/80da4f45e121e3723f9f9025b3f229f39a8fc419) | `` limine: link nixosTests.limine to passthru.tests ``                              |
| [`5b8928c1`](https://github.com/NixOS/nixpkgs/commit/5b8928c10436747e2662cf5e11ca40858eaccbee) | `` limine: enable BIOS support by default for x86 ``                                |
| [`b47b8c6e`](https://github.com/NixOS/nixpkgs/commit/b47b8c6eea50cec298e829abae679b907f658b9d) | `` limine: 9.0.1 -> 9.2.0 ``                                                        |
| [`f7c0e53d`](https://github.com/NixOS/nixpkgs/commit/f7c0e53df62ee85911478e140269f167253d735a) | `` python312Packages.edk2-pytool-library: 0.22.6 -> 0.23.0 ``                       |
| [`4d1a26b2`](https://github.com/NixOS/nixpkgs/commit/4d1a26b2ad34b3ae7f812c65978c24cd48506222) | `` godot: fix eval on Nix 2.3 ``                                                    |
| [`06210b25`](https://github.com/NixOS/nixpkgs/commit/06210b25bfbe5e35c9136127f6a3d51e4bb560d3) | `` skim: 0.16.0 -> 0.16.1 ``                                                        |
| [`a263693a`](https://github.com/NixOS/nixpkgs/commit/a263693a0fe201945cc974032e121525a750c3ff) | `` filen-cli: init at 0.0.29 ``                                                     |
| [`a7e0bdb7`](https://github.com/NixOS/nixpkgs/commit/a7e0bdb746e41b1b7b787d6c178c8a83e1bd3e44) | `` libreoffice-fresh: 25.2.0.3 -> 25.2.1.2 ``                                       |
| [`d5440886`](https://github.com/NixOS/nixpkgs/commit/d54408861588610541c8fc0e675c70564a192917) | `` spotifyd: 0.4.0 -> 0.4.1 ``                                                      |
| [`213e9041`](https://github.com/NixOS/nixpkgs/commit/213e90413c024832029ffa9f5f58679f3852255e) | `` pixelflasher: init at 7.11.1.0 ``                                                |
| [`08f2d90b`](https://github.com/NixOS/nixpkgs/commit/08f2d90be4c18169c4bb819621b2efb59463197f) | `` llm-gemini: init at 0.15 ``                                                      |
| [`4536f902`](https://github.com/NixOS/nixpkgs/commit/4536f9024b33e0367ce1049fa437eb01bd1b06cd) | `` docling: 2.25.2 -> 2.26.0 ``                                                     |
| [`5ed08223`](https://github.com/NixOS/nixpkgs/commit/5ed0822371e808b119c61988d87076a6485605bc) | `` libreoffice-*: fix update.sh for collabora ``                                    |
| [`9670e479`](https://github.com/NixOS/nixpkgs/commit/9670e479d89e47a1a4d62edf89495a23dba923f3) | `` inori: 0.2.3 -> 0.2.4 ``                                                         |
| [`d59bf158`](https://github.com/NixOS/nixpkgs/commit/d59bf15875095a7f04f3e364b2e17ea49c944fd1) | `` _1password-gui: Refactor update.sh to decrease manual work burden ``             |
| [`656d5574`](https://github.com/NixOS/nixpkgs/commit/656d55747907d555897a0308f259ae8e6f2f4054) | `` vimPlugins.aw-watcher-nvim: init at 2025-03-06 ``                                |
| [`e7fe9fdb`](https://github.com/NixOS/nixpkgs/commit/e7fe9fdb0a1625e802094dc4b7481ae9c544e452) | `` glance: use finalAttrs pattern ``                                                |
| [`6b04132c`](https://github.com/NixOS/nixpkgs/commit/6b04132c51af3dd6dd5d867265157c589bbbded9) | `` tilt: add completions ``                                                         |
| [`5f16d7d2`](https://github.com/NixOS/nixpkgs/commit/5f16d7d250573b56f92c162cb9e344a1a21dd5d2) | `` glance: 0.7.6 -> 0.7.7 ``                                                        |
| [`1b957065`](https://github.com/NixOS/nixpkgs/commit/1b957065bcabd41490d2e70186cc17b69328c442) | `` syshud: 0-unstable-2025-01-13 -> 0-unstable-2025-03-11 ``                        |
| [`399baf3e`](https://github.com/NixOS/nixpkgs/commit/399baf3e6bbfd7862bd6b8ef6a6efea3012dcaa7) | `` rabbit: unbreak the package ``                                                   |
| [`29b8c9dc`](https://github.com/NixOS/nixpkgs/commit/29b8c9dcfbd58ae258b7a6ea0a61b62e0d13fc23) | `` python312Packages.knx-frontend: 2025.1.30.194235 -> 2025.3.8.214559 (#390597) `` |
| [`24b80f09`](https://github.com/NixOS/nixpkgs/commit/24b80f09e64c1a57329636af80dddcb61be247b9) | `` home-assistant-custom-components.better_thermostat: 1.6.1 -> 1.7.0 (#390622) ``  |
| [`0ca1fc33`](https://github.com/NixOS/nixpkgs/commit/0ca1fc33509563e87989fad2cbc3d39f988570de) | `` vimPlugins: inherit lua & node packages before overrides ``                      |
| [`2f234491`](https://github.com/NixOS/nixpkgs/commit/2f234491379718de17ad9e613c764cccd345687d) | `` terragrunt: 0.73.15 -> 0.75.10; fix build ``                                     |
| [`3348d8a2`](https://github.com/NixOS/nixpkgs/commit/3348d8a2977075e84d6b3023c4a833a432836810) | `` signal-desktop(aarch64-linux): 7.36.0 -> 7.46.0-1 from COPR (#384032) ``         |
| [`28187526`](https://github.com/NixOS/nixpkgs/commit/281875261d71aaa786eb4e25a45f4ec355fe7aef) | `` Revert "build(deps): bump cachix/install-nix-action from 30 to 31" ``            |
| [`588f41be`](https://github.com/NixOS/nixpkgs/commit/588f41bef0e1a01a484f1a9f13493527eb8d08e4) | `` nixos/hydra: fix race condition in hydra-compress-logs ``                        |
| [`a92cce06`](https://github.com/NixOS/nixpkgs/commit/a92cce06e85cdf5610c00a81563cad4596de7ffa) | `` hyprutils: 0.5.1 -> 0.5.2 ``                                                     |
| [`229edc7e`](https://github.com/NixOS/nixpkgs/commit/229edc7e599fc6bb194597f91dd567f907c80965) | `` nftrace: init at 0.1.0 ``                                                        |
| [`1b040dd9`](https://github.com/NixOS/nixpkgs/commit/1b040dd91b153e1e5af23b1e62d9aaa49f9bf2f2) | `` altus: init at 5.6.0 ``                                                          |
| [`2581a405`](https://github.com/NixOS/nixpkgs/commit/2581a4054480e33a8199032b1a119915c386adf7) | `` bird: change alias to throw to avoid confusion ``                                |
| [`3f3312e1`](https://github.com/NixOS/nixpkgs/commit/3f3312e147b5cd48f0534f0d36544faf6e5f9d00) | `` mautrix-whatsapp: 0.11.3 -> 0.11.4 ``                                            |
| [`952db077`](https://github.com/NixOS/nixpkgs/commit/952db07769a279cf6429aaf81880359fc1ad5ae3) | `` newsraft: 0.28 -> 0.29 ``                                                        |
| [`cc2221e0`](https://github.com/NixOS/nixpkgs/commit/cc2221e0fd73eae0bc61ac739812b24b8d0242df) | `` mautrix-meta: 0.4.4 -> 0.4.5 ``                                                  |
| [`db3eb71f`](https://github.com/NixOS/nixpkgs/commit/db3eb71fddf99893f19d057974134ca1b04bdf43) | `` oh-my-zsh: 2025-02-19 -> 2025-03-11 (#389510) ``                                 |
| [`800fced8`](https://github.com/NixOS/nixpkgs/commit/800fced82370bc6ccbfda79386d9c00b6f0a603a) | `` run-scaled: remove ``                                                            |
| [`40d16735`](https://github.com/NixOS/nixpkgs/commit/40d16735019ebe05307978f03bd0c346d0a2df7d) | `` msolve: 0.7.4 -> 0.7.5 ``                                                        |
| [`31dd9ac8`](https://github.com/NixOS/nixpkgs/commit/31dd9ac80b1679838dba1d7fff450261553a4a1a) | `` libretro.gambatte: 0-unstable-2025-02-28 -> 0-unstable-2025-03-07 ``             |
| [`4630419e`](https://github.com/NixOS/nixpkgs/commit/4630419ed3f6ff2c1ef30a58b4abc2414c74546b) | `` libretro.genesis-plus-gx: 0-unstable-2025-01-17 -> 0-unstable-2025-03-08 ``      |
| [`e2590ba4`](https://github.com/NixOS/nixpkgs/commit/e2590ba4b7fd25d07a891823b7f1019e0ce505c9) | `` libretro.bsnes: 0-unstable-2025-02-28 -> 0-unstable-2025-03-07 ``                |
| [`312bedfa`](https://github.com/NixOS/nixpkgs/commit/312bedfad6bbbc46a1a72aa3ecbdb466f2f49ce1) | `` libretro.freeintv: 0-unstable-2024-10-21 -> 0-unstable-2025-03-05 ``             |
| [`ac8dacb4`](https://github.com/NixOS/nixpkgs/commit/ac8dacb4f63a4b4c9712207a9ca59d3c2218e74a) | `` sonarlint-ls: update 3.14.1 -> 3.17.0 and fix test ``                            |
| [`ff717c5e`](https://github.com/NixOS/nixpkgs/commit/ff717c5e2a0a30875146aa4833a6aba5bedfe0ab) | `` stu: 0.6.6 -> 0.7.0 ``                                                           |
| [`5db68fcd`](https://github.com/NixOS/nixpkgs/commit/5db68fcdc00a95d9957d34b7b14b7fafd9e9f24e) | `` nbxmpp: 6.0.0 -> 6.0.2 ``                                                        |
| [`97a6fa51`](https://github.com/NixOS/nixpkgs/commit/97a6fa51e2f8d4e7b62824b4f7c36b4e23f3c934) | `` gajim: 2.0.2 -> 2.0.3 ``                                                         |
| [`2bd6215c`](https://github.com/NixOS/nixpkgs/commit/2bd6215cb09d5fadb1b04c3d8400a70f0386f262) | `` libretro.mame2003: 0-unstable-2025-01-26 -> 0-unstable-2025-03-14 ``             |
| [`c59efa47`](https://github.com/NixOS/nixpkgs/commit/c59efa472a0325509d1b1322943b5cdb19af99bf) | `` libretro.beetle-saturn: 0-unstable-2024-10-21 -> 0-unstable-2025-03-16 ``        |
| [`5f6074da`](https://github.com/NixOS/nixpkgs/commit/5f6074da2b1317642f06a07ecdf2b34573916e09) | `` libretro.beetle-pce-fast: 0-unstable-2024-12-27 -> 0-unstable-2025-03-07 ``      |
| [`8cad67f2`](https://github.com/NixOS/nixpkgs/commit/8cad67f2a3231929db67a305c063206fefea8f35) | `` build(deps): bump cachix/install-nix-action from 30 to 31 ``                     |
| [`2f2a95dd`](https://github.com/NixOS/nixpkgs/commit/2f2a95ddcc33e069d188d68c79407b8a12e0d185) | `` build(deps): bump cachix/cachix-action from 15 to 16 ``                          |
| [`727b9e2d`](https://github.com/NixOS/nixpkgs/commit/727b9e2d89221826cd2efec360bb466b6168eefc) | `` python312Packages.dissect-hypervisor: 3.16 -> 3.17 ``                            |
| [`13813eef`](https://github.com/NixOS/nixpkgs/commit/13813eef98f326a4bb7ca1d2026eecb384477bff) | `` python312Packages.dissect-ntfs: 3.13 -> 3.14 ``                                  |
| [`fd6b4ecc`](https://github.com/NixOS/nixpkgs/commit/fd6b4eccf2a40c351c689b1b068d746272bc387e) | `` python312Packages.dissect-ffs: 3.10 -> 3.11 ``                                   |
| [`fb06e078`](https://github.com/NixOS/nixpkgs/commit/fb06e078168654cae274353d8448f0a851368945) | `` python312Packages.dissect-squashfs: 1.8 -> 1.9 ``                                |