### PR TITLE
chore(flake/nixvim): `02a85bd2` -> `ff0ccdf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,14 +138,15 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nuschtosSearch": []
+        "nuschtosSearch": [],
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1746965641,
-        "narHash": "sha256-6+Cn5aMDSWvsk4nOXmea3whAI4v+PjYaEpcDkTEAlXc=",
+        "lastModified": 1747083534,
+        "narHash": "sha256-r88FEbKX1HLTovPFt1QHxzZDV7D4TGHhYlJcHmK7hYk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "02a85bd29333ce9fbde0d2c57a2378f47205bb21",
+        "rev": "ff0ccdf572ad6700a2a29a82cc5d17db29708988",
         "type": "github"
       },
       "original": {
@@ -163,6 +164,21 @@
         "nixpkgs": "nixpkgs",
         "nixvim": "nixvim",
         "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     },
     "treefmt-nix": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`ff0ccdf5`](https://github.com/nix-community/nixvim/commit/ff0ccdf572ad6700a2a29a82cc5d17db29708988) | `` docs: add note on "following" nixpkgs input (#3317) ``                      |
| [`49a7bb57`](https://github.com/nix-community/nixvim/commit/49a7bb573aa44b8464e28b1f06720f26e87c03b5) | `` modules/top-level: change usages of import to callPackage ``                |
| [`4c23fb27`](https://github.com/nix-community/nixvim/commit/4c23fb2738d405f302d58e072955c7502526ffce) | `` tests/modules/performance/combine-plugins: use shared stub plugins ``       |
| [`a49b2708`](https://github.com/nix-community/nixvim/commit/a49b270861fc05d08835bccd74dd0643bf6b01bd) | `` tests/modules/performance/byte-compile-lua: use shared stub plugins ``      |
| [`75f2c1b1`](https://github.com/nix-community/nixvim/commit/75f2c1b1f1035330374de6cc9db9016e3c048a37) | `` modules/performance: ensure dependencies of lua packages also compiled ``   |
| [`9474ce91`](https://github.com/nix-community/nixvim/commit/9474ce916acd721deb89c832c78f20e14784ee5c) | `` modules/performance: ensure all lua dependencies are byte-compiled ``       |
| [`2210d7bb`](https://github.com/nix-community/nixvim/commit/2210d7bb10a16a12249d30f634fb2b4321214137) | `` tests/utils/plugin-stubs: add shared plugin stubs for use in tests ``       |
| [`0d78a477`](https://github.com/nix-community/nixvim/commit/0d78a477920e068f322ee662a9d74918128564a7) | `` modules/top-level/plugins: use mapNormalizedPlugins utils function ``       |
| [`2c618235`](https://github.com/nix-community/nixvim/commit/2c6182351f26535609372b8d136f339c2a1f46bf) | `` modules/performance: add ability to byte-compile plugin lua dependencies `` |
| [`404e5606`](https://github.com/nix-community/nixvim/commit/404e56066f1b7d774f593fa780e8d38e530aa766) | `` modules/performance: add ability to byte compile extraLuaPackages ``        |
| [`fac192c0`](https://github.com/nix-community/nixvim/commit/fac192c022a6db4bf92cf8f168fd388887b11f60) | `` tests/modules/performance/byte-compile-lua: improve tests ``                |
| [`d7475dd0`](https://github.com/nix-community/nixvim/commit/d7475dd0fa2af903db196cb7960cf91189159c63) | `` tests/modules/performance/byte-compile-lua: test with stub plugins ``       |
| [`5b47c657`](https://github.com/nix-community/nixvim/commit/5b47c65705964197d84dc8e54dfc2480e3e5a089) | `` tests/modules/performance/byte-compile-lua: improve bytecode detection ``   |
| [`ddddd780`](https://github.com/nix-community/nixvim/commit/ddddd780e0ba901cd990de2401348f95f706f762) | `` tests/fetch-tests: avoid unnecessary copy-to-store ``                       |
| [`8dbd0155`](https://github.com/nix-community/nixvim/commit/8dbd0155006b3e2c1f9e85c6bf78f67d867bea0d) | `` flake/dev/flake.lock: Update ``                                             |
| [`69266437`](https://github.com/nix-community/nixvim/commit/69266437beaac970568d12a46766706c72f361b3) | `` plugins/hunk: init ``                                                       |
| [`b505a2ae`](https://github.com/nix-community/nixvim/commit/b505a2aebdbd46f3ce92ca5bb1960078ea1edf89) | `` maintainers: add jalil-salame ``                                            |
| [`32127919`](https://github.com/nix-community/nixvim/commit/321279197268f900bfce4e1cd5cdd1fe8e96a385) | `` flake: add overridable systems input ``                                     |