### PR TITLE
chore(flake/nixvim): `ff46e752` -> `6b95b825`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1742857647,
-        "narHash": "sha256-5ZnZ9IfwPdkKwloR8p7By9JKwU+mLr5pWmwflbK4lGE=",
+        "lastModified": 1742916868,
+        "narHash": "sha256-2eN75OsaNpL3FzAs3hz9Xm3+htIP3iLdfRP6PGfOoS8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ff46e752a12a20c477b4813df7ab58b4df438ec0",
+        "rev": "6b95b825529aa2d8536f7684fe64382ef4d15d84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`6b95b825`](https://github.com/nix-community/nixvim/commit/6b95b825529aa2d8536f7684fe64382ef4d15d84) | `` tests/none-ls: re-enable semgrep test `` |
| [`3cc58f0c`](https://github.com/nix-community/nixvim/commit/3cc58f0c7412813244ea7f613223b762fc1cb332) | `` flake/dev/flake.lock: Update ``          |
| [`1d218caf`](https://github.com/nix-community/nixvim/commit/1d218caf1c321f73141d0e858fa2a3136574a3e4) | `` flake.lock: Update ``                    |
| [`ec92a181`](https://github.com/nix-community/nixvim/commit/ec92a1816e7deb33d03ff0ab7692fa504e3d1910) | `` plugins/vimwiki: init ``                 |