### PR TITLE
chore(flake/nixvim): `c9781223` -> `7d18194a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1746309817,
-        "narHash": "sha256-oqOpTyjdeY+LP+WiU9LxGdZ/bZ9YK7MNzNMDUw98kPM=",
+        "lastModified": 1746387720,
+        "narHash": "sha256-x8k0DKiQYRNaf9Hg+di+WCKxb76zJVWSjKOlPiuc22o=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c978122396a4208bf1965d346b7456e7256fe70c",
+        "rev": "7d18194a22325f212e17eb876d9c00afcc434113",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`7d18194a`](https://github.com/nix-community/nixvim/commit/7d18194a22325f212e17eb876d9c00afcc434113) | `` colorschemes/kanagawa-paper: init `` |
| [`f7f2dd04`](https://github.com/nix-community/nixvim/commit/f7f2dd042f28d235f7bf16cb31dbaee8f35159ca) | `` flake/dev/flake.lock: Update ``      |
| [`f40d1268`](https://github.com/nix-community/nixvim/commit/f40d12684ab95b3db252320673be71700f8373ef) | `` flake.lock: Update ``                |