### PR TITLE
chore(flake/treefmt-nix): `18bed671` -> `57dabe2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743589519,
-        "narHash": "sha256-iBzr7Zb11nQxwX90bO1+Bm1MGlhMSmu4ixgnQFB+j4E=",
+        "lastModified": 1743677901,
+        "narHash": "sha256-eWZln+k+L/VHO69tUTzEmgeDWNQNKIpSUa9nqQgBrSE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "18bed671738e36c5504e188aadc18b7e2a6e408f",
+        "rev": "57dabe2a6255bd6165b2437ff6c2d1f6ee78421a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                   |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`0a499a6d`](https://github.com/numtide/treefmt-nix/commit/0a499a6de83844a65d7a75e24969b2487ac0badc) | `` Update programs/sql-formatter.nix ``   |
| [`e089e068`](https://github.com/numtide/treefmt-nix/commit/e089e068237edbe4f7c62e5aca4a649afed0ce1d) | `` sql-formatter: fix multi file input `` |