### PR TITLE
chore(flake/nixvim): `6597afe2` -> `aa1ae69b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1746650585,
-        "narHash": "sha256-9WZtcSn1/UkYK4UNXkcLCnVR7aIVI83VweqVlCf06OA=",
+        "lastModified": 1746742749,
+        "narHash": "sha256-K65lPr8vr9vEvWK3Yqx9rL4eDN+eztXTT3ck6fdqAMQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6597afe2097ba07fdf515a541a2a02a7e06768cd",
+        "rev": "aa1ae69b573e64ce145672663471795daed2ec9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`aa1ae69b`](https://github.com/nix-community/nixvim/commit/aa1ae69b573e64ce145672663471795daed2ec9e) | `` plugins/oil-git-status: init ``                              |
| [`36d63a7c`](https://github.com/nix-community/nixvim/commit/36d63a7c3e0b28d0a2a798826a3b990867079b21) | `` flake/dev/flake.lock: Update ``                              |
| [`c1fa5ee9`](https://github.com/nix-community/nixvim/commit/c1fa5ee94211006cf1563d95782206eefbe15cb6) | `` plugins/dap-view: disable controls test ``                   |
| [`cca235aa`](https://github.com/nix-community/nixvim/commit/cca235aacff07c01383c481b31c1b5c5bf445bef) | `` plugins/dap-view: init module ``                             |
| [`324801b2`](https://github.com/nix-community/nixvim/commit/324801b226b7b4b353870ddb31ba3b8e2275b8ec) | `` plugins/whitespace: init module ``                           |
| [`1158bb13`](https://github.com/nix-community/nixvim/commit/1158bb13f2ea9ccedff2dffa8de164c42a723877) | `` plugins/visual-whitespace: init module ``                    |
| [`e656464d`](https://github.com/nix-community/nixvim/commit/e656464da48c56aded05c7bdc431e239ebf2f116) | `` flake-modules/new-plugin: add dry run argument ``            |
| [`d22e7878`](https://github.com/nix-community/nixvim/commit/d22e7878ec535b0a17c9124a48f919170a2bcc6a) | `` flake-modules/new-plugin: add maintainer argument ``         |
| [`0754cdc5`](https://github.com/nix-community/nixvim/commit/0754cdc51d54fe6c4442a2be331b7f93b9338f58) | `` flake-modules/new-plugin: sync with plugins/TEMPLATE.nix ``  |
| [`f7b3f648`](https://github.com/nix-community/nixvim/commit/f7b3f648470bf25ac7a578022ad2b5ef94331545) | `` flake-modules/new-plugin: refactor input normalization ``    |
| [`94298096`](https://github.com/nix-community/nixvim/commit/94298096e820987d1d2c2bf8dc8900b12072c4e8) | `` flake-modules/new-plugin: optionalize package name ``        |
| [`c3b04f76`](https://github.com/nix-community/nixvim/commit/c3b04f76ecca1694003338bc6e089189f18a3d5e) | `` flake-modules/new-plugin: tweak template ``                  |
| [`10f899d6`](https://github.com/nix-community/nixvim/commit/10f899d669659f0248b9c9768bd2fd06eaa8d3b1) | `` plugins/lsp: correct motivation for `onAttach` alias impl `` |
| [`5fed6b93`](https://github.com/nix-community/nixvim/commit/5fed6b9363b69913313c3b7ae0a84fa551177d03) | `` plugins/claude-code: don't test on darwin ``                 |
| [`52c68b4d`](https://github.com/nix-community/nixvim/commit/52c68b4da4e5e68745e2750a271ae4df06c04abe) | `` plugins/claude-code: add claude-code dependency ``           |
| [`b17c801f`](https://github.com/nix-community/nixvim/commit/b17c801f2eff7f60dad60f5f63deec3456cd6519) | `` plugins/claude-code: init module ``                          |