### PR TITLE
chore(flake/nixvim): `754b8df7` -> `a183298b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1743536158,
-        "narHash": "sha256-/jlBU7EGIfaa5VKwvVyrSspuuNmgKYOjAuTd2ywyevg=",
+        "lastModified": 1743598191,
+        "narHash": "sha256-30aI8rWjX64E9vIlE4iqgQguTjItvTnQLTqHtFppF/w=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "754b8df7e37be04b7438decee5a5aa18af72cbe1",
+        "rev": "a183298bf67307bdb7a25a2a3c565e76029f1b9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`a183298b`](https://github.com/nix-community/nixvim/commit/a183298bf67307bdb7a25a2a3c565e76029f1b9e) | `` flake/dev/flake.lock: Update `` |
| [`0e1010b9`](https://github.com/nix-community/nixvim/commit/0e1010b9085e4226f1e686bb3ce5b86bf7f97e74) | `` flake.lock: Update ``           |
| [`8ffda5af`](https://github.com/nix-community/nixvim/commit/8ffda5afb163ff9604e34c0af552693dc76ed4e0) | `` plugins/cord: init ``           |