### PR TITLE
chore(flake/nixpkgs): `3730d8a3` -> `8fcc7145`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746461020,
-        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
+        "lastModified": 1746592047,
+        "narHash": "sha256-GYYT5Pc+sZZWomgC7EgDSNSfmXd9Jby9nXQ6bAswUCg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
+        "rev": "8fcc71459655f2486b3da197b8d6a62f595a33d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`b9f3ecd3`](https://github.com/NixOS/nixpkgs/commit/b9f3ecd3296748fb5bdf1bb2486780dcf1303987) | `` check-sieve: 0.10 -> 0.10-unstable-2025-05-06 ``                                  |
| [`5216b92e`](https://github.com/NixOS/nixpkgs/commit/5216b92e72f942e89c3b840fee018eeb10064f6a) | `` inputplumber: 0.56.0 -> 0.56.1 ``                                                 |
| [`c9ad2fa1`](https://github.com/NixOS/nixpkgs/commit/c9ad2fa1736d18df5260ba71566aa80a64c0b916) | `` bento: 1.6.0 -> 1.6.1 ``                                                          |
| [`3f15d9c4`](https://github.com/NixOS/nixpkgs/commit/3f15d9c4b46970204fe65f806ce0b4ca6d674247) | `` chromium,chromedriver: 136.0.7103.59 -> 136.0.7103.92 ``                          |
| [`2e0c3464`](https://github.com/NixOS/nixpkgs/commit/2e0c34649bc980a7ad392b57235f762b7ce06b2f) | `` maintainers/scripts/update.nix: Fix reverse toposort with independent packages `` |
| [`9260a0c7`](https://github.com/NixOS/nixpkgs/commit/9260a0c7b79614cfc882065fe9fe4c6b73e326f4) | `` pnpm-lock-export: drop ``                                                         |
| [`9133c5d1`](https://github.com/NixOS/nixpkgs/commit/9133c5d1e446c6cc365a7769a1a98756f822e21a) | `` generic-updater: Allow filtering tags ending with suffix ``                       |
| [`248324ed`](https://github.com/NixOS/nixpkgs/commit/248324edb1f311e96c381086e5ac992f72f87d85) | `` libretro-shaders-slang: 0-unstable-2025-04-22 -> 0-unstable-2025-05-04 ``         |
| [`1a0fd0f9`](https://github.com/NixOS/nixpkgs/commit/1a0fd0f90a2da0166d72eff86e12cc4b6c7d7d12) | `` python312Packages.angr: 9.2.152 -> 9.2.153 ``                                     |
| [`380ed59a`](https://github.com/NixOS/nixpkgs/commit/380ed59a37839e4752d52022b77f5a0a21837f3a) | `` python313Packages.cle: 9.2.152 -> 9.2.153 ``                                      |
| [`8baaf564`](https://github.com/NixOS/nixpkgs/commit/8baaf564b0ada8fc41f338e0c8076ef9d90d6b1b) | `` libretro.snes9x: 0-unstable-2025-04-06 -> 0-unstable-2025-05-03 ``                |
| [`e4ea6ad9`](https://github.com/NixOS/nixpkgs/commit/e4ea6ad9dfe4fc553a215338709675c98dac1d9c) | `` python3Packages.aiohomeconnect: 0.16.3 -> 0.17.0 ``                               |
| [`d3074997`](https://github.com/NixOS/nixpkgs/commit/d30749974155697a0e4bfd5141af0adef0127f84) | `` python313Packages.claripy: 9.2.152 -> 9.2.153 ``                                  |
| [`01ae0af3`](https://github.com/NixOS/nixpkgs/commit/01ae0af3a457e8f919cc47cbe2a1c78cd5d690a0) | `` python313Packages.pyvex: 9.2.152 -> 9.2.153 ``                                    |
| [`c0495c02`](https://github.com/NixOS/nixpkgs/commit/c0495c021bc9ac7da5a20698d35af7f80b25a97c) | `` python313Packages.ailment: 9.2.152 -> 9.2.153 ``                                  |
| [`f7fdd915`](https://github.com/NixOS/nixpkgs/commit/f7fdd9154439c1c83343b5e134623ed51356950b) | `` python313Packages.archinfo: 9.2.152 -> 9.2.153 ``                                 |
| [`3da0a8b9`](https://github.com/NixOS/nixpkgs/commit/3da0a8b95d19b3d5605ec1576dfbbb56e3422d07) | `` mud: 1.0.13 -> 1.0.14 ``                                                          |
| [`0d584f7c`](https://github.com/NixOS/nixpkgs/commit/0d584f7c8fe87a8ddd8ce013b8b19b47fc3834aa) | `` ci/compare: nix stats comparison ``                                               |
| [`20a0a814`](https://github.com/NixOS/nixpkgs/commit/20a0a814b3f1791b5221d47a7af320c6422207d4) | `` rerun: 0.23.1 -> 0.23.2 ``                                                        |
| [`10bbdadd`](https://github.com/NixOS/nixpkgs/commit/10bbdadd9c83c4ffef0caf21fb5a6cc45e35f338) | `` scalafmt: 3.9.4 -> 3.9.6 ``                                                       |
| [`d74522fe`](https://github.com/NixOS/nixpkgs/commit/d74522fef072c0155ca7ccf270c6ba888c302b99) | `` maintainer-list: run keep-sorted ``                                               |
| [`224de839`](https://github.com/NixOS/nixpkgs/commit/224de839f1473399e894f1d11fc2b98bb4a14a59) | `` workflows/check-maintainers-sorted: drop and replace with keep-sorted ``          |
| [`9c147c1b`](https://github.com/NixOS/nixpkgs/commit/9c147c1bfb0a631b07fef6d94d17af8cc826ff39) | `` cyberpunk-neon: 0-unstable-2025-04-17 -> 0-unstable-2025-05-05 ``                 |
| [`cfc0080d`](https://github.com/NixOS/nixpkgs/commit/cfc0080deeeb1d8b7bf8a5accd5354654796ac0c) | `` opencloud-desktop: init at 1.0.0 ``                                               |
| [`ced8683b`](https://github.com/NixOS/nixpkgs/commit/ced8683b7c27b9c62d36adeaf5fbb3e33517639a) | `` vimPlugins.luau-lsp-nvim: init at 2025-02-01 ``                                   |
| [`fad2fb4c`](https://github.com/NixOS/nixpkgs/commit/fad2fb4c83ea353eb253db701208b9332aa02b80) | `` rtrtr: 0.3.1 -> 0.3.2 ``                                                          |
| [`33417766`](https://github.com/NixOS/nixpkgs/commit/33417766c6beaa379a5e1b16dfa2bfda61a49cc8) | `` tpnote: 1.25.8 -> 1.25.9 ``                                                       |
| [`b1670b35`](https://github.com/NixOS/nixpkgs/commit/b1670b35c09add7d4951fdd6c5f381356161d549) | `` vscode-extensions.mongodb.mongodb-vscode: 1.13.0 -> 1.13.1 ``                     |
| [`7b133ea8`](https://github.com/NixOS/nixpkgs/commit/7b133ea838e927c6c627412ca24964abe460a65f) | `` python312Packages.instructor: disable a benchmarking test ``                      |
| [`9a35e886`](https://github.com/NixOS/nixpkgs/commit/9a35e88613124de6ec97337779ab16f9da0739de) | `` librewolf: fix syntax error causing patches to not be applied ``                  |
| [`c42e6f34`](https://github.com/NixOS/nixpkgs/commit/c42e6f349e2da7e80eca2c8c195da9da09bc9c36) | `` or-tools: Restore abseil-cpp and protobuf pins to fix build failure ``            |
| [`f2cae790`](https://github.com/NixOS/nixpkgs/commit/f2cae790191384f46fd9ed0fd4bc6c3aa47f5247) | `` mdq: 0.6.1 -> 0.7.2 ``                                                            |
| [`e920abae`](https://github.com/NixOS/nixpkgs/commit/e920abae309d8e340d53d4d5fc75df43e3e0329c) | `` zoekt: 3.7.2-2-unstable-2025-04-22 -> 3.7.2-2-unstable-2025-05-06 ``              |
| [`8aded6ec`](https://github.com/NixOS/nixpkgs/commit/8aded6ec3a56e8aa03683a13dfe2e17f584b1096) | `` linuxPackages.nvidiaPackages.vulkan_beta: 570.123.07 -> 570.123.11 ``             |
| [`7b4bc6b6`](https://github.com/NixOS/nixpkgs/commit/7b4bc6b6a4547e7679a7d273091730cacf772f2c) | `` firefox-beta-bin-unwrapped: 138.0b9 -> 139.0b4 ``                                 |
| [`d186214a`](https://github.com/NixOS/nixpkgs/commit/d186214a3affa55c22bf5c3dbff7bc6103006b61) | `` prefect: 3.3.5 -> 3.4.0 ``                                                        |
| [`2bd91fe9`](https://github.com/NixOS/nixpkgs/commit/2bd91fe97ce6451c6571efd0572d9d1dfbd236e3) | `` vimPlugins.idris2-nvim: 2024-11-28 -> 2025-05-04 ``                               |
| [`a9a329c0`](https://github.com/NixOS/nixpkgs/commit/a9a329c03b5a935ace4e8208373f41e8cd787009) | `` netbird: 0.43.1 -> 0.43.2 ``                                                      |
| [`65d873da`](https://github.com/NixOS/nixpkgs/commit/65d873da59379bb0d7170f909cc88d1e4bca7abf) | `` turso-cli: 1.0.7 -> 1.0.9 ``                                                      |
| [`29ed9662`](https://github.com/NixOS/nixpkgs/commit/29ed9662460fe48d31556b77fc561cd9eaee65e4) | `` python3Packages.pyinstaller-hooks-contrib: 2025.2 -> 2025.4 ``                    |
| [`5ff2c712`](https://github.com/NixOS/nixpkgs/commit/5ff2c712b2120fa18906f8c33fb974133d517dec) | `` ytdl-sub: 2025.04.18 -> 2025.05.05 ``                                             |
| [`53ae009b`](https://github.com/NixOS/nixpkgs/commit/53ae009bda881405ca59326bddbd3c09d2136948) | `` zed-editor: 0.184.8 -> 0.184.10 ``                                                |
| [`93f55f26`](https://github.com/NixOS/nixpkgs/commit/93f55f267aa8403a6e6d84531c788570166f68a1) | `` fabric-ai: 1.4.183 -> 1.4.185 ``                                                  |
| [`bc812154`](https://github.com/NixOS/nixpkgs/commit/bc8121549d12ae791599ef7ad149011e9065bb06) | `` pre-commit: add gitMinimal to wrapper ``                                          |
| [`3c7fd6bd`](https://github.com/NixOS/nixpkgs/commit/3c7fd6bd1fc5cc797b22983280accf500ffd982a) | `` doctl: 1.125.0 -> 1.125.1 ``                                                      |
| [`a949c18f`](https://github.com/NixOS/nixpkgs/commit/a949c18fd5ece60a02a8ab7aaf395c0ac394a291) | `` nodejs_24: 24.0.0-rc.3 -> 24.0.0 ``                                               |
| [`a52b36db`](https://github.com/NixOS/nixpkgs/commit/a52b36db145210868edcccb386c7423a9ad70dd9) | `` kubectl-rook-ceph: 0.9.3 -> 0.9.4 ``                                              |
| [`39385e4e`](https://github.com/NixOS/nixpkgs/commit/39385e4e3be03b0baa8c1aa44fa4cc8caf0b5da6) | `` typical: fix build ``                                                             |
| [`6e3b6caf`](https://github.com/NixOS/nixpkgs/commit/6e3b6caf7bfb8fb1fc62c4162a2573b89a3f5a93) | `` vscode-extensions.betterthantomorrow.calva: 2.0.502 -> 2.0.508 ``                 |
| [`897273d0`](https://github.com/NixOS/nixpkgs/commit/897273d06676a1145ed4b0e26ffb23ee91bbe775) | `` consul: 1.20.6 -> 1.21.0 ``                                                       |
| [`2c9357e6`](https://github.com/NixOS/nixpkgs/commit/2c9357e616a95f6d781a30344597c7e5c0534b93) | `` gittuf: 0.9.0 -> 0.10.0 ``                                                        |
| [`6c72b0e1`](https://github.com/NixOS/nixpkgs/commit/6c72b0e1431f9462d77d2d47729595d7b9c88eed) | `` pgmoneta: 0.16.0 -> 0.16.1 ``                                                     |
| [`d30e6a08`](https://github.com/NixOS/nixpkgs/commit/d30e6a0879e09dd39c76d0682374f45f941f08eb) | `` erlang: fix empty documentation chunks in OTP 26 ``                               |
| [`fa74c47f`](https://github.com/NixOS/nixpkgs/commit/fa74c47f610236ef64a77181a28c7bdd68262f9e) | `` Remove maintainer karolchmist ``                                                  |
| [`a2cc5561`](https://github.com/NixOS/nixpkgs/commit/a2cc5561638f928b55f9e3c1230da25a946c3214) | `` nhost-cli: 1.29.5 -> 1.29.6 ``                                                    |
| [`d95d3724`](https://github.com/NixOS/nixpkgs/commit/d95d3724d856cc5b75e40f5451383e87a3a9818d) | `` fetchgit: add preFetch hook ``                                                    |
| [`e673b0fd`](https://github.com/NixOS/nixpkgs/commit/e673b0fda8da3e75beefe732212477bf8c940c45) | `` pantheon.appcenter: 8.1.0 -> 8.2.0 ``                                             |
| [`5f72ae74`](https://github.com/NixOS/nixpkgs/commit/5f72ae747c6ae1118566e80b69ba8e08d1c44334) | `` python313Packages.pyisy: 3.4.0 -> 3.4.1 ``                                        |
| [`cc816bee`](https://github.com/NixOS/nixpkgs/commit/cc816beebdf4d47f744f47d1e4abcdd585b356c6) | `` pspg: 5.8.9 -> 5.8.10 ``                                                          |
| [`04b88953`](https://github.com/NixOS/nixpkgs/commit/04b88953a025f339b458745bc506258fab960000) | `` python313Packages.wandb: 0.19.8 -> 0.19.10 ``                                     |
| [`96e6ba6d`](https://github.com/NixOS/nixpkgs/commit/96e6ba6d8f1a7036e741d4e56b89b0f72a12ac7e) | `` python3Packages.oelint-data: 1.0.10 -> 1.0.11 ``                                  |
| [`72206406`](https://github.com/NixOS/nixpkgs/commit/722064067cd18ca93493eee802dd3e689f994d77) | `` snipe-it: 8.1.0 -> 8.1.2 ``                                                       |
| [`a076b4c2`](https://github.com/NixOS/nixpkgs/commit/a076b4c28186cd76a2214360df601b5a8c476d22) | `` gat: 0.23.0 -> 0.23.1 ``                                                          |
| [`d654a947`](https://github.com/NixOS/nixpkgs/commit/d654a947cd7b3161e88574a872723d6e692fcade) | `` whistle: 2.9.97 -> 2.9.98 ``                                                      |
| [`34d32c3d`](https://github.com/NixOS/nixpkgs/commit/34d32c3dc1d9b4bf757c123134987a313711cf54) | `` mochi: 1.18.7 -> 1.18.11 ``                                                       |
| [`1ddbbe1b`](https://github.com/NixOS/nixpkgs/commit/1ddbbe1b819c96e1880a3ac6b46fc96d98fdbbd9) | `` python313Packages.aiohttp-client-cache: 0.12.4 -> 0.13.0 ``                       |
| [`c46b6e9a`](https://github.com/NixOS/nixpkgs/commit/c46b6e9af11a4902f6fd9eadc33b578fbd0421a3) | `` python313Packages.url-normalize: 1.4.3 -> 2.2.1 ``                                |
| [`7031e7e0`](https://github.com/NixOS/nixpkgs/commit/7031e7e01dae898ac4cc4eb6de7e0ecce0b5de8c) | `` anyrun: 0-unstable-2025-04-04 -> 0-unstable-2025-04-29 ``                         |
| [`7587d7f8`](https://github.com/NixOS/nixpkgs/commit/7587d7f85185860cecfa13cc5d8956c1a405c94f) | `` nushellPlugins.net: 1.9.0 -> 1.10.0 ``                                            |
| [`45c8c4b1`](https://github.com/NixOS/nixpkgs/commit/45c8c4b193a6264af0a35772682f8df6d8fe8636) | `` lux-cli: share source and cargoHash with lux-lua ``                               |
| [`d027a67f`](https://github.com/NixOS/nixpkgs/commit/d027a67f4ade57af289f10e2cc906be24820665a) | `` clightning: 25.02.1 -> 25.02.2 ``                                                 |
| [`57c566ab`](https://github.com/NixOS/nixpkgs/commit/57c566abdc68181e66998dc667f1d10f861bddac) | `` amazon-q-cli: add `versionCheckHook` ``                                           |
| [`800f89ce`](https://github.com/NixOS/nixpkgs/commit/800f89ce4fd86c8fe10feb5e124fa65326f3c39d) | `` mcphost: init at 0.7.1 ``                                                         |
| [`1032a46f`](https://github.com/NixOS/nixpkgs/commit/1032a46ffe4ba4f56919a9643443a9a6791811ed) | `` grml-zsh-config: remove unecessary dependencies ``                                |
| [`f507d475`](https://github.com/NixOS/nixpkgs/commit/f507d475830a834b70125ae40249acd0b829b3ef) | `` kubectl-gadget: 0.39.0 -> 0.40.0 ``                                               |
| [`44f7a3c1`](https://github.com/NixOS/nixpkgs/commit/44f7a3c1b82802774ef3d43ad8f3a4c44bb629b6) | `` python313Packages.boto3-stubs: 1.38.8 -> 1.38.9 ``                                |
| [`505777ef`](https://github.com/NixOS/nixpkgs/commit/505777ef57761252f938d9b1f5bab7e5bcf455b9) | `` python313Packages.botocore-stubs: 1.38.8 -> 1.38.9 ``                             |
| [`73d9f1ab`](https://github.com/NixOS/nixpkgs/commit/73d9f1ab488dd522ee80f133afd7cb3028f95d07) | `` python312Packages.mypy-boto3-mediaconvert: 1.38.0 -> 1.38.9 ``                    |
| [`21e01faf`](https://github.com/NixOS/nixpkgs/commit/21e01faf22ba40816f00f651187e7f21170cc271) | `` python312Packages.mypy-boto3-ecs: 1.38.3 -> 1.38.9 ``                             |
| [`98d1e1c7`](https://github.com/NixOS/nixpkgs/commit/98d1e1c7ed564857a4dedcbf3eae32acb1519481) | `` python312Packages.mypy-boto3-ec2: 1.38.6 -> 1.38.9 ``                             |
| [`61a390e0`](https://github.com/NixOS/nixpkgs/commit/61a390e01302e652bcff231300f6c591a8bdc39e) | `` python312Packages.mypy-boto3-devicefarm: 1.38.0 -> 1.38.9 ``                      |
| [`a6390c8a`](https://github.com/NixOS/nixpkgs/commit/a6390c8ad7bb95fe0e5d84724d91cb7d857dc295) | `` werf: 2.35.4 -> 2.35.8 ``                                                         |
| [`233adf1b`](https://github.com/NixOS/nixpkgs/commit/233adf1b921e132b9c9cbe9fc576146c892deb34) | `` python313Packages.twilio: 9.5.2 -> 9.6.0 ``                                       |
| [`33bac1c2`](https://github.com/NixOS/nixpkgs/commit/33bac1c2ccca63b568b307d968a87b4b5b2e4435) | `` amazon-q-cli: use `finalAttrs` pattern ``                                         |
| [`0ec3b2c9`](https://github.com/NixOS/nixpkgs/commit/0ec3b2c9524c3fa599e3b1e2553e363e6db90bf1) | `` amazon-q-cli: 1.8.0 -> 1.9.1 ``                                                   |
| [`da8114d3`](https://github.com/NixOS/nixpkgs/commit/da8114d3382082e933b819d2a389641a548859d0) | `` oils-for-unix: 0.28.0 -> 0.29.0 ``                                                |
| [`a913d445`](https://github.com/NixOS/nixpkgs/commit/a913d4455ffe2560106c0632bd1f0c121289bcea) | `` pgbackrest: 2.55.0 -> 2.55.1 ``                                                   |
| [`795f25b7`](https://github.com/NixOS/nixpkgs/commit/795f25b7735363c0e84695ee9989cef4ae6b6ec6) | `` python312Packages.fmpy: init at 0.3.23 ``                                         |
| [`a190ba0c`](https://github.com/NixOS/nixpkgs/commit/a190ba0c1eacb63c55dfd963873dd68525a0a05d) | `` vimPlugins.nvim-dbee: fix update script ``                                        |
| [`01fb9591`](https://github.com/NixOS/nixpkgs/commit/01fb9591f9ab950bf9231be550e1f4b2b75e5754) | `` lpcnet: Fix tests on aarch64-linux ``                                             |