### PR TITLE
chore(flake/nixvim): `7114362f` -> `51203927`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1744119992,
-        "narHash": "sha256-XtwL/QfMjJtqO//mAjEfiC7noaAtH/gtQttcBE8dufs=",
+        "lastModified": 1744200902,
+        "narHash": "sha256-BqTLjxT1C1XfREDBQSxPrfKI9DBpZHBVLHzfXZs+h8M=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7114362f36123a8401f4905c2e833fd9a0c2ddd1",
+        "rev": "51203927e395535c4a427295efed4e1b2ef8349b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`51203927`](https://github.com/nix-community/nixvim/commit/51203927e395535c4a427295efed4e1b2ef8349b) | `` flake/dev/flake.lock: Update `` |
| [`a6faaf12`](https://github.com/nix-community/nixvim/commit/a6faaf12ec59fd5c6b2a96ff7cb663f7512e4ced) | `` flake.lock: Update ``           |