### PR TITLE
chore(flake/nixvim): `d79c291d` -> `d44b33a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1742396414,
-        "narHash": "sha256-e9Uv44rVDAG2ohNejttl9Pq5r4dxIzWxt+1hvKTQK5E=",
+        "lastModified": 1742488644,
+        "narHash": "sha256-vXpu7G4aupNCPlv8kAo7Y/jocfSUwglkvNx5cR0XjBo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d79c291d5d80d587d518e0f530cc55adb0638c80",
+        "rev": "d44b33a1ea1a3e584a8c93164dbe0ba2ad4f3a13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                   |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`d44b33a1`](https://github.com/nix-community/nixvim/commit/d44b33a1ea1a3e584a8c93164dbe0ba2ad4f3a13) | `` plugins/faust: init ``                                                                 |
| [`7e51c72d`](https://github.com/nix-community/nixvim/commit/7e51c72da2107ff0c1c04e9c6bbce4f624b7dfc8) | `` plugins/image: remove unneeded magick dependency (already propagated by image-nvim) `` |
| [`279d2570`](https://github.com/nix-community/nixvim/commit/279d2570b5bc808809aee810c4f8d825c665ecee) | `` plugins/image: migrate to mkNeovimPlugin ``                                            |
| [`c5967bf6`](https://github.com/nix-community/nixvim/commit/c5967bf6a566deff2cabb4f0474333cbf0e06e01) | `` plugins/devdocs: init ``                                                               |
| [`695add12`](https://github.com/nix-community/nixvim/commit/695add12fc25c5de975c7e93207e9442bde625e6) | `` plugins/diagram: init ``                                                               |
| [`ea6df31d`](https://github.com/nix-community/nixvim/commit/ea6df31d30df0049fb1451ce62fc3025e10def4b) | `` flake/dev/flake.lock: Update ``                                                        |