### PR TITLE
chore(flake/treefmt-nix): `b2b6c027` -> `763f1ce0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745780832,
-        "narHash": "sha256-jGzkZoJWx+nJnPe0Z2xQBUOqMKuR1slVFQrMjFTKgeM=",
+        "lastModified": 1745848521,
+        "narHash": "sha256-gNrTO3pEjmu3WiuYrUHJrTGCFw9v+qZXCFmX/Vjf5WI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "b2b6c027d708fbf4b01c9c11f6e80f2800b5a624",
+        "rev": "763f1ce0dd12fe44ce6a5c6ea3f159d438571874",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                     |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`763f1ce0`](https://github.com/numtide/treefmt-nix/commit/763f1ce0dd12fe44ce6a5c6ea3f159d438571874) | `` programs.dprint: update plugins example (#341) (#327) `` |
| [`d1863f30`](https://github.com/numtide/treefmt-nix/commit/d1863f30d9ca67f679f9c2583d7adf674b5d9b8a) | `` programs.dprint: update plugins example (#341) ``        |
| [`18966808`](https://github.com/numtide/treefmt-nix/commit/189668081607c1abc3af0f10058ae98f0b4eec59) | `` rustfmt: bump edition (#342) ``                          |
| [`fbdcbaa6`](https://github.com/numtide/treefmt-nix/commit/fbdcbaa61875bc98c4156bd01788b53ab690914f) | `` Supress verbose git stuff (#347) ``                      |
| [`746c838a`](https://github.com/numtide/treefmt-nix/commit/746c838afbe0840fdca05d7bf806e74a030803d9) | `` update examples ``                                       |
| [`0769377e`](https://github.com/numtide/treefmt-nix/commit/0769377ee19721d0770ec21073de738b03eb3005) | `` php-cs-fixer: pin to PHP 8.3 ``                          |
| [`ab08744c`](https://github.com/numtide/treefmt-nix/commit/ab08744c2622abe46646d41d4c415c4882c8c0b8) | `` feat: update nixpkgs input ``                            |