### PR TITLE
chore(flake/treefmt-nix): `29ec5026` -> `708ec80c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746216483,
-        "narHash": "sha256-4h3s1L/kKqt3gMDcVfN8/4v2jqHrgLIe4qok4ApH5x4=",
+        "lastModified": 1746989248,
+        "narHash": "sha256-uoQ21EWsAhyskNo8QxrTVZGjG/dV4x5NM1oSgrmNDJY=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "29ec5026372e0dec56f890e50dbe4f45930320fd",
+        "rev": "708ec80ca82e2bbafa93402ccb66a35ff87900c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                       |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`966db02d`](https://github.com/numtide/treefmt-nix/commit/966db02dee09fea0b1c81e035d0f632882b46aaf) | `` just: format justfile in subdirectories `` |
| [`9d0b6546`](https://github.com/numtide/treefmt-nix/commit/9d0b6546c04f3b3addc6161470eaae7a7a700583) | `` feat(biome): add css support ``            |