### PR TITLE
chore(flake/nixvim): `81fdde9f` -> `d81f3725`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1743288994,
-        "narHash": "sha256-hUlfAcIUnS8/eSFq+uzOHPZO1p8QgBTAoqhDWzEkUto=",
+        "lastModified": 1743362786,
+        "narHash": "sha256-XbXIRDbb8/vLBX1M096l7lM5wfzBTp1ZXfUl9bUhVGU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "81fdde9fc529e0a5f9ff0d570f31acfe85fd20ac",
+        "rev": "d81f37256d0a8691b837b74979d27bf89be8ecdd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`d81f3725`](https://github.com/nix-community/nixvim/commit/d81f37256d0a8691b837b74979d27bf89be8ecdd) | `` plugins/aw-watcher: init ``       |
| [`a3b16fa0`](https://github.com/nix-community/nixvim/commit/a3b16fa00404dce7eccc289ce0b54a8111628d4f) | `` plugins/highlight-colors: init `` |