### PR TITLE
chore(flake/nixvim): `64cd675e` -> `c26f5c2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1746479605,
-        "narHash": "sha256-YZT1uhEuHx+BLCpy25g4fPxyyyRNx07iA+fVKLczr18=",
+        "lastModified": 1746536883,
+        "narHash": "sha256-EJax0aiJIVJlqF7QyAefZ9fi1HgGcm7U1rBkcm2Z3Ps=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "64cd675ece86352c8540da765aef72eeba045cf5",
+        "rev": "c26f5c2e31c1da895bf9289783ff8e2fe3637ca0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`c26f5c2e`](https://github.com/nix-community/nixvim/commit/c26f5c2e31c1da895bf9289783ff8e2fe3637ca0) | `` plugins/lsp-format: use `lsp.onAttach` instead of an autoCmd `` |
| [`a45b5f37`](https://github.com/nix-community/nixvim/commit/a45b5f372f510d8a97e4d325b7907453c66efd8e) | `` modules/lsp: add `onAttach` option ``                           |
| [`391e4fd0`](https://github.com/nix-community/nixvim/commit/391e4fd093eaa993089525da2648cc2b4ec380ce) | `` flake/dev/flake.lock: Update ``                                 |
| [`1d0e4a0b`](https://github.com/nix-community/nixvim/commit/1d0e4a0bb506a3fd38265a5961cf0b04bf010f23) | `` flake.lock: Update ``                                           |
| [`53084257`](https://github.com/nix-community/nixvim/commit/53084257189483605182aaf388696ace02f5d208) | `` modules/lsp/servers: move to dedicated file/dir ``              |