### PR TITLE
chore(flake/treefmt-nix): `29a3d7b7` -> `18bed671`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743081648,
-        "narHash": "sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE=",
+        "lastModified": 1743589519,
+        "narHash": "sha256-iBzr7Zb11nQxwX90bO1+Bm1MGlhMSmu4ixgnQFB+j4E=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "29a3d7b768c70addce17af0869f6e2bd8f5be4b7",
+        "rev": "18bed671738e36c5504e188aadc18b7e2a6e408f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                          |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`97bd2d28`](https://github.com/numtide/treefmt-nix/commit/97bd2d286702ba82fa10b14e28fc2236dea0aa1c) | `` meson: add option for editorconfig support `` |
| [`a39d06aa`](https://github.com/numtide/treefmt-nix/commit/a39d06aa8cb289f06da3ac0d4eb8656f3d8598be) | `` muon: add option for editorconfig support ``  |