### PR TITLE
chore(flake/nixvim): `4b276785` -> `c9781223`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1746221140,
-        "narHash": "sha256-lXFXddrfTY47kF3IGmUQHgJssvGnYY5T4luL+1UmCkc=",
+        "lastModified": 1746309817,
+        "narHash": "sha256-oqOpTyjdeY+LP+WiU9LxGdZ/bZ9YK7MNzNMDUw98kPM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4b27678512c4b8a3c16676fd6d5d885f2fb84cb3",
+        "rev": "c978122396a4208bf1965d346b7456e7256fe70c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`c9781223`](https://github.com/nix-community/nixvim/commit/c978122396a4208bf1965d346b7456e7256fe70c) | `` plugins/lf: use nestedLiteralLua in settingsExample ``        |
| [`8fcd7f1a`](https://github.com/nix-community/nixvim/commit/8fcd7f1a92a9e8b8c9be91d8bc52b15742abfb20) | `` plugins/lf: init ``                                           |
| [`552dec0e`](https://github.com/nix-community/nixvim/commit/552dec0e559a39d5d1c9b838a7b3c119ad08d768) | `` modules/lsp/keymaps: init ``                                  |
| [`90eb4e68`](https://github.com/nix-community/nixvim/commit/90eb4e681c7dcb1ca4a929705d4a721163300449) | `` modules/lsp/servers: move the `*` server to its own module `` |
| [`8b3107ad`](https://github.com/nix-community/nixvim/commit/8b3107ad6f520080135e06ab6c017bdd3952d210) | `` plugins/clangd-extensions: adapt to new lsp module ``         |
| [`3f180f35`](https://github.com/nix-community/nixvim/commit/3f180f35b8dd56af4a6bd9f86d6f809e482f831c) | `` flake/dev/flake.lock: Update ``                               |
| [`47a6ac42`](https://github.com/nix-community/nixvim/commit/47a6ac42d2cf9147b6ba2229d6e502c31001dfbd) | `` flake.lock: Update ``                                         |
| [`8523385b`](https://github.com/nix-community/nixvim/commit/8523385bd8046723e174e57d0730277c2078720b) | `` plugins/schemastore: adapt to new lsp module ``               |