### PR TITLE
chore(flake/nixpkgs): `adaa24fb` -> `e06158e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747179050,
-        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
+        "lastModified": 1747327360,
+        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
+        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
| [`0680f195`](https://github.com/NixOS/nixpkgs/commit/0680f195d11d393a897d5c621efdeead37b729ce) | `` magnetophonDSP.VoiceOfFaust: 1.1.5 -> 1.1.7 (#407081) ``                                                                  |
| [`a6049de7`](https://github.com/NixOS/nixpkgs/commit/a6049de7ae0b322214979d2368afcf99bcf2c87e) | `` vscode-extensions.dbaeumer.vscode-eslint: refactor, move into its own directory, provide default working configuration `` |
| [`883bc58b`](https://github.com/NixOS/nixpkgs/commit/883bc58b6b09829ff8bab0c11fd084bf4fd9fa12) | `` python3Packages.docling-core: 2.29.0 -> 2.30.1 ``                                                                         |
| [`b1c1948a`](https://github.com/NixOS/nixpkgs/commit/b1c1948a0d8d2f44c23a58d74b015e59b7ece36a) | `` vscode-extensions.esbenp.prettier-vscode: refactor, move into its own directory, provide default working configuration `` |
| [`9f73695b`](https://github.com/NixOS/nixpkgs/commit/9f73695b367208419bb470fc325b94133b98b416) | `` ddev: 1.24.4 -> 1.24.5 ``                                                                                                 |
| [`838e4934`](https://github.com/NixOS/nixpkgs/commit/838e49340d211d579ccb57b1e0e8be5d04109bdf) | `` hyperswarm: 4.11.5 -> 4.11.7 ``                                                                                           |
| [`9ff655f4`](https://github.com/NixOS/nixpkgs/commit/9ff655f4608b62841dcb1f2f00f5bb98a4aed636) | `` Revert "pdftk: use minimal jre" ``                                                                                        |
| [`3337c438`](https://github.com/NixOS/nixpkgs/commit/3337c438c3067063274927f7d54a080c9334ca09) | `` rnnoise-plugin: split outputs (#407334) ``                                                                                |
| [`6ef38996`](https://github.com/NixOS/nixpkgs/commit/6ef389965264028bf8ca72a3070d0d5f4719c05c) | `` k3s: fix document formatting (#407223) ``                                                                                 |
| [`5ddcb277`](https://github.com/NixOS/nixpkgs/commit/5ddcb277b7d5601a873c2751a62c5d4edfb0257f) | `` vscode-extensions.amazonwebservices.amazon-q-vscode: 1.66.0 -> 1.67.0 ``                                                  |
| [`17ae116c`](https://github.com/NixOS/nixpkgs/commit/17ae116c3e62c0432951b85d147950d72a2dc48c) | `` taler-twister: init at 1.0.0 ``                                                                                           |
| [`c48cd180`](https://github.com/NixOS/nixpkgs/commit/c48cd1808baedf8496365511585bdfaf764da1f1) | `` vscode-extensions.danielgavin.ols: 0.1.34 -> 0.1.35 ``                                                                    |
| [`03b15b88`](https://github.com/NixOS/nixpkgs/commit/03b15b8825bdceb738124f59f56f90ed31a2c3be) | `` surrealdb: 2.3.1 -> 2.3.2 ``                                                                                              |
| [`d9fe0af0`](https://github.com/NixOS/nixpkgs/commit/d9fe0af014141f36cd3a79207a6085bdf69d9be8) | `` rime-wanxiang: 6.7.8 -> 6.7.9 ``                                                                                          |
| [`43600d34`](https://github.com/NixOS/nixpkgs/commit/43600d343e39c667053ce1b8550513d6e8da65ba) | `` framework-tool: 0.4.1 -> 0.4.2 ``                                                                                         |
| [`2070b231`](https://github.com/NixOS/nixpkgs/commit/2070b2319a068f5b37567c4d7a80375f40654997) | `` vscode-extensions.wakatime.vscode-wakatime: 25.0.1 -> 25.0.3 ``                                                           |
| [`0f407b75`](https://github.com/NixOS/nixpkgs/commit/0f407b75b28547e90e08f88577cfb5b6b6906c46) | `` vscode-extensions.banacorn.agda-mode: 0.5.6 -> 0.5.7 ``                                                                   |
| [`7d14281d`](https://github.com/NixOS/nixpkgs/commit/7d14281d913000f937e6d0b493c1b6f905c32708) | `` make-bootstrap-tools-cross: add riscv64-unknown-linux-musl ``                                                             |
| [`7eb25809`](https://github.com/NixOS/nixpkgs/commit/7eb258098116e2280aa43c6f681dd405f7cc0b49) | `` lib.systems.examples.riscv64-musl: init ``                                                                                |
| [`dfcaa1da`](https://github.com/NixOS/nixpkgs/commit/dfcaa1dae95b342150eaf85e31bacaf6687d14d9) | `` vscode-extensions.1Password.op-vscode: 1.0.4 -> 1.0.5 ``                                                                  |
| [`93d23513`](https://github.com/NixOS/nixpkgs/commit/93d23513bfdb968f82dc50f4b0cbd389d81ff0b9) | `` nbxplorer: 2.5.25 -> 2.5.26 ``                                                                                            |
| [`37f27af1`](https://github.com/NixOS/nixpkgs/commit/37f27af14a874dd2dfa5cb0b184f023b241e6bab) | `` python3Packages.paramax: 0.0.0 -> 0.0.3 ``                                                                                |
| [`064f77c3`](https://github.com/NixOS/nixpkgs/commit/064f77c33cb122cd08397d07e6e43d5201b7e322) | `` vimPlugins.codecompanion-history-nvim: init at 2025-05-15 ``                                                              |
| [`56c39dbe`](https://github.com/NixOS/nixpkgs/commit/56c39dbe8b2a6c5bd4ae148825d80bb92e1fc2bd) | `` whatsapp-emoji-font: 2.25.1.75-1 -> 2.25.9.78-1 ``                                                                        |
| [`f05e53b1`](https://github.com/NixOS/nixpkgs/commit/f05e53b18fc3289fd23effd0e3fb43322b6f4928) | `` python3Packages.pyvista: 0.45.0 -> 0.45.2 ``                                                                              |
| [`b3073ef3`](https://github.com/NixOS/nixpkgs/commit/b3073ef35d9556b1c27e26eba16e26c5add8c6f7) | `` roddhjav-apparmor-rules: 0-unstable-2025-05-03 -> 0-unstable-2025-05-14 (#407184) ``                                      |
| [`7a5844a9`](https://github.com/NixOS/nixpkgs/commit/7a5844a90239c576511efe450ebcbacd90b558b9) | `` outfieldr: init at 1.1.0 ``                                                                                               |
| [`b850be1b`](https://github.com/NixOS/nixpkgs/commit/b850be1b1f36fb941c33644b0fb07cd27ed2981a) | `` matomo: 5.3.1 -> 5.3.2 ``                                                                                                 |
| [`9ad350c5`](https://github.com/NixOS/nixpkgs/commit/9ad350c557bdabdcad25e72fd8284d0866d2b317) | `` matomo: add version regex to update script ``                                                                             |
| [`bf259bc8`](https://github.com/NixOS/nixpkgs/commit/bf259bc8ec0fb07246b731ab44a3ef8f62e5a7c5) | `` zotero: change alias zotero_7 to refer to zotero, not zotero-beta ``                                                      |
| [`e4a89f5c`](https://github.com/NixOS/nixpkgs/commit/e4a89f5cc0244b8f75adc32adcd97fd4079ab0e0) | `` coqPackages.HoTT: 8.20 -> 9.0 ``                                                                                          |
| [`2c3bb138`](https://github.com/NixOS/nixpkgs/commit/2c3bb1389e6359c76f5ecc3b9e16b7c804d7f3ea) | `` varnish76: drop ``                                                                                                        |
| [`918e0afe`](https://github.com/NixOS/nixpkgs/commit/918e0afe2b25dbc28d71c3b92e329b8f9a497814) | `` libigl: 2.5.0 -> 2.6.0 ``                                                                                                 |
| [`e5f23698`](https://github.com/NixOS/nixpkgs/commit/e5f23698ab33a481160a8da4971af4ba18311300) | `` servo: 0-unstable-2025-05-13 -> 0-unstable-2025-05-15 ``                                                                  |
| [`75f94762`](https://github.com/NixOS/nixpkgs/commit/75f947629d1652e7d7b71979dcc772593497eddf) | `` gcc-arm-embedded: fix hardcoded library paths on x86_64-darwin ``                                                         |
| [`5e31efee`](https://github.com/NixOS/nixpkgs/commit/5e31efee6b634dbe79787cc55cd152dbb474fe61) | `` ocamlPackages.junit: 2.0.2 → 2.3.0 ``                                                                                     |
| [`b6379913`](https://github.com/NixOS/nixpkgs/commit/b6379913ebcef62dcd94b9173187b108540a50b9) | `` vscode-extensions.ms-dotnettools.csharp: 2.72.34 -> 2.76.27 ``                                                            |
| [`04fa62d4`](https://github.com/NixOS/nixpkgs/commit/04fa62d4f93d25af20e7c38c9eb894fe64330bca) | `` vscode-extensions.ms-dotnettools.csharp: remove update script ``                                                          |
| [`8e1fe516`](https://github.com/NixOS/nixpkgs/commit/8e1fe516204b4fbced0d34bb3887950d55e84282) | `` komac: remove kachick from maintainers ``                                                                                 |
| [`dac983ed`](https://github.com/NixOS/nixpkgs/commit/dac983ed241222868e58d82b00f3bdf5282b5b74) | `` hugo: remove kachick from maintainers ``                                                                                  |
| [`4d4e2533`](https://github.com/NixOS/nixpkgs/commit/4d4e25331cc23d0191d17174d5e7414615667007) | `` python3Packages.docling-ibm-models: 3.4.2 -> 3.4.3 ``                                                                     |
| [`65ef02cb`](https://github.com/NixOS/nixpkgs/commit/65ef02cb141ef4c9ae057f2118ccd1dbd9d67059) | `` uemacs: format with nixfmt-rfc-style ``                                                                                   |
| [`4597d8af`](https://github.com/NixOS/nixpkgs/commit/4597d8af38ae28cf2ecc064532f6cf270450706b) | `` uemacs: fix cross ``                                                                                                      |
| [`858bf5b2`](https://github.com/NixOS/nixpkgs/commit/858bf5b2a28a533682c102b9fd2fbcd35e8c3608) | `` fortune-kind: fix FORTUNE_DIR wrapping ``                                                                                 |
| [`3c0d3409`](https://github.com/NixOS/nixpkgs/commit/3c0d340920f8ca876191957ed327021bdc5bc8b7) | `` keypunch: 5.1 -> 6.3 ``                                                                                                   |
| [`354a0534`](https://github.com/NixOS/nixpkgs/commit/354a05348d7a96010bb3abe457d70c05907a5746) | `` fretboard: 8.0 -> 9.1 ``                                                                                                  |
| [`7a740588`](https://github.com/NixOS/nixpkgs/commit/7a740588582dc750266aa3235bd116a1b901d9af) | `` komikku: modernize ``                                                                                                     |
| [`216c1928`](https://github.com/NixOS/nixpkgs/commit/216c19280abab573b3448f0985a3172963c3d9c9) | `` komikku: 1.72.0 -> 1.76.1 ``                                                                                              |
| [`016a6cf6`](https://github.com/NixOS/nixpkgs/commit/016a6cf6be6513889c41a35c90e5aef2559b499b) | `` python312Packages.modern-colorthief: init at 0.1.7 ``                                                                     |
| [`0476cb35`](https://github.com/NixOS/nixpkgs/commit/0476cb35131cb09ba463bcfb1649d5139c14fe41) | `` vscode-extensions.ms-python.vscode-pylance: 2025.4.1 -> 2025.5.1 ``                                                       |
| [`87373297`](https://github.com/NixOS/nixpkgs/commit/873732972b3e25b761ec3b6b0bcf4ce46952564e) | `` simplotask: 1.16.4 -> 1.17.0 ``                                                                                           |
| [`77dde61c`](https://github.com/NixOS/nixpkgs/commit/77dde61cdd88dd1798827d7def489e4bdf8b365b) | `` rembg: 2.0.65 -> 2.0.66 ``                                                                                                |
| [`1c97f7a9`](https://github.com/NixOS/nixpkgs/commit/1c97f7a9162b63677aeb6334ab3be501fad32aea) | `` dosage-tracker: 1.9.4 -> 1.9.9 ``                                                                                         |
| [`558b9e5e`](https://github.com/NixOS/nixpkgs/commit/558b9e5ecc7a59edaddb8c035b2716c070b9a7f1) | `` github-mcp-server: 0.2.1 -> 0.3.0 ``                                                                                      |
| [`35286d89`](https://github.com/NixOS/nixpkgs/commit/35286d899e85c411843d152b0495995fb64f94e5) | `` python3Packages.elastic-apm: fix tests ``                                                                                 |
| [`2ffe6da5`](https://github.com/NixOS/nixpkgs/commit/2ffe6da5268441a315d8ed86844ad94d5bcba401) | `` qtcreator: 16.0.1 -> 16.0.2 ``                                                                                            |
| [`28e2f521`](https://github.com/NixOS/nixpkgs/commit/28e2f5216405bfb6de1c25ddc223fd385bfaa67c) | `` azure-storage-azcopy: 10.29.0 -> 10.29.2 ``                                                                               |
| [`5ace6ebe`](https://github.com/NixOS/nixpkgs/commit/5ace6ebe0814e59ce42c83b69ec35e9a6298db36) | `` kdiff3: 1.12.2 -> 1.12.3 ``                                                                                               |
| [`773edbf3`](https://github.com/NixOS/nixpkgs/commit/773edbf34c21a6e6b4af49331789eb9b0d471887) | `` yquake2: 8.50 -> 8.51 ``                                                                                                  |
| [`952a08eb`](https://github.com/NixOS/nixpkgs/commit/952a08eb965f015e5c5dbdf7f3ea29a33af1beeb) | `` socket_wrapper: 1.4.4 -> 1.5.0 ``                                                                                         |
| [`4e7af8e0`](https://github.com/NixOS/nixpkgs/commit/4e7af8e0face1528a8810b18dbc3d9c84d34fb76) | `` linux_testing: 6.15-rc5 -> 6.15-rc6 ``                                                                                    |
| [`4dda2e37`](https://github.com/NixOS/nixpkgs/commit/4dda2e378cbc2782ee967acee275aa999501294e) | `` jasper-gtk-theme: init at 0-unstable-2025-04-02 ``                                                                        |
| [`6f5a66f5`](https://github.com/NixOS/nixpkgs/commit/6f5a66f50d57b95f58dc16ecb6c6c0efb1b812b9) | `` ungoogled-chromium: 136.0.7103.92-1 -> 136.0.7103.113-1 ``                                                                |
| [`856078e9`](https://github.com/NixOS/nixpkgs/commit/856078e9847ba535a77c5c74412d885fb88765e7) | `` gnomeExtensions: auto-update ``                                                                                           |
| [`3565f259`](https://github.com/NixOS/nixpkgs/commit/3565f259d8f1ea101bdb341c8a8342e605a78add) | `` terraform: 1.11.4 -> 1.12.0 ``                                                                                            |
| [`8c29a7f6`](https://github.com/NixOS/nixpkgs/commit/8c29a7f620418206ad09dd7992e01f612b8b7de6) | `` dim: don't vendor Cargo.lock ``                                                                                           |
| [`90d4d630`](https://github.com/NixOS/nixpkgs/commit/90d4d63008c19fea4b30cb633ef543484adcce5a) | `` python3Packages.orderly-set: 5.3.2 -> 5.4.1 ``                                                                            |