### PR TITLE
chore(flake/nixvim): `ff0ccdf5` -> `1c53ad9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1747083534,
-        "narHash": "sha256-r88FEbKX1HLTovPFt1QHxzZDV7D4TGHhYlJcHmK7hYk=",
+        "lastModified": 1747173002,
+        "narHash": "sha256-06aYCSKtw1nlDn7PEAXwAYncSn8Fky4rtYrALep7f6I=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ff0ccdf572ad6700a2a29a82cc5d17db29708988",
+        "rev": "1c53ad9b2f5fd4a3c1f644d03895cda7756c92a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`1c53ad9b`](https://github.com/nix-community/nixvim/commit/1c53ad9b2f5fd4a3c1f644d03895cda7756c92a3) | `` plugins/timerly: init ``                                       |
| [`d3859727`](https://github.com/nix-community/nixvim/commit/d385972711e9a9a3e7f5e556dd44785c3e2fd4f6) | `` Revert "tests/lsp: disable ols test because odin is broken" `` |
| [`64880922`](https://github.com/nix-community/nixvim/commit/64880922bd011fddfe19e852f517778c214498c5) | `` flake/dev/flake.lock: Update ``                                |
| [`fcd3accd`](https://github.com/nix-community/nixvim/commit/fcd3accd346dc1b9cfbcb36272fa6ce4320ad2dc) | `` flake.lock: Update ``                                          |
| [`cbd5f7de`](https://github.com/nix-community/nixvim/commit/cbd5f7de5e93cf501526cb64e64b1d4936fe9c45) | `` modules/lsp/onAttach: fix `bufnr` and document `event` arg ``  |