### PR TITLE
chore(flake/nixvim): `f2e96b67` -> `0ec7ea3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1746054759,
-        "narHash": "sha256-U9ucHYT7K+NH/utYdtVdrnrNZoUinccL7bmnCRc9yjI=",
+        "lastModified": 1746138649,
+        "narHash": "sha256-mLtPx5Zb6b3iMmypaYsxzA8vjiI6DQObpbmGcn5QDjo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "f2e96b67a30859ae21fc626bd33cc74c4d95d356",
+        "rev": "0ec7ea3d6242de84c8a18b228b963064751cb56d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`0ec7ea3d`](https://github.com/nix-community/nixvim/commit/0ec7ea3d6242de84c8a18b228b963064751cb56d) | `` user-configs: add @LudovicDeMatteis's config ``     |
| [`c91753bb`](https://github.com/nix-community/nixvim/commit/c91753bbe57781e08226829b9e354facd50caf1b) | `` flake/dev/flake.lock: Update ``                     |
| [`6ae7753c`](https://github.com/nix-community/nixvim/commit/6ae7753cfd07848a8821e30de37257dc487a55d0) | `` flake.lock: Update ``                               |
| [`a072e3c3`](https://github.com/nix-community/nixvim/commit/a072e3c3a710ee2c76c971a29cca5ae700fc96da) | `` modules/lsp: enable `servers."*"` by default ``     |
| [`b6e2016b`](https://github.com/nix-community/nixvim/commit/b6e2016b7fa5dba2f7f62e71828fba5db505b4cf) | `` modules/lsp: check if server `settings` is empty `` |