### PR TITLE
chore(flake/nixvim): `78f6ff03` -> `d86fe3df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1745415369,
-        "narHash": "sha256-XcbDjFXADOGDRXq9da4gvlKBLuMdDQ32ZSem5kf9MmE=",
+        "lastModified": 1745538632,
+        "narHash": "sha256-f2BzxQNoMF+wb+7b5O5p3fQ5r7I9u0ezzGBq2f38kl8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "78f6ff036918dcb6369f8b48abcef6a8788096e8",
+        "rev": "d86fe3df569c748b2632cfa5d27da0ea59709212",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`d86fe3df`](https://github.com/nix-community/nixvim/commit/d86fe3df569c748b2632cfa5d27da0ea59709212) | `` modules/diagnostics: fix `virtual_lines` example ``             |
| [`e6e53695`](https://github.com/nix-community/nixvim/commit/e6e536953580a956c143fc4413e8d9b4c876aeb8) | `` lib/utils: fix `literalLua` multiline rendering ``              |
| [`62ecd39b`](https://github.com/nix-community/nixvim/commit/62ecd39b40bf8a61fa428d026bb7061e1350f456) | `` flake/dev/flake.lock: Update ``                                 |
| [`b5617733`](https://github.com/nix-community/nixvim/commit/b56177333d42d42563bf8faf7605a59a7e35a448) | `` plugins/lsp: mark ruff_lsp as unpackaged ``                     |
| [`3c37b39a`](https://github.com/nix-community/nixvim/commit/3c37b39a7bbca30eb5a482954bdab28b4466ff56) | `` plugins/lsp: add package for just-lsp ``                        |
| [`991f3c87`](https://github.com/nix-community/nixvim/commit/991f3c8709a79bcd0e54fac6f745d14f88d503bf) | `` treewide: re-enable godot tests ``                              |
| [`57b21234`](https://github.com/nix-community/nixvim/commit/57b21234cee0237b4e98ecb4810777796ab615b9) | `` flake/dev/flake.lock: Update ``                                 |
| [`157bcae6`](https://github.com/nix-community/nixvim/commit/157bcae64a431802c41d71483583ab9340de79de) | `` flake.lock: Update ``                                           |
| [`f4246897`](https://github.com/nix-community/nixvim/commit/f42468972cc3ec4048efd49c96e363ba81145bb9) | `` Fix typo: nix lists are space separated, not comma separated `` |