### PR TITLE
chore(flake/nixpkgs): `f771eb40` -> `46e634be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745526057,
-        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
+        "lastModified": 1745930157,
+        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
+        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`b60b21e1`](https://github.com/NixOS/nixpkgs/commit/b60b21e10481d4738370657c3ecd5e57adc8ca4e) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.4.0 -> 4.4.3 ``  |
| [`dca1ee3b`](https://github.com/NixOS/nixpkgs/commit/dca1ee3b1c3f5fbefeb2a96a1d8b3441cd17a347) | `` tail-tray: 0.2.20 -> 0.2.21 ``                                                   |
| [`160b7ac3`](https://github.com/NixOS/nixpkgs/commit/160b7ac3672041cc61043396ce5cfede68978967) | `` esphome: 2025.4.0 -> 2025.4.1 ``                                                 |
| [`7886dc03`](https://github.com/NixOS/nixpkgs/commit/7886dc03bed13f0378d1c8750d81c2b1cade13a5) | `` olive-editor: fix eval ``                                                        |
| [`2f262a49`](https://github.com/NixOS/nixpkgs/commit/2f262a491a9deb14fc921f51d833263e07290586) | `` chatmcp: 0.0.26-alpha -> 0.0.28-alpha ``                                         |
| [`42a94cfd`](https://github.com/NixOS/nixpkgs/commit/42a94cfd8900666ea623da04158cd08c8e57b710) | `` thrift-ls: 0.2.5 -> 0.2.7 ``                                                     |
| [`ac30d44b`](https://github.com/NixOS/nixpkgs/commit/ac30d44b2c7862b9c3be73d5bc6f60801741a18d) | `` karma-runner: 6.4.2 -> 6.4.4 ``                                                  |
| [`b6b69301`](https://github.com/NixOS/nixpkgs/commit/b6b6930180ad4bb113fa6b965ec22fae52e3ed9a) | `` oelint-adv: 6.7.1 -> 7.2.6 ``                                                    |
| [`36c0c11c`](https://github.com/NixOS/nixpkgs/commit/36c0c11c6ebce89e6d7d83ff0c569a613ab4a05f) | `` python312Packages.oelint-data: init at 1.0.10 ``                                 |
| [`d9867702`](https://github.com/NixOS/nixpkgs/commit/d98677027dc02b6b1794a97887e8f118d3339686) | `` python312Packages.anytree: 2.12.1 -> 2.13.0 ``                                   |
| [`a834a94e`](https://github.com/NixOS/nixpkgs/commit/a834a94ea79e7109051e100ec024286677fbad66) | `` python312Packages.test2ref: init at 0.8.2 ``                                     |
| [`1fc23387`](https://github.com/NixOS/nixpkgs/commit/1fc23387aa9e373747d7e7b4cfe0c8b39f516778) | `` animeko: 4.9.0 -> 4.9.1 ``                                                       |
| [`8e50a8dc`](https://github.com/NixOS/nixpkgs/commit/8e50a8dc02b937201dcb0c780d2c500fb3f541e8) | `` python312Packages.correctionlib: 2.6.4 -> 2.7.0 ``                               |
| [`650017cd`](https://github.com/NixOS/nixpkgs/commit/650017cd982414f652b380e4e5b9da0d0a2061e6) | `` hyperhdr: add eymeric as maintainer ``                                           |
| [`6b6a7302`](https://github.com/NixOS/nixpkgs/commit/6b6a730201a7b5bc072b9dfb132a38c0296fc6fd) | `` hyperhdr: Fix dlopen path for alsa-lib ``                                        |
| [`b3c1e31e`](https://github.com/NixOS/nixpkgs/commit/b3c1e31e2491b6508efaa2a53ab23504511052d2) | `` hyperhdr: unvendoring ``                                                         |
| [`80710101`](https://github.com/NixOS/nixpkgs/commit/807101012dba68d5318c3fa6bcc20365e143eaa7) | `` python312Packages.langgraph-checkpoint: 2.0.24 -> 2.0.25 ``                      |
| [`a677d5c8`](https://github.com/NixOS/nixpkgs/commit/a677d5c8c3adfffcb46fe4b88b313986d527177b) | `` python312Packages.types-s3transfer: 0.11.5 -> 0.12.0 ``                          |
| [`67ef8994`](https://github.com/NixOS/nixpkgs/commit/67ef8994e516fce09d0f7c82409e23c38c5366dd) | `` devcontainer: 0.75.0 -> 0.76.0 ``                                                |
| [`e3ec9b29`](https://github.com/NixOS/nixpkgs/commit/e3ec9b29dfa0f41daccf9d87194dbe2d6a528275) | `` warp-terminal: set meta.position to fix maintainers pings ``                     |
| [`7a18dba2`](https://github.com/NixOS/nixpkgs/commit/7a18dba247be8be2572bf8e223885cf36616afa7) | `` warp-terminal: 0.2025.04.16.08.11.stable_02 -> 0.2025.04.23.08.11.stable_01 ``   |
| [`4182d185`](https://github.com/NixOS/nixpkgs/commit/4182d18564de8b565efcac78656fd8a007420bae) | `` ocamlPackages.dune-release: 2.0.0 → 2.1.0 ``                                     |
| [`c6c49d2e`](https://github.com/NixOS/nixpkgs/commit/c6c49d2ed2b46775da39a556fd5dbfee5e99ed1e) | `` cudaPackages.nccl-tests: 2.14.1 -> 2.15.0 ``                                     |
| [`ba9ab12d`](https://github.com/NixOS/nixpkgs/commit/ba9ab12dc2c37ee6c1814b0150087230f2e0962a) | `` nixos/lk-jwt-service:  add test ``                                               |
| [`c8f4df34`](https://github.com/NixOS/nixpkgs/commit/c8f4df349c07e9e0737b1bddd0715ebfe192de1e) | `` livekit: add test ``                                                             |
| [`f06ca886`](https://github.com/NixOS/nixpkgs/commit/f06ca8867699bf94da904d7f579050e7c5395b80) | `` temurin-{,jre-}bin-24: init at 24.0.0 ``                                         |
| [`d984889f`](https://github.com/NixOS/nixpkgs/commit/d984889fa9b23fc329790a0f06870a2c418b5edd) | `` grafana-alloy: 1.8.1 -> 1.8.2 ``                                                 |
| [`216e5eee`](https://github.com/NixOS/nixpkgs/commit/216e5eeec726c2dae575cb2beeee87a7a26472b9) | `` basedpyright: 1.29.0 -> 1.29.1 ``                                                |
| [`6945b080`](https://github.com/NixOS/nixpkgs/commit/6945b08041b2d56b18d97c29bca441a816331be4) | `` charmcraft: 3.4.4 -> 3.4.5 ``                                                    |
| [`5803bdb9`](https://github.com/NixOS/nixpkgs/commit/5803bdb9fcacad00890d87f33f4e983d53c29628) | `` Revert "Use mkImageMediaOverride for filesystem attributes of various images" `` |
| [`165d26be`](https://github.com/NixOS/nixpkgs/commit/165d26be7078b29f482ffacd0001026e39c4bbb9) | `` mieru: 3.14.0 -> 3.14.1 ``                                                       |
| [`68f5c2fd`](https://github.com/NixOS/nixpkgs/commit/68f5c2fd841c28ed353580f9c387e0c2a63ce944) | `` gat: 0.22.0 -> 0.23.0 ``                                                         |
| [`f76ab273`](https://github.com/NixOS/nixpkgs/commit/f76ab273147bde6dd3ebea398f9317187e38c077) | `` ripunzip: 2.0.1 -> 2.0.2 ``                                                      |
| [`c0c7eea7`](https://github.com/NixOS/nixpkgs/commit/c0c7eea70b2a954a81f0be5fbe333c6fbbeed1ec) | `` pretix: 2025.3.0 -> 2025.4.0 ``                                                  |
| [`c18a1a0d`](https://github.com/NixOS/nixpkgs/commit/c18a1a0d204d7ffa60ef0a9b9e3e3b5179bdea1b) | `` lms: 3.65.0 -> 3.66.0 ``                                                         |
| [`0d6cca15`](https://github.com/NixOS/nixpkgs/commit/0d6cca15d121ba8d1a08b3e51fe27fda3a443d4a) | `` iosevka-bin: 33.2.1 -> 33.2.2 ``                                                 |
| [`3b1ce662`](https://github.com/NixOS/nixpkgs/commit/3b1ce66257345adb324d5b24d225e73520157fb8) | `` python3Packages.openusd: 24.11 -> 25.02a ``                                      |
| [`76e2d006`](https://github.com/NixOS/nixpkgs/commit/76e2d0061493b2869d0a9facb27bc89fc98b5796) | `` python313Packages.django-otp: 1.5.4 -> 1.6.0 ``                                  |
| [`8deb5284`](https://github.com/NixOS/nixpkgs/commit/8deb5284980ebd04d828afa2f29824839189bd42) | `` python313Packages.djangorestframework: 3.15.2 -> 3.16.0 ``                       |
| [`1cd76fbd`](https://github.com/NixOS/nixpkgs/commit/1cd76fbdd194fd465ec2f77e96b8a237dc0ba5a6) | `` pxview: drop ``                                                                  |
| [`8fe68a9e`](https://github.com/NixOS/nixpkgs/commit/8fe68a9e8dfd5f9076404c0a550e1e8343caa68b) | `` neocomp: drop ``                                                                 |
| [`e7b96066`](https://github.com/NixOS/nixpkgs/commit/e7b96066b7f73e742c1d706a8dbffd90c0d019c9) | `` pxlib: drop ``                                                                   |
| [`a13bb64c`](https://github.com/NixOS/nixpkgs/commit/a13bb64c8bb4b8e7160c60700f09e53e54e943e8) | `` nextcloud-client: 3.16.3 -> 3.16.4 ``                                            |
| [`333589a3`](https://github.com/NixOS/nixpkgs/commit/333589a31c6fcf558deca7283575c8d73ff4f129) | `` python3Packages.streamz: disable flaky test ``                                   |
| [`c634aaa6`](https://github.com/NixOS/nixpkgs/commit/c634aaa6a8be9ce7fe610d94ff91bbe31f0fe93c) | `` windsurf: 1.7.0 -> 1.7.2 ``                                                      |
| [`0bece815`](https://github.com/NixOS/nixpkgs/commit/0bece8153e5251784d09f893272b0c3ebf509c91) | `` home-manager: 0-unstable-2025-04-19 -> 0-unstable-2025-04-28 ``                  |
| [`276196ba`](https://github.com/NixOS/nixpkgs/commit/276196ba4362079a6f90f420f9c6821163b2f5dc) | `` mujoco: 3.3.1 -> 3.3.2 ``                                                        |
| [`4983188f`](https://github.com/NixOS/nixpkgs/commit/4983188f6a4c0e2cc3e57889561e26c1a6911391) | `` vimPlugins.dial-nvim: Revert #402618 (no-op) ``                                  |
| [`2c8f3290`](https://github.com/NixOS/nixpkgs/commit/2c8f32904f62ac2a101963182a6673a4fa04dd47) | `` python3Packages.ingredient-parser-nlp: 2.0.0 -> 2.1.0 ``                         |
| [`21b2bad2`](https://github.com/NixOS/nixpkgs/commit/21b2bad2abcd3538704e8bd9e08da7ac0205cff6) | `` python312Packages.july: init at 0.1.3 ``                                         |
| [`b1d4067e`](https://github.com/NixOS/nixpkgs/commit/b1d4067e31679e7071c43c78aa367794f090ed20) | `` maple-font: 7.0 -> 7.1 ``                                                        |
| [`0a467340`](https://github.com/NixOS/nixpkgs/commit/0a467340f12bdb9a7cb9ef13c5ff6d2416627f9a) | `` python312Packages.qdrant-client: 1.13.0 -> 1.14.2 ``                             |
| [`bb1f166d`](https://github.com/NixOS/nixpkgs/commit/bb1f166d4892f28a7c2fa2c23591a48078b80d19) | `` treewide: remove gtk = gtk* ``                                                   |
| [`ddb70b51`](https://github.com/NixOS/nixpkgs/commit/ddb70b514617be39132839bf1baa5808647be77f) | `` python313Packages.pyexploitdb: 0.2.77 -> 0.2.78 ``                               |
| [`709543ee`](https://github.com/NixOS/nixpkgs/commit/709543eec11d307f281cc2c034c0ad97496aa9cd) | `` teams-for-linux: 2.0.8 -> 2.0.11 ``                                              |
| [`794bb1e8`](https://github.com/NixOS/nixpkgs/commit/794bb1e840d9dcbd35f6fbc68d67afa402d5b919) | `` python313Packages.garth: 0.5.6 -> 0.5.7 ``                                       |
| [`600e73cf`](https://github.com/NixOS/nixpkgs/commit/600e73cfaa40813de39e1a8296b32cb8c6b97747) | `` python313Packages.tencentcloud-sdk-python: 3.0.1364 -> 3.0.1366 ``               |
| [`8237bca4`](https://github.com/NixOS/nixpkgs/commit/8237bca46c80d58422fbbf7e6b5fd25103ee0093) | `` python313Packages.publicsuffixlist: 1.0.2.20250425 -> 1.0.2.20250428 ``          |
| [`8c9caaeb`](https://github.com/NixOS/nixpkgs/commit/8c9caaebaa1f85c4b229c2dd2ab975dad2c52240) | `` auth0-cli: 1.11.0 -> 1.12.0 ``                                                   |
| [`5c24cbdf`](https://github.com/NixOS/nixpkgs/commit/5c24cbdf6ab6a1a542563668e55c88b1e376b817) | `` hyperhdr: 20.0.0.0 -> 21.0.0.0 ``                                                |
| [`000c2b0a`](https://github.com/NixOS/nixpkgs/commit/000c2b0a9ec7229140351ba1a80ad1905246608b) | `` python313Packages.pontos: 25.3.3 -> 25.4.0 ``                                    |
| [`a0d5f6ed`](https://github.com/NixOS/nixpkgs/commit/a0d5f6eda73eadab1696a2ceaf677012bc81428d) | `` azurehound: 2.3.1 -> 2.4.0 ``                                                    |
| [`caab2a7b`](https://github.com/NixOS/nixpkgs/commit/caab2a7b4d09ae843c49e77a512faac84f39d79e) | `` python313Packages.opower: 0.11.1 -> 0.12.0 ``                                    |
| [`6a015aea`](https://github.com/NixOS/nixpkgs/commit/6a015aeac4b133cd4904688de2b323d0e3cbc1b4) | `` python3Packages.databricks-sdk: Disable slow tests ``                            |
| [`180b5f65`](https://github.com/NixOS/nixpkgs/commit/180b5f650c1921d46204a5c4f7212b1d2698fdcb) | `` python313Packages.faraday-plugins: 1.23.0 -> 1.24.0 ``                           |
| [`fbf5b6c4`](https://github.com/NixOS/nixpkgs/commit/fbf5b6c4f77e8dbd0ea7bc9c84bba36835f99a8d) | `` python313Packages.aiosmtplib: 4.0.0 -> 4.0.1 ``                                  |
| [`4aaffc35`](https://github.com/NixOS/nixpkgs/commit/4aaffc352d34ce502b00b998e0e93b2adc364f27) | `` ldeep: 1.0.84 -> 1.0.85 ``                                                       |
| [`c091d5b6`](https://github.com/NixOS/nixpkgs/commit/c091d5b671a924ce34a4ab89acd3244d3eea0782) | `` python313Packages.pyarrow-hotfix: 0.6 -> 0.7 ``                                  |
| [`29731c04`](https://github.com/NixOS/nixpkgs/commit/29731c04c6b6700cb2c154ea8122a640e0ed110f) | `` python313Packages.tailscale: 0.6.1 -> 0.6.2 ``                                   |
| [`0b5855f0`](https://github.com/NixOS/nixpkgs/commit/0b5855f03faa3ba4a2dda48dd4bb0cef7aba9feb) | `` python313Packages.sse-starlette: 2.2.1 -> 2.3.3 ``                               |
| [`51387b8d`](https://github.com/NixOS/nixpkgs/commit/51387b8d0ba635490dbaa4daf86e6250ebda243c) | `` mockgen: 0.5.1 -> 0.5.2 ``                                                       |
| [`af50b0bc`](https://github.com/NixOS/nixpkgs/commit/af50b0bc38a163da37f0ba3fa79892f2d1b8cbfb) | `` vimPlugins.dial-nvim: init at 2025-03-29 ``                                      |
| [`4bdfe1f5`](https://github.com/NixOS/nixpkgs/commit/4bdfe1f59e422f5806ac73e571e7635a8184b1d2) | `` python313Packages.boto3-stubs: 1.38.3 -> 1.38.4 ``                               |
| [`f0270994`](https://github.com/NixOS/nixpkgs/commit/f0270994606c3032b4015f08cbc8ea078f358d77) | `` python313Packages.botocore-stubs: 1.38.3 -> 1.38.4 ``                            |
| [`38b48f13`](https://github.com/NixOS/nixpkgs/commit/38b48f13ad2f28ebbbf9cbb590eb6f69aec75061) | `` python312Packages.mypy-boto3-imagebuilder: 1.38.1 -> 1.38.4 ``                   |
| [`637f6e15`](https://github.com/NixOS/nixpkgs/commit/637f6e154fa73ec6fff6f969ed274896b3023af8) | `` python312Packages.mypy-boto3-dynamodb: 1.38.2 -> 1.38.4 ``                       |
| [`a0dbd48f`](https://github.com/NixOS/nixpkgs/commit/a0dbd48f05ea0d6b405484e67951a550cd3557b3) | `` python312Packages.mypy-boto3-cloudfront: 1.38.0 -> 1.38.4 ``                     |
| [`e126f7ff`](https://github.com/NixOS/nixpkgs/commit/e126f7ff03403889a2853e4fb1e5eef1d48ab38d) | `` python312Packages.mypy-boto3-acm: 1.38.0 -> 1.38.4 ``                            |
| [`fdb6c240`](https://github.com/NixOS/nixpkgs/commit/fdb6c240562c5ad516253419cc6f26819705d3e0) | `` python312Packages.django-rq: 3.0 -> 3.0.1 (#402596) ``                           |
| [`fd85b6e1`](https://github.com/NixOS/nixpkgs/commit/fd85b6e1ea82633c14482e4f7983c8ad3eaad1dc) | `` nzbhydra2: 7.12.3 -> 7.13.0 ``                                                   |
| [`a9707a0e`](https://github.com/NixOS/nixpkgs/commit/a9707a0ee4d8fe13d99bf7b5db12ac236b38bb91) | `` kube-score: 1.19.0 -> 1.20.0 ``                                                  |
| [`de734f21`](https://github.com/NixOS/nixpkgs/commit/de734f218bb3a91051a7eecb5a296f8813c72098) | `` imgpkg: 0.45.0 -> 0.46.0 ``                                                      |
| [`ceb06d19`](https://github.com/NixOS/nixpkgs/commit/ceb06d19b1a9450bed0eb774d0b5b6728c721ec9) | `` opencl-clhpp: correct license to asl20 ``                                        |
| [`30953f5f`](https://github.com/NixOS/nixpkgs/commit/30953f5ff2763bc4464ec4ea6010614489e9dd17) | `` opencl-headers: add opencl-clhpp to passthru.tests ``                            |
| [`450c8a5f`](https://github.com/NixOS/nixpkgs/commit/450c8a5f1fd9d0d385d7a3e06c80c96961d29d03) | `` opencl-headers: adopt ``                                                         |
| [`051b1d26`](https://github.com/NixOS/nixpkgs/commit/051b1d262a049acd422e82f55152d59b958b1d70) | `` clpeak: 1.1.0 -> 1.1.4, refactor and adopt, update license to asl20 ``           |
| [`95f9b9ff`](https://github.com/NixOS/nixpkgs/commit/95f9b9ffc3ca2d1999dd4b3dff2ae54178a81860) | `` opencl-clhpp: add passthru.tests.pkg-config ``                                   |
| [`3bcb7247`](https://github.com/NixOS/nixpkgs/commit/3bcb7247bd1026fd2822595485d39581255774aa) | `` opencl-clhpp: build tests and examples ``                                        |
| [`761a8d73`](https://github.com/NixOS/nixpkgs/commit/761a8d73365010faf52e8664e80031fe26a3a42c) | `` opencl-clhpp: adopt ``                                                           |
| [`d57031f3`](https://github.com/NixOS/nixpkgs/commit/d57031f31b55771cadd380c6371bdae2d63d18e6) | `` opencl-clhpp: 2024.05.08 -> 2024.10.24 ``                                        |
| [`956f9425`](https://github.com/NixOS/nixpkgs/commit/956f94252a7fff048583c109e3fd4b7885f8fa9f) | `` oxidized: 0.30.1 -> 0.33.0 ``                                                    |
| [`a10d8c33`](https://github.com/NixOS/nixpkgs/commit/a10d8c3344d97f333f5d44834490ef19e1260b82) | `` python312Packages.pylance: 0.26.0 -> 0.26.1 ``                                   |
| [`acee5b0c`](https://github.com/NixOS/nixpkgs/commit/acee5b0c34384e82fb54818af010d06953219690) | `` checkov: 3.2.408 -> 3.2.411 ``                                                   |
| [`bd642032`](https://github.com/NixOS/nixpkgs/commit/bd64203235a5dd349f9301e2f91cc5f263a16a2e) | `` pinocchio: 3.5.0 -> 3.6.0 ``                                                     |
| [`33116c52`](https://github.com/NixOS/nixpkgs/commit/33116c527ebd2bb8a5fb0e3c55422bda08919aee) | `` cdncheck: 1.1.15 -> 1.1.16 ``                                                    |
| [`975b4f95`](https://github.com/NixOS/nixpkgs/commit/975b4f95413629ad3d12d233dafbbb5b13ed3fd5) | `` prometheus-nginx-exporter: 1.4.1 -> 1.4.2 ``                                     |
| [`fe488590`](https://github.com/NixOS/nixpkgs/commit/fe48859094e352ed0693fe360fd64f7ad33125e8) | `` piv-agent: 0.22.0 -> 0.23.0 ``                                                   |