### PR TITLE
chore(flake/treefmt-nix): `adc195ee` -> `61c88349`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742370146,
-        "narHash": "sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU=",
+        "lastModified": 1742982148,
+        "narHash": "sha256-aRA6LSxjlbMI6MmMzi/M5WH/ynd8pK+vACD9za3MKLQ=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "adc195eef5da3606891cedf80c0d9ce2d3190808",
+        "rev": "61c88349bf6dff49fa52d7dfc39b21026c2a8881",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                               |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`4613f759`](https://github.com/numtide/treefmt-nix/commit/4613f759ecbf59bdd3035f02c1467b416fb3ca5a) | `` sqlfluff: improve performance ``   |
| [`f8c987ff`](https://github.com/numtide/treefmt-nix/commit/f8c987ff4910a21d11bbfd480e01aa255cdada79) | `` sqlfluff: support sqlfluff lint `` |