### PR TITLE
chore(flake/nixvim): `7d18194a` -> `64cd675e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1746387720,
-        "narHash": "sha256-x8k0DKiQYRNaf9Hg+di+WCKxb76zJVWSjKOlPiuc22o=",
+        "lastModified": 1746479605,
+        "narHash": "sha256-YZT1uhEuHx+BLCpy25g4fPxyyyRNx07iA+fVKLczr18=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7d18194a22325f212e17eb876d9c00afcc434113",
+        "rev": "64cd675ece86352c8540da765aef72eeba045cf5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`64cd675e`](https://github.com/nix-community/nixvim/commit/64cd675ece86352c8540da765aef72eeba045cf5) | `` Port lsp-format to use non-deprecated setup instructions ``                                 |
| [`4016854b`](https://github.com/nix-community/nixvim/commit/4016854bccf192d6a5d7fdd5860571dfa1ece55c) | `` flake/dev/flake.lock: Update ``                                                             |
| [`9cad0ea6`](https://github.com/nix-community/nixvim/commit/9cad0ea6948de0a90801e570b937ac82a710e5ac) | `` flake.lock: Update ``                                                                       |
| [`ce5d7080`](https://github.com/nix-community/nixvim/commit/ce5d708018e11865e5079514319429081e4e194b) | `` plugins/blink-copilot: Mention in the description that copilot-lua is enabled by default `` |