### PR TITLE
chore(flake/nixvim): `95ca65c8` -> `2628efee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1747224967,
-        "narHash": "sha256-we27kbNAAEeT0+PxJ2aUNVFXlJ7uvh4pxTc3R8RUqxA=",
+        "lastModified": 1747366174,
+        "narHash": "sha256-3oEIxMBQXNXsW/ugW0Yv76qtjrsxv/JHeULtMp2eq1E=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "95ca65c8d1adee5594bd14f527c68d564fb68879",
+        "rev": "2628efee7111398e3ba1e7ba3cff00f580fe554b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`2628efee`](https://github.com/nix-community/nixvim/commit/2628efee7111398e3ba1e7ba3cff00f580fe554b) | `` flake/devshell: add treefmt to shell ``                     |
| [`4c989abc`](https://github.com/nix-community/nixvim/commit/4c989abc8cb53c94986bca6fc5f058d53a1d55cc) | `` flake/devshell: run treefmt directly in `format` command `` |
| [`46e13593`](https://github.com/nix-community/nixvim/commit/46e1359338d0f86acf80c61cbcb4d7a4c1198e58) | `` flake: use pre-configured treefmt package in git-hooks ``   |