### PR TITLE
chore(flake/nixvim): `b72ba2e4` -> `8d8a8568`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1745593478,
-        "narHash": "sha256-GV0YnG6ZLW+BDsEKS2rjTtKcfTcTbdlVaf0ESQDBsK8=",
+        "lastModified": 1745697134,
+        "narHash": "sha256-WvozW6IXhuRfGlDy7S777S5fjZeGSOEIRRbo2eK6K5o=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b72ba2e4e2af53269a19b99bf684480f3ad4a78f",
+        "rev": "8d8a8568968f0e77b90749929c4683633d1ebdf6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`8d8a8568`](https://github.com/nix-community/nixvim/commit/8d8a8568968f0e77b90749929c4683633d1ebdf6) | `` plugins/lsp: remove unused internal enabledServers.*.capabilities option `` |
| [`6c733505`](https://github.com/nix-community/nixvim/commit/6c733505577c84ef4a7c6659a7118da874f144dd) | `` modules/diagnostic: rename `diagnostics` -> `diagnostic.config` ``          |
| [`c3a42a7a`](https://github.com/nix-community/nixvim/commit/c3a42a7ac454bbb61af6b2198fc27dd1976f281e) | `` plugins/lsp: remove `standalonePlugins` default ``                          |
| [`47f44488`](https://github.com/nix-community/nixvim/commit/47f44488aeb295622cdac273d4449be08fbee1d7) | `` modules/performance: document `pathsToLink` default ``                      |
| [`6418cf34`](https://github.com/nix-community/nixvim/commit/6418cf34146487764e1a43571fba7640fb123d98) | `` modules/performance: update runtimepath `pathsToLink` ``                    |
| [`f0ec7738`](https://github.com/nix-community/nixvim/commit/f0ec77386968faf46b9ac15ca2172476fd8dd043) | `` plugins/lsp: simplify implementation of per-server capabilities ``          |
| [`2e559d3c`](https://github.com/nix-community/nixvim/commit/2e559d3c3a337b2405e607ffc86067c05f6150fc) | `` plugins/lsp: simplify implementation of inlayHints ``                       |