### PR TITLE
chore(flake/nixpkgs): `52faf482` -> `2c8d3f48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743315132,
-        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`75545814`](https://github.com/NixOS/nixpkgs/commit/75545814743d6bc3c378f39bdb3e5fc7e512734e) | `` nixos/h2o: enable HTTP/3 via QUIC ``                                                 |
| [`301581e0`](https://github.com/NixOS/nixpkgs/commit/301581e073d36641c426df4d581d3d4c167cd891) | `` nixos/h2o: typo ``                                                                   |
| [`454411d3`](https://github.com/NixOS/nixpkgs/commit/454411d33e8058062e0ebf37ecd3202b75adf903) | `` nixos/h2o: reduce variable name noise ``                                             |
| [`385e1aa8`](https://github.com/NixOS/nixpkgs/commit/385e1aa892d6b9837a1572099e3c4564edcb7f3a) | `` go_1_22/buildGo122Module: remove ``                                                  |
| [`418ac80e`](https://github.com/NixOS/nixpkgs/commit/418ac80e0424a758a0da64f9c9a1792664344a5f) | `` cloudflared: mark broken ``                                                          |
| [`58ecd4ed`](https://github.com/NixOS/nixpkgs/commit/58ecd4ed76296c8dff95afbfc3feaab77fe7886f) | `` ivpn{,-service}: unpin Go builder ``                                                 |
| [`eeb90f65`](https://github.com/NixOS/nixpkgs/commit/eeb90f652a5e180e9e4a8556b411bf9c5635fb7d) | `` wireguard-go: mark broken ``                                                         |
| [`23502cd2`](https://github.com/NixOS/nixpkgs/commit/23502cd2e966e11c8f44d70f0b95962daafeab7d) | `` warp-plus: mark broken ``                                                            |
| [`9216f2e4`](https://github.com/NixOS/nixpkgs/commit/9216f2e485f826171f9d79eebb39c0b56d73a9fd) | `` pingu: mark broken ``                                                                |
| [`307365ac`](https://github.com/NixOS/nixpkgs/commit/307365acaa3d481fd6cc7ea55e229b1ca6893219) | `` gitmux: unpin Go builder, disable tests ``                                           |
| [`46f46dd8`](https://github.com/NixOS/nixpkgs/commit/46f46dd8f7c52e87c977a3d815184d57beff2f5d) | `` acme-dns: 1.1 -> 1.1-unstable-2024-12-15, unpin Go builder, mark broken on darwin `` |
| [`14b235a1`](https://github.com/NixOS/nixpkgs/commit/14b235a1fb6b1207e3c80c0f21b9fd0025b23bb5) | `` grafana-agent: mark broken ``                                                        |
| [`8a528b3f`](https://github.com/NixOS/nixpkgs/commit/8a528b3fc8a38cc7d8aedeeadb528b12d7703004) | `` prometheus-node-cert-exporter: unpin Go builder ``                                   |
| [`092e15e8`](https://github.com/NixOS/nixpkgs/commit/092e15e8d6c2dadc5d478feb8dbf33dab6c26def) | `` prometheus-dnsmasq-exporter: unpin Go builder, mark broken on darwin ``              |
| [`f9b5b73f`](https://github.com/NixOS/nixpkgs/commit/f9b5b73f03f071a41edfe6b8069ee22bf9109261) | `` datadog-agent: unpin Go builder ``                                                   |
| [`75779d02`](https://github.com/NixOS/nixpkgs/commit/75779d02f256dee7f34638de9c59a303e060addc) | `` sensu-go-{agent,backend,cli}: unpin Go builder ``                                    |
| [`2a566731`](https://github.com/NixOS/nixpkgs/commit/2a566731ea7e446d9449f8b0f4fe7518dda46785) | `` nomad_1_{7,8}: remove ``                                                             |
| [`c5194f64`](https://github.com/NixOS/nixpkgs/commit/c5194f644153b796a5e2bdc54ba3165d83f3794c) | `` nexttrace: unpin Go builder, mark broken on darwin ``                                |
| [`b6729c81`](https://github.com/NixOS/nixpkgs/commit/b6729c8121beeb7a9cc4869f3def5152d843aced) | `` photofield: unpin Go builder ``                                                      |
| [`81492a48`](https://github.com/NixOS/nixpkgs/commit/81492a48d41354e31eb0b7addadbc0f82e261e92) | `` zincsearch: unpin Go builder ``                                                      |
| [`bfc4ad96`](https://github.com/NixOS/nixpkgs/commit/bfc4ad96e3095771f0a72e85672b471ea02360d0) | `` phlare: remove ``                                                                    |
| [`7f51f360`](https://github.com/NixOS/nixpkgs/commit/7f51f3603d245b1663b278b08cd72862c39792de) | `` hof: 0.6.9 -> 0.6.10, unpin Go builder, mark broken on darwin ``                     |
| [`4a4efe11`](https://github.com/NixOS/nixpkgs/commit/4a4efe11635f1b9c6a902c6741ab3703e99629e9) | `` honeytrap: unpin Go builder, fix versioning, mark broken on darwin ``                |
| [`007d3e9c`](https://github.com/NixOS/nixpkgs/commit/007d3e9c63cd84675f92cf2bd9ef27a07cf43eec) | `` devdash: remove ``                                                                   |
| [`95942824`](https://github.com/NixOS/nixpkgs/commit/9594282483ad77119e11e253cdab60934071438e) | `` bitmagnet: don't build dev binaries ``                                               |
| [`c7637335`](https://github.com/NixOS/nixpkgs/commit/c7637335cfe237710e1dd6a88e8cf8c2146b5c4e) | `` bitmagnet: 0.9.5 -> 0.10.0, unpin Go builder ``                                      |
| [`48fab785`](https://github.com/NixOS/nixpkgs/commit/48fab78541f254c31e6fc4193b0eb840425d4c3a) | `` bettercap: unpin Go builder, mark broken on darwin ``                                |
| [`1cbbdfea`](https://github.com/NixOS/nixpkgs/commit/1cbbdfea6f55dc3ac682fc6384339a0b375d5ee0) | `` ali: unpin Go builder, mark broken on darwin ``                                      |
| [`60318c17`](https://github.com/NixOS/nixpkgs/commit/60318c179054fc68c445a259430cd5286a08d0b8) | `` buildbotPackages: fix top-level definition ``                                        |
| [`3539fffd`](https://github.com/NixOS/nixpkgs/commit/3539fffd201bd74b286c95e33c1387b735debe3f) | `` cloudpan189-go: remove ``                                                            |
| [`58dabc40`](https://github.com/NixOS/nixpkgs/commit/58dabc406009d3e1ee81ef1a5c27c01bc56b5aa8) | `` python313Packages.boto3-stubs: 1.37.24 -> 1.37.25 ``                                 |
| [`81541847`](https://github.com/NixOS/nixpkgs/commit/8154184700a35696d34a32d0b9fb42ffc0709580) | `` python313Packages.botocore-stubs: 1.37.24 -> 1.37.25 ``                              |
| [`4b945801`](https://github.com/NixOS/nixpkgs/commit/4b945801302399557f4ca7af8093a33b036b20e9) | `` python312Packages.mypy-boto3-sagemaker: 1.37.23 -> 1.37.25 ``                        |
| [`bfc4651b`](https://github.com/NixOS/nixpkgs/commit/bfc4651b66ca2beba222c5424013c36c692754d3) | `` python312Packages.mypy-boto3-cleanrooms: 1.37.15 -> 1.37.25 ``                       |
| [`234cdf86`](https://github.com/NixOS/nixpkgs/commit/234cdf862b0628e891def086f5999e3f2fb23cb8) | `` checkov: 3.2.395 -> 3.2.396 ``                                                       |
| [`ba5bba36`](https://github.com/NixOS/nixpkgs/commit/ba5bba362a461a9af110fbacecac0a9b9869a70a) | `` python313Packages.netutils: 1.12.0 -> 1.13.0 ``                                      |
| [`1daa2fbc`](https://github.com/NixOS/nixpkgs/commit/1daa2fbc0de87f20130900bc566031a39931a676) | `` http-scanner: init at 1.0.1 ``                                                       |
| [`673b83cc`](https://github.com/NixOS/nixpkgs/commit/673b83cc7334ee761474b01bc06ee420b3311dc6) | `` python312Packages.swh-scheduler: init at 3.1.0 ``                                    |
| [`4e91a457`](https://github.com/NixOS/nixpkgs/commit/4e91a457780586d98c99d3301801ce0cf27e6114) | `` python312Packages.plotille: init at 5.0.0 ``                                         |
| [`387987c5`](https://github.com/NixOS/nixpkgs/commit/387987c50fa9fbfa10aa02d70b1ee1d2665b6f02) | `` python312Packages.swh-storage: init at 3.1.0 ``                                      |
| [`df4895cb`](https://github.com/NixOS/nixpkgs/commit/df4895cb62a5e5bcd362f6580d522918445e0bf8) | `` python312Packages.swh-journal: init at 2.0.0 ``                                      |
| [`0d3a1cd8`](https://github.com/NixOS/nixpkgs/commit/0d3a1cd8884869dfab0e4d681eee078f96373ecd) | `` python312Packages.pytest-shared-session-scope: init at 0.4.0 ``                      |
| [`e9dfc5bf`](https://github.com/NixOS/nixpkgs/commit/e9dfc5bfb52de51aed10bdd3e1a39cd0c3e2640b) | `` python312Packages.swh-objstorage: init at 4.0.0 ``                                   |
| [`74d8a5f0`](https://github.com/NixOS/nixpkgs/commit/74d8a5f072807199b9f751af688be8fa51590f61) | `` python312Packages.swh-perfecthash: init at 1.3.2 ``                                  |
| [`3c92e1c9`](https://github.com/NixOS/nixpkgs/commit/3c92e1c9f197d93328191b5b457cfe5f6a5cbff1) | `` python312Packages.swh-scanner: add patch to fix a test ``                            |
| [`5df5826b`](https://github.com/NixOS/nixpkgs/commit/5df5826b5c05506df08f1780793017e9b4c708a2) | `` cmph: add missing `meta.mainProgram` ``                                              |
| [`dda8c5c4`](https://github.com/NixOS/nixpkgs/commit/dda8c5c4593ad6cc7cd48a2272cbd70ceb9933d1) | `` python313Packages.cassandra-driver: mark as broken for Python >= 3.13 ``             |
| [`d9d2749c`](https://github.com/NixOS/nixpkgs/commit/d9d2749cdf0ac8a6083b1564532a4e2f041c7619) | `` verilator: 5.028 -> 5.034 ``                                                         |
| [`765bf285`](https://github.com/NixOS/nixpkgs/commit/765bf28543316070ad4ff3c32712d6c2a0824553) | `` python312Packages.wsnsimpy: drop ``                                                  |
| [`4da503af`](https://github.com/NixOS/nixpkgs/commit/4da503af1a403d38592ddb838ca2fc78cdad0ce5) | `` python312Packages.simpy: modernise, unbreak with Python >= 3.13 ``                   |
| [`7a8f7eaa`](https://github.com/NixOS/nixpkgs/commit/7a8f7eaaef4b26522e940f9a581fafc587a3d88e) | `` vpkedit: init at 4.4.2 ``                                                            |
| [`4e9ce6fc`](https://github.com/NixOS/nixpkgs/commit/4e9ce6fc943fbe7683a8ede495b03a0960c292b5) | `` python313Packages.yolink-api: 0.4.9 -> 0.5.0 ``                                      |
| [`dd33924e`](https://github.com/NixOS/nixpkgs/commit/dd33924e2d7bc5b3219502434bcd80ccb0edfe6e) | `` python313Packages.tencentcloud-sdk-python: 3.0.1352 -> 3.0.1353 ``                   |
| [`193958bf`](https://github.com/NixOS/nixpkgs/commit/193958bfbce00ea2ea298a447de9d4f11cb63f0c) | `` kdePackages: Plasma 6.3.3 -> 6.3.4 ``                                                |
| [`39630fc8`](https://github.com/NixOS/nixpkgs/commit/39630fc8762169a822a57d67909cee9516344ac0) | `` python312Packages.pysmartthings: 2.7.4 -> 3.0.1 ``                                   |
| [`b3a07ffc`](https://github.com/NixOS/nixpkgs/commit/b3a07ffccb83b85476885e885efbc03a29accb27) | `` gamescope: 3.16.2 -> 3.16.3 ``                                                       |
| [`bb50a5ba`](https://github.com/NixOS/nixpkgs/commit/bb50a5ba4592aa1ece024242cb5fb03873f3bdfa) | `` hyprland-protocols: 0.6.2 -> 0.6.3 ``                                                |
| [`35b644f6`](https://github.com/NixOS/nixpkgs/commit/35b644f69aa619ca005cfea290b603ff11208336) | `` python312Packages.netbox-plugin-prometheus-sd: 1.1.2 -> 1.2.0 ``                     |
| [`80828761`](https://github.com/NixOS/nixpkgs/commit/80828761fd64198dbc75b446f88bf7fc1401d09c) | `` copilot-language-server: 1.292.0 -> 1.294.0 ``                                       |
| [`e83f25b6`](https://github.com/NixOS/nixpkgs/commit/e83f25b6df17dec048704057da42d22164ec745d) | `` tail-tray: 0.2.18 -> 0.2.19 ``                                                       |
| [`f4026b91`](https://github.com/NixOS/nixpkgs/commit/f4026b9109fdf54222335c500075dd4e8561abac) | `` static-web-server: 2.36.0 -> 2.36.1 ``                                               |
| [`01cb06a6`](https://github.com/NixOS/nixpkgs/commit/01cb06a6044cecf52359f407905a2650cf3e477e) | `` dust: 1.1.2 -> 1.2.0 ``                                                              |
| [`f7b90766`](https://github.com/NixOS/nixpkgs/commit/f7b90766f1397a4b4eb685e6ed08ec0001ac9b83) | `` LycheeSlicer: init at 7.3.1 ``                                                       |
| [`ed9a1c64`](https://github.com/NixOS/nixpkgs/commit/ed9a1c64337488ffc47068ba8659579d655528a3) | `` jna: 5.16.0 -> 5.17.0 ``                                                             |
| [`fd6dc55c`](https://github.com/NixOS/nixpkgs/commit/fd6dc55cc17651e26e70a68cb0023a5c7896d62e) | `` wpaperd: 1.1.1 -> 1.2.0 ``                                                           |
| [`0c505839`](https://github.com/NixOS/nixpkgs/commit/0c505839a052ca3e122e9b0c7378c083168da948) | `` vimPlugins.visual-whitespace-nvim: init at 2025-03-31 ``                             |
| [`e1146016`](https://github.com/NixOS/nixpkgs/commit/e1146016a6c10dda4d9ef1c1541932f552bba7ec) | `` signal-desktop-source: bump SOURCE_DATE_EPOCH ``                                     |
| [`06ff7718`](https://github.com/NixOS/nixpkgs/commit/06ff77181f6683b7a99cdcd95f9e445c2d2b4b3e) | `` signal-desktop-source: build sticker-creator ``                                      |
| [`3a8bcc62`](https://github.com/NixOS/nixpkgs/commit/3a8bcc62f6f94d1915a68684e5e6f350c21ec30f) | `` signal-desktop-source: 7.46.0 -> 7.48.0 ``                                           |
| [`7bc20ae0`](https://github.com/NixOS/nixpkgs/commit/7bc20ae07a82167a205e7985e1fbdb704e21ad75) | `` lunacy: 11.1 -> 11.2.1 ``                                                            |
| [`f73ce732`](https://github.com/NixOS/nixpkgs/commit/f73ce7324d638531e2d0bdd2a97168cdd080c9c3) | `` orchard: 0.29.0 -> 0.31.0 ``                                                         |
| [`ff7ae6d1`](https://github.com/NixOS/nixpkgs/commit/ff7ae6d12b7ff961758b7192df46120091c11bcd) | `` mullvad-browser: 14.0.7 -> 14.0.9 ``                                                 |
| [`7d7ba194`](https://github.com/NixOS/nixpkgs/commit/7d7ba194bf834a5194dadfa8f9debcfabaa718bb) | `` tor-browser: 14.0.7 -> 14.0.9 ``                                                     |
| [`ce75ef61`](https://github.com/NixOS/nixpkgs/commit/ce75ef61f9686bf14580f23126ec5be614676181) | `` python312Packages.evosax: 0.1.6 -> 0.2.0 ``                                          |
| [`9856460d`](https://github.com/NixOS/nixpkgs/commit/9856460dbda3423383bde6bf31e263591302baa8) | `` hamrs-pro: add jhollowe as a maintainer ``                                           |
| [`2c66a3bc`](https://github.com/NixOS/nixpkgs/commit/2c66a3bcc8bee7af5700ec08c587211f0d8616d3) | `` hamrs-pro: init at 2.33.0 ``                                                         |
| [`d5ff9142`](https://github.com/NixOS/nixpkgs/commit/d5ff91426200548d0dc59ef666482a2e030c8378) | `` python312Packages.pycrdt: 0.12.10 -> 0.12.11 ``                                      |
| [`ca716565`](https://github.com/NixOS/nixpkgs/commit/ca71656541d4b07a02b360f59177d2485bd5b860) | `` go_1_23: 1.23.7 -> 1.23.8 ``                                                         |
| [`3f7221eb`](https://github.com/NixOS/nixpkgs/commit/3f7221eb2803304bb2ac420bc3968e07024259b5) | `` python312Packages.pyytlounge: 2.3.0 -> 3.1.0 ``                                      |
| [`b2edafe1`](https://github.com/NixOS/nixpkgs/commit/b2edafe12b3b4bbda2096dd96b3bc6bbf0d3d74c) | `` vectorcode: init at 0.5.3 ``                                                         |
| [`13778a23`](https://github.com/NixOS/nixpkgs/commit/13778a233053fd0fddcd7034554515db0c0c9e07) | `` python312Packages.tree-sitter-language-pack: cleanup ``                              |
| [`e2ca5905`](https://github.com/NixOS/nixpkgs/commit/e2ca590576c8330807e56f276f1a9f072f30ea43) | `` python312Packages.tree-sitter-embedded-template: cleanup, add tests ``               |
| [`6379453f`](https://github.com/NixOS/nixpkgs/commit/6379453fa35b1e0fa50ea62caac7f9a618ec0102) | `` python312Packages.tree-sitter-c-sharp: cleanup, add tests ``                         |
| [`eb3cec74`](https://github.com/NixOS/nixpkgs/commit/eb3cec7408e91a85121788ef510e3baa353f021b) | `` python312Packages.tree-sitter-yaml: cleanup, add tests ``                            |
| [`140f2af4`](https://github.com/NixOS/nixpkgs/commit/140f2af47be3422e76ca149dcad0b80f95b59e3b) | `` python313Packages.yfinance: 0.2.54 -> 0.2.55 ``                                      |
| [`bf22ad7c`](https://github.com/NixOS/nixpkgs/commit/bf22ad7c210bb19522bb9af96ab63acff4ede483) | `` harper: 0.26.0 -> 0.27.0 ``                                                          |
| [`aaf92e57`](https://github.com/NixOS/nixpkgs/commit/aaf92e571229c204ad873bd3ab2a7b84da3599ff) | `` python313Packages.pynmeagps: 1.0.46 -> 1.0.48 ``                                     |
| [`3eac5d4f`](https://github.com/NixOS/nixpkgs/commit/3eac5d4f480634a464309975d8250cbfa7de177d) | `` python313Packages.mypy-boto3-builder: 8.9.2 -> 8.10.1 ``                             |
| [`8a73fafc`](https://github.com/NixOS/nixpkgs/commit/8a73fafca5841e02ada1793e89cc41b95eda3874) | `` python313Packages.pychromecast: 14.0.6 -> 14.0.7 ``                                  |
| [`dfd82bf3`](https://github.com/NixOS/nixpkgs/commit/dfd82bf3e5b6893798389c333d35fa28b9ad6e24) | `` nixos/strfry: init ``                                                                |
| [`e6b51c91`](https://github.com/NixOS/nixpkgs/commit/e6b51c9110dbfff2d43aa5c8dd9be0a4ba5985ff) | `` strfry: init at 1.0.4 ``                                                             |
| [`c13f4fa8`](https://github.com/NixOS/nixpkgs/commit/c13f4fa827c57c4ec333527eb16e01a459c5a7fe) | `` python313Packages.mcpadapt: 0.0.18 -> 0.0.19 ``                                      |
| [`82b16da5`](https://github.com/NixOS/nixpkgs/commit/82b16da55d72874d252ea5b831e0ddc2ad789377) | `` vimPlugins.vim-fold-cycle: init at 2020-05-11 ``                                     |
| [`61bffce5`](https://github.com/NixOS/nixpkgs/commit/61bffce5dc37af57bf257b7e78d398b960cbbc41) | `` python313Packages.pyfronius: 0.7.7 -> 0.8.0 ``                                       |
| [`bd7ead7f`](https://github.com/NixOS/nixpkgs/commit/bd7ead7fc3ebe794f8261889adc7924d6d26ec40) | `` python313Packages.dirigera: 1.2.2 -> 1.2.3 ``                                        |
| [`0867a9b9`](https://github.com/NixOS/nixpkgs/commit/0867a9b91d7b24132d34810c8e8549a850928ee9) | `` python313Packages.django-allauth: 65.5.0 -> 65.6.0 ``                                |
| [`99c209dc`](https://github.com/NixOS/nixpkgs/commit/99c209dc5cd008d59649a9830247bf8475ea9bd2) | `` python313Packages.django-admin-sortable2: 2.2.4 -> 2.2.6 ``                          |
| [`181ba57e`](https://github.com/NixOS/nixpkgs/commit/181ba57e9bc800523b2ac77ace534028242c4ebd) | `` python313Packages.django-storages: 1.14.4 -> 1.14.5 ``                               |
| [`54be451a`](https://github.com/NixOS/nixpkgs/commit/54be451a0f3ce4905b2614ed37ad6cac92af3a96) | `` python313Packages.apprise: 1.9.2 -> 1.9.3 ``                                         |
| [`8c94060d`](https://github.com/NixOS/nixpkgs/commit/8c94060dc76a82d39619ec99113ecc188eafa70c) | `` python313Packages.aiomqtt: 2.3.0 -> 2.3.1 ``                                         |
| [`5ff5fbd0`](https://github.com/NixOS/nixpkgs/commit/5ff5fbd0e8c2428b63d4230453cc723dacdd6c66) | `` vimPlugins.vim-foldsearch: init at 2024-05-15 ``                                     |
| [`fffb97ba`](https://github.com/NixOS/nixpkgs/commit/fffb97ba1166333536c558f0e781dfb12ead5d5b) | `` python313Packages.evohome-async: 1.0.4 -> 1.0.5 ``                                   |
| [`38c30057`](https://github.com/NixOS/nixpkgs/commit/38c300576d8f0f30bf6eba0756d320665cb8c38a) | `` cnspec: 11.47.1 -> 11.48.0 ``                                                        |
| [`bb742fb4`](https://github.com/NixOS/nixpkgs/commit/bb742fb49ba7cdb0b732c6370119d22100e5a7a9) | `` python313Packages.tencentcloud-sdk-python: 3.0.1351 -> 3.0.1352 ``                   |
| [`7704c34c`](https://github.com/NixOS/nixpkgs/commit/7704c34c04d9b2f9f9f3094926d6e0adadf2ab59) | `` cargo-codspeed: 2.9.1 -> 2.10.0 ``                                                   |
| [`1586a89d`](https://github.com/NixOS/nixpkgs/commit/1586a89d9ee3019b233a4d73014c96da8d8d498c) | `` chromium,chromedriver: 134.0.6998.165 -> 135.0.7049.52 ``                            |
| [`dff8e834`](https://github.com/NixOS/nixpkgs/commit/dff8e834a006b9e8c976971e67a3248b399f4cc6) | `` googler: drop ``                                                                     |
| [`5179f462`](https://github.com/NixOS/nixpkgs/commit/5179f4621cb4dea41797ff39e9ee6d4cebe9b9d2) | `` nixosTests.buildbot: migrate to runTest ``                                           |
| [`0e553a83`](https://github.com/NixOS/nixpkgs/commit/0e553a831e4c154d623c3b4b862d0daf6215ec8e) | `` build(deps): bump cachix/install-nix-action from {30,31} to 31.1.0 (#394893) ``      |
| [`25264d10`](https://github.com/NixOS/nixpkgs/commit/25264d105d4a34a8807141cc8587871b12dfe32b) | `` nixos/docling-serve: init ``                                                         |
| [`426ef3f9`](https://github.com/NixOS/nixpkgs/commit/426ef3f9d60bd82d952d0e7014f184df152707b0) | `` docling-serve: init at 0.7.0 ``                                                      |
| [`96d9ab06`](https://github.com/NixOS/nixpkgs/commit/96d9ab064ed55129d568955c5fec8a676415d6b8) | `` python312Packages.docling: disable one test ``                                       |
| [`2e5115f7`](https://github.com/NixOS/nixpkgs/commit/2e5115f7948bd1f0a0fa994da6c0c88a96823d1c) | `` python312Packages.docling: cleanup dependencies ``                                   |
| [`fab4accc`](https://github.com/NixOS/nixpkgs/commit/fab4acccedbca68694602e12b50a475f3b3ccd0a) | `` nixosTests.binary-cache{no-compression,xz}: migrate to runTest ``                    |
| [`77cb9637`](https://github.com/NixOS/nixpkgs/commit/77cb9637765e177eb34202f2491784e1cfe6a425) | `` kubernetes-controller-tools: 0.17.2 -> 0.17.3 ``                                     |
| [`1ddc0a9c`](https://github.com/NixOS/nixpkgs/commit/1ddc0a9c8147fd9a2073e647493ac92a1ef27a51) | `` kbld: 0.45.0 -> 0.45.1 ``                                                            |
| [`fe5391e1`](https://github.com/NixOS/nixpkgs/commit/fe5391e180cd8ed9c03c9325ddfc00fdd7895695) | `` nixosTests.bcachefs: migrate to runTest ``                                           |
| [`baecb706`](https://github.com/NixOS/nixpkgs/commit/baecb706a125c32f0bf527ee95035218571484d7) | `` prometheus-node-exporter: 1.9.0 -> 1.9.1 ``                                          |
| [`1c3507db`](https://github.com/NixOS/nixpkgs/commit/1c3507db7e102141e271ae2b98e05ca83915123d) | `` uiua-unstable: 0.15.0-rc.1 -> 0.15.0-rc.2 ``                                         |
| [`ec798cb3`](https://github.com/NixOS/nixpkgs/commit/ec798cb3b130e7ab2385258f34cc8b9ab0fca6d3) | `` wasm-tools: 1.227.1 -> 1.228.0 ``                                                    |
| [`55516075`](https://github.com/NixOS/nixpkgs/commit/55516075b4b534f1d50d843171542735919d7698) | `` code-cursor: 0.47.8 -> 0.48.6 ``                                                     |
| [`49cf5474`](https://github.com/NixOS/nixpkgs/commit/49cf547427c17515d4b2c7a669ffdbe123d7eac8) | `` git-blame-ignore-revs: Add previous commit ``                                        |
| [`374e6bcc`](https://github.com/NixOS/nixpkgs/commit/374e6bcc403e02a35e07b650463c01a52b13a7c8) | `` treewide: Format all Nix files ``                                                    |
| [`2140bf39`](https://github.com/NixOS/nixpkgs/commit/2140bf39e41767f25a395d20fb0d5698b8934b33) | `` CONTRIBUTING: Improve and update formatting docs ``                                  |
| [`927521a6`](https://github.com/NixOS/nixpkgs/commit/927521a6ace142da9f96ec7e87035a604fba818e) | `` workflows/check-nix-format: Enforce formatting on all files ``                       |