### PR TITLE
chore(flake/nixvim): `2628efee` -> `1deeb7f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1747366174,
-        "narHash": "sha256-3oEIxMBQXNXsW/ugW0Yv76qtjrsxv/JHeULtMp2eq1E=",
+        "lastModified": 1747495941,
+        "narHash": "sha256-h/35nPaCLRvtoIN/c8ZqbEKAeK/YTGuB7IKEj+kBLkU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2628efee7111398e3ba1e7ba3cff00f580fe554b",
+        "rev": "1deeb7f689ad5c23b738c56ce4afea5ef9bbd7d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`1deeb7f6`](https://github.com/nix-community/nixvim/commit/1deeb7f689ad5c23b738c56ce4afea5ef9bbd7d1) | `` plugins/lsp: add package for luau_lsp `` |
| [`61c44d7a`](https://github.com/nix-community/nixvim/commit/61c44d7a7fdb3d9ab1c36fdb6f16bffca01cb87d) | `` docs/man: minor cleanup ``               |
| [`2a4719f2`](https://github.com/nix-community/nixvim/commit/2a4719f275d624fd5a1207443327a6715c16999c) | `` docs/mdbook: add page ToC ``             |
| [`ffdeb40a`](https://github.com/nix-community/nixvim/commit/ffdeb40a505c6f7d2dfd9bcae6358e4e97bb0d2e) | `` flake/dev: sort flake inputs ``          |
| [`0ccc452a`](https://github.com/nix-community/nixvim/commit/0ccc452af218dc1eb948d65b03a46af3271aa07b) | `` maintainers: enforce sorting ``          |
| [`0a6bd171`](https://github.com/nix-community/nixvim/commit/0a6bd171cf4e5f11f5233dd7419aa36d695ad00b) | `` flake: add `keep-sorted` to treefmt ``   |