### PR TITLE
chore(flake/nixvim): `8d8a8568` -> `89c94d9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1745697134,
-        "narHash": "sha256-WvozW6IXhuRfGlDy7S777S5fjZeGSOEIRRbo2eK6K5o=",
+        "lastModified": 1745746098,
+        "narHash": "sha256-3f6vvpa2/8XmzTaJjhUYtedlNMHIjwXJ6C2oWXBTubk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8d8a8568968f0e77b90749929c4683633d1ebdf6",
+        "rev": "89c94d9ea72d7080838981295f9b526eb3a960de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`89c94d9e`](https://github.com/nix-community/nixvim/commit/89c94d9ea72d7080838981295f9b526eb3a960de) | `` plugins/telescope/media-files: use the top-level dependencies option `` |
| [`0a301a42`](https://github.com/nix-community/nixvim/commit/0a301a428a690873733c9670f3de065e1544a6d3) | `` plugins/telescope/media-files: remove old rename warnings ``            |