### PR TITLE
chore(flake/nixvim): `1c0dd320` -> `95573411`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1742991302,
-        "narHash": "sha256-5S+qnc5ijgFWlAWS9+L7uAgpDnL0RtVEDhVpHWGoavA=",
+        "lastModified": 1743157969,
+        "narHash": "sha256-ldlSyVKNaXL7ys7Jr7mLhlpGDE4VPVcWmV7Odupn5TY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1c0dd320d9c4f250ac33382e11d370b7abe97622",
+        "rev": "95573411bc9be155a93b0f15d2bad62c6b43b3cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`95573411`](https://github.com/nix-community/nixvim/commit/95573411bc9be155a93b0f15d2bad62c6b43b3cc) | `` modules/keymaps: add replace_keycodes keymap sub-option ``         |
| [`fe95b14d`](https://github.com/nix-community/nixvim/commit/fe95b14d5229a2fa90bebd79b2058388bb68d072) | `` lib/keymap-helpers (mapConfigOptions): use mkNullOrStr for desc `` |
| [`dbec7ff2`](https://github.com/nix-community/nixvim/commit/dbec7ff2eb7366f956ffa27e34e67116e8e1909e) | `` flake/dev/flake.lock: apply changes from #3121 ``                  |
| [`8e732cfa`](https://github.com/nix-community/nixvim/commit/8e732cfac1e99dd53822c4e536d09e242ef9fd2a) | `` flake/dev: rename `nixpkgs` input to avoid shadowing ``            |