### PR TITLE
chore(flake/nixpkgs): `d89fc19e` -> `adaa24fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746904237,
-        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "lastModified": 1747179050,
+        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`67202a3b`](https://github.com/NixOS/nixpkgs/commit/67202a3b4be80f0f472ad430e7d12625acb42f8c) | `` steampipe: 1.1.0 -> 1.1.2 ``                                                |
| [`ad9ec4fa`](https://github.com/NixOS/nixpkgs/commit/ad9ec4fa863a90c62c088673749bbb0e5b8f9e58) | `` commitizen: 4.6.2 -> 4.7.0 (#406405) ``                                     |
| [`4321b75a`](https://github.com/NixOS/nixpkgs/commit/4321b75a4cb8921cb53234fb0b489f51105036f2) | `` bootdev-cli: 1.19.0 -> 1.19.1 ``                                            |
| [`eafac01f`](https://github.com/NixOS/nixpkgs/commit/eafac01f808e835eab3c0fa1f7a88af14401bc67) | `` python3Packages.google-cloud-texttospeech: 2.26.0 -> 2.27.0 ``              |
| [`d46ee91c`](https://github.com/NixOS/nixpkgs/commit/d46ee91c805099eb92957b50d9ac151223ae2156) | `` opensnitch: modernize, adopt ``                                             |
| [`560b5595`](https://github.com/NixOS/nixpkgs/commit/560b55950ea6f693a1b660e5610f2c6167314c2c) | `` opensnitch-ui: modernize, adopt ``                                          |
| [`82c3175c`](https://github.com/NixOS/nixpkgs/commit/82c3175cde7d3ffe22d7fdf63a12a56a3d3e1b8f) | `` tootik: 0.15.6 -> 0.16.0 ``                                                 |
| [`23b64cfc`](https://github.com/NixOS/nixpkgs/commit/23b64cfcd8d7e4dae8e36f3631b43d81af003013) | `` home-assistant-custom-components.versatile_thermostat: 7.2.10 -> 7.3.0 ``   |
| [`b7671527`](https://github.com/NixOS/nixpkgs/commit/b76715275d502a1d330383ba4c6e7fa11d2d6f8c) | `` vimPlugins.blink-cmp: 1.2.0 -> 1.3.0 ``                                     |
| [`5962dedb`](https://github.com/NixOS/nixpkgs/commit/5962dedbf77d9e025f58d2f1544815892a3f612c) | `` vimPlugins.blink-cmp-npm-nvim: init at 2025-05-12 ``                        |
| [`5338f032`](https://github.com/NixOS/nixpkgs/commit/5338f03232fca8a50a2d6c39bc8e51a4704372d7) | `` calibre: 8.2.100 -> 8.4.0 ``                                                |
| [`ef78d32e`](https://github.com/NixOS/nixpkgs/commit/ef78d32e6063c754c5602b791efc4e8ba42b0c32) | `` atlas: 0.32.1 -> 0.33.0 ``                                                  |
| [`8c613c96`](https://github.com/NixOS/nixpkgs/commit/8c613c96572d03d2461d457aa2f159b22179cbf4) | `` calibre: add update script ``                                               |
| [`4ef79e9e`](https://github.com/NixOS/nixpkgs/commit/4ef79e9e3f3320ca6d3bec474c9f5d853bb2def6) | `` tbb_2021_11_0: address feedback from #405670 ``                             |
| [`64a6640a`](https://github.com/NixOS/nixpkgs/commit/64a6640a7df358180082efbfd169b6ad00aeb52b) | `` yash: 2.58.1 -> 2.59 ``                                                     |
| [`3a00b4ec`](https://github.com/NixOS/nixpkgs/commit/3a00b4ecf4e8e2635f95882ee968b6290d7e8b7e) | `` tbb: add silvanshade to maintainers ``                                      |
| [`34187977`](https://github.com/NixOS/nixpkgs/commit/34187977a179e88344d15e86455d8885c91f4b09) | `` tbb_2021_11_0: fix static builds ``                                         |
| [`1ad13007`](https://github.com/NixOS/nixpkgs/commit/1ad1300775871e241af36484893d6885153265f2) | `` hexpatch: 1.11.1 -> 1.11.2 ``                                               |
| [`1b09e021`](https://github.com/NixOS/nixpkgs/commit/1b09e0219fa052fcc778ac6c139f028d76462f86) | `` hobbes: 0-unstable-2023-06-03 -> 0-unstable-2025-04-23 ``                   |
| [`c549cc92`](https://github.com/NixOS/nixpkgs/commit/c549cc924fb1765c31a1c6e74c87dd636892235d) | `` gopher: fix build for GCC 14 ``                                             |
| [`64ba3e27`](https://github.com/NixOS/nixpkgs/commit/64ba3e270bc759990339cb591dff625acd110534) | `` cyclonedx-python: 6.0.0 -> 6.1.1 ``                                         |
| [`28d82c15`](https://github.com/NixOS/nixpkgs/commit/28d82c159da5bf298bfbac87e8b3a34888658706) | `` homebox: 1.18.0 -> 1.19.0 ``                                                |
| [`3d07eb42`](https://github.com/NixOS/nixpkgs/commit/3d07eb421fc0bd8d4ccad02a78b6c3356d122824) | `` linuxPackages.nvidiaPackages.vulkan_beta: 570.123.11 -> 570.123.14 ``       |
| [`ddb28e9c`](https://github.com/NixOS/nixpkgs/commit/ddb28e9c5ae982100b49520eccdc6e16a412c79a) | `` python3Packages.docling: 2.31.1 -> 2.31.2 ``                                |
| [`6a8e9b40`](https://github.com/NixOS/nixpkgs/commit/6a8e9b408904ed60525ead42c0cd4c58c04af9e6) | `` gotraceui: fix build ``                                                     |
| [`a5d2bfd1`](https://github.com/NixOS/nixpkgs/commit/a5d2bfd1ff762daeb75a8678f89ce74dffc96c92) | `` synadm: 0.47 -> 0.48 ``                                                     |
| [`222ded96`](https://github.com/NixOS/nixpkgs/commit/222ded96823c3b8ce8c4a7f1b57095ab7ca6b51d) | `` cargo-edit: 0.13.3 -> 0.13.4 ``                                             |
| [`0b3c382a`](https://github.com/NixOS/nixpkgs/commit/0b3c382ad922cac542f574053456babde108425d) | `` add changelog ``                                                            |
| [`05f9e0a1`](https://github.com/NixOS/nixpkgs/commit/05f9e0a1a3e24343dad680b8837e89aff511c68e) | `` xplr: 0.21.9 -> 1.0.0 (#405125) ``                                          |
| [`95cc9765`](https://github.com/NixOS/nixpkgs/commit/95cc97659c813256dc17d2905904144c1588e6ad) | `` release-notes: init for 25.11 ``                                            |
| [`30506f34`](https://github.com/NixOS/nixpkgs/commit/30506f343448c7761b5cec1024843424623a5bae) | `` Add @kvz and @Acconut as maintainers of tusd (#406699) ``                   |
| [`86de96db`](https://github.com/NixOS/nixpkgs/commit/86de96dbc1a8e65bc5f02b98d708315c0ec0fc02) | `` workflows/periodic-merges: integrate with staging-25.05 ``                  |
| [`93695476`](https://github.com/NixOS/nixpkgs/commit/93695476f6ddcd0daaf8add8ad63722992235cfd) | `` cpu_features: 0.10.0 -> 0.10.1 ``                                           |
| [`a0bd5306`](https://github.com/NixOS/nixpkgs/commit/a0bd5306eb0dd01492a24c9be498225570203982) | `` maintainers: remove comment referencing missing script ``                   |
| [`bb667e20`](https://github.com/NixOS/nixpkgs/commit/bb667e2046f0203c1cfae8ccdcb9a2da765802ef) | `` firefox-bin-unwrapped: 138.0.1 -> 138.0.3 ``                                |
| [`e408e254`](https://github.com/NixOS/nixpkgs/commit/e408e2547160eead1390d30305d8ee34780f2689) | `` firefox-unwrapped: 138.0.1 -> 138.0.3 ``                                    |
| [`497608f2`](https://github.com/NixOS/nixpkgs/commit/497608f2dc08f5e470e39c43d7bbd4e9e0978584) | `` resticprofile: 0.29.1 -> 0.30.1 ``                                          |
| [`0418326c`](https://github.com/NixOS/nixpkgs/commit/0418326c8f207d6600b9378e7407c5099fb715be) | `` _1password-gui-beta: Fix build error ``                                     |
| [`8fe6f95d`](https://github.com/NixOS/nixpkgs/commit/8fe6f95d69e635c69708b255857eff77cff9f9da) | `` linuxPackages.evdi: 1.14.9 -> 1.14.10 ``                                    |
| [`d7035eaa`](https://github.com/NixOS/nixpkgs/commit/d7035eaab7bf1b4d9e5418cbe77c02911b702cce) | `` lokalise2-cli: 3.1.3 -> 3.1.4 ``                                            |
| [`cb69b4f4`](https://github.com/NixOS/nixpkgs/commit/cb69b4f4343c14941776ff9bf43f8614a373d895) | `` python312Packages.llama-cloud-services: init at 0.6.22 ``                   |
| [`6c38a6fd`](https://github.com/NixOS/nixpkgs/commit/6c38a6fd0a0c93c8a1c12e513ecb40ff376ed824) | `` tfswitch: 1.4.4 -> 1.4.5 ``                                                 |
| [`beaf6a2a`](https://github.com/NixOS/nixpkgs/commit/beaf6a2a62a227f9add6fee3c69db70faf91aaac) | `` gale: 1.5.6 -> 1.5.12 ``                                                    |
| [`b9ddb2a4`](https://github.com/NixOS/nixpkgs/commit/b9ddb2a4b3cf7e7ab8f02eb7ecf25af9f8dac121) | `` stackit-cli: 0.31.0 -> 0.32.0 ``                                            |
| [`a27f09cd`](https://github.com/NixOS/nixpkgs/commit/a27f09cd910a5f18ed82bb10fa8473ec36de2c55) | `` vendir: 0.43.2 -> 0.44.0 ``                                                 |
| [`6f7e705a`](https://github.com/NixOS/nixpkgs/commit/6f7e705a3d48371a22f2f48a61305de8e4a84e2a) | `` Apply suggestions from code review ``                                       |
| [`b1747ba7`](https://github.com/NixOS/nixpkgs/commit/b1747ba75cba72b61b796f5346d0b58018e2e3c1) | `` sonarlint-ls: 3.21.0.76098 -> 3.22.0.76129 ``                               |
| [`9d1e3393`](https://github.com/NixOS/nixpkgs/commit/9d1e33930fb3f8b9e1591779f7a287424aba32c2) | `` fzf-git-sh: Use full path for zsh ``                                        |
| [`b93974ad`](https://github.com/NixOS/nixpkgs/commit/b93974ade02b6e88cdcc394ec8e59ae49a7e8588) | `` codebook: 0.2.12 → 0.2.13 ``                                                |
| [`da248bbd`](https://github.com/NixOS/nixpkgs/commit/da248bbd4919f910ca95c74a63893d6bcd8dc462) | `` stevenblack-blocklist: 3.15.34 -> 3.15.37 ``                                |
| [`b0ca69a7`](https://github.com/NixOS/nixpkgs/commit/b0ca69a742298cd090940fe085cfb756be45537d) | `` synapse-admin-etkecc: 0.10.3-etke39 -> 0.10.4-etke40 ``                     |
| [`6ce9a72d`](https://github.com/NixOS/nixpkgs/commit/6ce9a72d1ce4203aab90ec43ac71d5306b053fea) | `` ucc: 1.3.0 -> 1.4.4 ``                                                      |
| [`e52ca15a`](https://github.com/NixOS/nixpkgs/commit/e52ca15a64edfa19edee31e9cccd5164c96ed967) | `` libretro.genesis-plus-gx: 0-unstable-2025-04-25 -> 0-unstable-2025-05-02 `` |
| [`d7c4d0ff`](https://github.com/NixOS/nixpkgs/commit/d7c4d0ff56e68ff975a43f3b8553aaecce0479d3) | `` cockpit: 337 -> 338 ``                                                      |
| [`c6978e8a`](https://github.com/NixOS/nixpkgs/commit/c6978e8a58ff5a9fc1ab30310dedbdfc3f5ebc42) | `` nixos/test-driver: exit early if /dev/vhost-vsock isn't available ``        |
| [`03d513c4`](https://github.com/NixOS/nixpkgs/commit/03d513c424440ebf6f22725aa3348433cf854bd3) | `` signal-desktop{,-bin}: move my maintainership (#406687) ``                  |
| [`4caf0d42`](https://github.com/NixOS/nixpkgs/commit/4caf0d427e4312f0100aecbc4e1181815c8d433f) | `` signal-desktop-{bin,source}: fix icon in KDE Task switcher (#399903) ``     |
| [`f82d9b11`](https://github.com/NixOS/nixpkgs/commit/f82d9b11dc10531829d9210d85c63a4e2d352472) | `` alt-ergo: 2.6.1 → 2.6.2 ``                                                  |
| [`28faf5e4`](https://github.com/NixOS/nixpkgs/commit/28faf5e4058c39de8c8937928654eee66917e1ad) | `` cfripper: 1.17.0 -> 1.17.1 ``                                               |
| [`9ed4e750`](https://github.com/NixOS/nixpkgs/commit/9ed4e7508e06389acc64bca0c2b95e95a452f3e1) | `` vscode-extensions.julialang.language-julia: 1.138.1 -> 1.140.2 ``           |
| [`576233fa`](https://github.com/NixOS/nixpkgs/commit/576233fa22b9ca7468144764dc5af0783ad5541a) | `` nixf-diagnose: init at 0.1.2 ``                                             |
| [`b72c82dc`](https://github.com/NixOS/nixpkgs/commit/b72c82dc57bf890665504fea4ed76643fa0bc128) | `` vscode-extensions.sonarsource.sonarlint-vscode: 4.21.0 -> 4.22.0 ``         |
| [`0cafd7ce`](https://github.com/NixOS/nixpkgs/commit/0cafd7cef7d548a304dd44248f30f1b7da044933) | `` matrix-authentication-service: set VERGEN_GIT_DESCRIBE ``                   |
| [`201b0e24`](https://github.com/NixOS/nixpkgs/commit/201b0e24e0291446134342eb70b8f730a1c67a8e) | `` matrix-authentication-service: use finalAttrs ``                            |
| [`1bb9657e`](https://github.com/NixOS/nixpkgs/commit/1bb9657e1739326d9fd646b8318be918f892ed6d) | `` docling: 2.31.0 -> 2.31.1 ``                                                |
| [`41e4ba4b`](https://github.com/NixOS/nixpkgs/commit/41e4ba4b5582261708256649b228c8ec79aa6222) | `` suyu: drop ``                                                               |
| [`614887a0`](https://github.com/NixOS/nixpkgs/commit/614887a04a298ae96f3cf98c776b474bdec37181) | `` paretosecurity: 0.2.15 -> 0.2.17 ``                                         |
| [`b32f22f8`](https://github.com/NixOS/nixpkgs/commit/b32f22f80b5136db3910646d2d20185780128923) | `` trdl-client: 0.10.0 -> 0.11.0 ``                                            |
| [`3bd5f3c4`](https://github.com/NixOS/nixpkgs/commit/3bd5f3c4db7f773b9a6ad708f8fd025ec1058faf) | `` snipe-it: 8.1.2 -> 8.1.3 ``                                                 |
| [`68bcd5e6`](https://github.com/NixOS/nixpkgs/commit/68bcd5e6f26da5cb4f75e5adb8a67441cb88fa88) | `` workflows/eval: fix missing dependency of tag job ``                        |
| [`afc3b334`](https://github.com/NixOS/nixpkgs/commit/afc3b33403dc2ba5a5ba51f214e14b2cede30bb6) | `` workflows/get-merge-commit: fix actionlint warning ``                       |
| [`1893f543`](https://github.com/NixOS/nixpkgs/commit/1893f5439e495a4cd301aedd2acf45903cdb6ea7) | `` workflows/check-format: run on all files ``                                 |
| [`fab95ba4`](https://github.com/NixOS/nixpkgs/commit/fab95ba4b9523f310644e6e6087c0014535c8e02) | `` ocamlPackages.base: 0.17.1 → 0.17.2 ``                                      |
| [`7355b5bf`](https://github.com/NixOS/nixpkgs/commit/7355b5bf9e07e6de12c8d31fe1a6fddbe14ba848) | `` diffnav: 0.3.0 -> 0.3.1 ``                                                  |
| [`6739ec28`](https://github.com/NixOS/nixpkgs/commit/6739ec2800ecea97a1e4fd7acc1ffdae66c538b6) | `` vscode-extensions.tabnine.tabnine-vscode: 3.268.0 -> 3.271.0 ``             |
| [`85395200`](https://github.com/NixOS/nixpkgs/commit/85395200f0712e59146a8333eaf46965e38736ea) | `` svt-av1-psy: set `meta.mainProgram` ``                                      |
| [`300dc81f`](https://github.com/NixOS/nixpkgs/commit/300dc81fec82e0f541825d454683dafb09ac1c84) | `` svt-av1-psy: limit x86_64-specific dependencies ``                          |
| [`dfac0293`](https://github.com/NixOS/nixpkgs/commit/dfac029351fedd449500101e26dcc16b2b063d83) | `` krillinai: 1.1.4 -> 1.1.5 ``                                                |
| [`d82f8004`](https://github.com/NixOS/nixpkgs/commit/d82f8004dff82c45450f7297462d23a4d270d9ff) | `` linux_xanmod_latest: 6.14.5 -> 6.14.6 ``                                    |
| [`8dfb8b9c`](https://github.com/NixOS/nixpkgs/commit/8dfb8b9c77fc93c82bda7e9ae37f7c5bffd889f9) | `` linux_xanmod: 6.12.26 -> 6.12.28 ``                                         |
| [`b75e65eb`](https://github.com/NixOS/nixpkgs/commit/b75e65eb6aed71b0f716d73aeb02cbb827d465a1) | `` terraform-providers.yandex: 0.140.1 -> 0.141.0 ``                           |
| [`34490f92`](https://github.com/NixOS/nixpkgs/commit/34490f921611bfae6996588dfe2e3894996993b3) | `` terraform-providers.pagerduty: 3.24.2 -> 3.25.0 ``                          |
| [`cfc1abb2`](https://github.com/NixOS/nixpkgs/commit/cfc1abb27773783e87729342b0952aad2cc713be) | `` linuxPackages.rtl8821ce: 0-unstable-2025-03-31 -> 0-unstable-2025-05-02 ``  |
| [`7507c464`](https://github.com/NixOS/nixpkgs/commit/7507c4643dcc8ae8c90a2bf0cf9447c82b070e09) | `` syncthing-macos: init at 1.29.2-2 ``                                        |
| [`14d98b0f`](https://github.com/NixOS/nixpkgs/commit/14d98b0f41806eb85caf5a1172f8139377d29873) | `` plasma-panel-spacer-extended: 1.10.0 -> 1.10.1 ``                           |
| [`7d5ec9ab`](https://github.com/NixOS/nixpkgs/commit/7d5ec9abf12f8bf473792f1e122400aa666bf10b) | `` supercell-wx: 0.4.8 -> 0.4.9 ``                                             |
| [`db438a63`](https://github.com/NixOS/nixpkgs/commit/db438a631388791b1f31b3b9f5ebe7a5506afd64) | `` sendme: 0.25.0 -> 0.26.0 ``                                                 |
| [`15ffca80`](https://github.com/NixOS/nixpkgs/commit/15ffca801ddcbf78b477fb0339b4a01999397317) | `` tuckr: 0.11.1 -> 0.11.2 ``                                                  |
| [`e0552c6c`](https://github.com/NixOS/nixpkgs/commit/e0552c6cafda5d65aeca6dec97da6f8f88f95ab8) | `` git-bug-migration: add maintainer: sudoforge ``                             |
| [`518c8e58`](https://github.com/NixOS/nixpkgs/commit/518c8e58f9bbf4746a9716e9456c0c32c3efe2c6) | `` zmap: 4.3.3 -> 4.3.4 ``                                                     |
| [`3bda0cd0`](https://github.com/NixOS/nixpkgs/commit/3bda0cd0cb75ebe8d1fae00447352742f904225e) | `` eksctl: 0.207.0 -> 0.208.0 ``                                               |