### PR TITLE
chore(flake/nixvim): `60638182` -> `78f6ff03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1745324162,
-        "narHash": "sha256-Sjb/LvtWpPtSXacjJCTrLAmWtXNJd0SWxO3PzTvD7Tc=",
+        "lastModified": 1745415369,
+        "narHash": "sha256-XcbDjFXADOGDRXq9da4gvlKBLuMdDQ32ZSem5kf9MmE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "60638182b8d1b0fe13631d02eafaf8903499ee60",
+        "rev": "78f6ff036918dcb6369f8b48abcef6a8788096e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`78f6ff03`](https://github.com/nix-community/nixvim/commit/78f6ff036918dcb6369f8b48abcef6a8788096e8) | `` plugins/lsp: use vim.lsp native API ``                                        |
| [`954e5264`](https://github.com/nix-community/nixvim/commit/954e526448afa94caf2c3020e6932f74ce6b5e14) | `` flake/dev/flake.lock: Update ``                                               |
| [`e91333ae`](https://github.com/nix-community/nixvim/commit/e91333ae56b6ca1d206997cad9be9fe439bfa112) | `` plugins/lsp: remove string support for plugins.lsp.enabledServers elements `` |