### PR TITLE
chore(flake/nixvim): `cc891866` -> `7114362f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1744028177,
-        "narHash": "sha256-etbUDe2Httgl6oI14M1nTV39+478dJ0UyLJKx/DtZi8=",
+        "lastModified": 1744119992,
+        "narHash": "sha256-XtwL/QfMjJtqO//mAjEfiC7noaAtH/gtQttcBE8dufs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "cc8918663a711a10cd45650e7bb4c933c5ec4ad7",
+        "rev": "7114362f36123a8401f4905c2e833fd9a0c2ddd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                              |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`7114362f`](https://github.com/nix-community/nixvim/commit/7114362f36123a8401f4905c2e833fd9a0c2ddd1) | `` plugins/nvim-jdtls: rename to jdtls, migrate to mkNeovimPlugin `` |
| [`d67fcbd1`](https://github.com/nix-community/nixvim/commit/d67fcbd1d3622a65bbce777624b460ab9e5f1160) | `` flake/dev/flake.lock: Update ``                                   |
| [`9d607625`](https://github.com/nix-community/nixvim/commit/9d607625a15aa7b015fa7f08518e9771448256f7) | `` flake.lock: Update ``                                             |