### PR TITLE
chore(flake/nixvim): `7b431133` -> `99a2f96c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1743844372,
-        "narHash": "sha256-59T+ikFiTt0CiSvuja3/xYahT6SL2s3XtNykfG8l0gk=",
+        "lastModified": 1743964204,
+        "narHash": "sha256-DFktXTeZWVM4kEET+GQHhI0XlrUG0HUAi+hZ7C/MEp0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7b4311333b542178828e90f6997d8f03e8327b89",
+        "rev": "99a2f96cf0f54034201b40d878aa9bb21b72cdf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`99a2f96c`](https://github.com/nix-community/nixvim/commit/99a2f96cf0f54034201b40d878aa9bb21b72cdf2) | `` plugins/telescope/advanced-git-search: init ``                 |
| [`757e02a1`](https://github.com/nix-community/nixvim/commit/757e02a183426f3dd29afb7cd38e09d12270b9b1) | `` plugins/tinygit: init ``                                       |
| [`f464541b`](https://github.com/nix-community/nixvim/commit/f464541b18e90746474724c675361c69a768291d) | `` plugins/hurl: init ``                                          |
| [`eb719d80`](https://github.com/nix-community/nixvim/commit/eb719d80a87a5c6a362b81d37423065aedc1d9e6) | `` colorschemes/github-theme: init ``                             |
| [`50e9895c`](https://github.com/nix-community/nixvim/commit/50e9895c2c93d98e09cceaa7ea568ce90de5dc7c) | `` plugins/copilot-vim: bump node.js to 20.x version ``           |
| [`90c3f246`](https://github.com/nix-community/nixvim/commit/90c3f2468e6719dd096e5c55134eb3c24b0b9ccd) | `` plugins/colorful-menu: init ``                                 |
| [`380435c5`](https://github.com/nix-community/nixvim/commit/380435c555ced04c9aca51f3d37f81b8fabed6e0) | `` plugins/telescope/zoxide: init ``                              |
| [`5908b5a7`](https://github.com/nix-community/nixvim/commit/5908b5a7377348047aa77e2a432323f7b8f65073) | `` plugins/lsp: register pkgs.vectorcode for vectorcode_server `` |
| [`2a7ee288`](https://github.com/nix-community/nixvim/commit/2a7ee288955211666e7de1fb4f4ee407ae2acf1e) | `` flake/dev/flake.lock: Update ``                                |
| [`a78b1492`](https://github.com/nix-community/nixvim/commit/a78b14920b4030d5ba2b66bd8e51a156f643f56e) | `` flake.lock: Update ``                                          |