### PR TITLE
chore(flake/nixvim): `99a2f96c` -> `cc891866`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1743964204,
-        "narHash": "sha256-DFktXTeZWVM4kEET+GQHhI0XlrUG0HUAi+hZ7C/MEp0=",
+        "lastModified": 1744028177,
+        "narHash": "sha256-etbUDe2Httgl6oI14M1nTV39+478dJ0UyLJKx/DtZi8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "99a2f96cf0f54034201b40d878aa9bb21b72cdf2",
+        "rev": "cc8918663a711a10cd45650e7bb4c933c5ec4ad7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`cc891866`](https://github.com/nix-community/nixvim/commit/cc8918663a711a10cd45650e7bb4c933c5ec4ad7) | `` generated: Updated lspconfig-servers.json ``   |
| [`114d02c3`](https://github.com/nix-community/nixvim/commit/114d02c332ebab41cd5810f1a609775166d6d481) | `` flake/dev/flake.lock: Update ``                |
| [`f2f75c6a`](https://github.com/nix-community/nixvim/commit/f2f75c6ae451fcc244585e9bde29763eddad39d8) | `` flake.lock: Update ``                          |
| [`797c075d`](https://github.com/nix-community/nixvim/commit/797c075db2c2b112ae12e098f9bc12913a64ecf3) | `` readme: fix & simplify simple flake example `` |