### PR TITLE
chore(flake/nixvim): `c26f5c2e` -> `6597afe2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1746536883,
-        "narHash": "sha256-EJax0aiJIVJlqF7QyAefZ9fi1HgGcm7U1rBkcm2Z3Ps=",
+        "lastModified": 1746650585,
+        "narHash": "sha256-9WZtcSn1/UkYK4UNXkcLCnVR7aIVI83VweqVlCf06OA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c26f5c2e31c1da895bf9289783ff8e2fe3637ca0",
+        "rev": "6597afe2097ba07fdf515a541a2a02a7e06768cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`6597afe2`](https://github.com/nix-community/nixvim/commit/6597afe2097ba07fdf515a541a2a02a7e06768cd) | `` tests/lsp: disable ols test because odin is broken ``  |
| [`60f9ddf3`](https://github.com/nix-community/nixvim/commit/60f9ddf36981e8e43e6eb071caba47193d2da010) | `` generated: Updated lspconfig-servers.json ``           |
| [`dfca942d`](https://github.com/nix-community/nixvim/commit/dfca942dbbb600bc18827502dcc7ed6bd716fea1) | `` flake/dev/flake.lock: Update ``                        |
| [`9b5e955b`](https://github.com/nix-community/nixvim/commit/9b5e955b51c3532a4b27945bec6ba3a3fc006240) | `` flake.lock: Update ``                                  |
| [`5c52e8f9`](https://github.com/nix-community/nixvim/commit/5c52e8f9e438b6850f2c7a6e4bf3f967a3a699fd) | `` plugins.lsp: alias `onAttach` to new `lsp.onAttach` `` |