### PR TITLE
chore(flake/nixvim): `aa1ae69b` -> `1b1e43a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
         "nuschtosSearch": []
       },
       "locked": {
-        "lastModified": 1746742749,
-        "narHash": "sha256-K65lPr8vr9vEvWK3Yqx9rL4eDN+eztXTT3ck6fdqAMQ=",
+        "lastModified": 1746822201,
+        "narHash": "sha256-XAt4FgViCT9kcSkODQUcbQ8JejjjbTGcMVGIP+7o7YE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "aa1ae69b573e64ce145672663471795daed2ec9e",
+        "rev": "1b1e43a36e4f701fb2fc870c322373579936f739",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`1b1e43a3`](https://github.com/nix-community/nixvim/commit/1b1e43a36e4f701fb2fc870c322373579936f739) | `` plugins/oil-git-status: set `signcolumn` sane default ``    |
| [`17e13d47`](https://github.com/nix-community/nixvim/commit/17e13d478de2c088476058a8272b8b6f3e24ddfe) | `` plugins/oil-git-status: improve `signcolumn` warning ``     |
| [`2797fd8b`](https://github.com/nix-community/nixvim/commit/2797fd8b64038bb43e16bf76f1c12af9a8db3e19) | `` plugins/oil-git-status: update `signcolumn` instructions `` |
| [`3556951d`](https://github.com/nix-community/nixvim/commit/3556951d361d5732cd261079b0543ccbee6035dd) | `` plugins/oil-git-status: fix whitespace in desc ``           |
| [`52db53ce`](https://github.com/nix-community/nixvim/commit/52db53cea2ea3e845526087061f0ca20b9e6e63a) | `` flake/dev/flake.lock: Update ``                             |
| [`cacdb973`](https://github.com/nix-community/nixvim/commit/cacdb973655a5b48d032c9053abf39bfdd20348f) | `` config-examples: add cirius-nix (#3307) ``                  |
| [`2d485ca1`](https://github.com/nix-community/nixvim/commit/2d485ca1a25244e518ec67e908fef668e05e8fad) | `` colorschemes/bamboo: init ``                                |
| [`a6eda590`](https://github.com/nix-community/nixvim/commit/a6eda59091bfb984dde882ae7faad0f48ee8e216) | `` plugins/lz-n: update references to options ``               |
| [`4bd021d2`](https://github.com/nix-community/nixvim/commit/4bd021d25f944639cf5e503fffc1c1f54b8249e5) | `` plugins/lz-n: add tests for keymap(<plugin>).set API ``     |
| [`b1cfeb4f`](https://github.com/nix-community/nixvim/commit/b1cfeb4f3478e637418c88a067a726509b7aeb86) | `` plugins/lz-n: add support for keymap(<plugin>).set API ``   |
| [`bb2e1acf`](https://github.com/nix-community/nixvim/commit/bb2e1acf70c7ef6dbca28b1f71e55c8dd69807f6) | `` plugins/lz-n: add HeitorAugustoLN as a maintainer ``        |
| [`a9938e06`](https://github.com/nix-community/nixvim/commit/a9938e06aede35b502f4231bc40b1a8a6d91b888) | `` plugins/lz-n: remove `with lib` ``                          |