### PR TITLE
chore(flake/nixvim): `3d84c137` -> `7776e37b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1742645604,
-        "narHash": "sha256-4LB/Gx1p/ml79xZfgTvOYvMXXnj5vrFfDYcWIndgXP0=",
+        "lastModified": 1742732006,
+        "narHash": "sha256-ZIBMfPNb/hfoFf79MRnhDXGKl0yGhjlYEpy3+/jbxFI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "3d84c137eab329ec1a6d4c4b0a067bfa8eea0bb5",
+        "rev": "7776e37b67e7875c3cd56d9d20fd050798071706",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`7776e37b`](https://github.com/nix-community/nixvim/commit/7776e37b67e7875c3cd56d9d20fd050798071706) | `` flake/dev/flake.lock: Update `` |
| [`c0952df4`](https://github.com/nix-community/nixvim/commit/c0952df40805b37174e1e5d9a3d1fc8e6e101735) | `` flake.lock: Update ``           |