### PR TITLE
chore(flake/nixvim): `14c7f5f8` -> `47dba84e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1747683610,
-        "narHash": "sha256-Jis9/4lnr3pn1AIRgCnoeiReKs2MGy6COWc6JtAEESo=",
+        "lastModified": 1747743401,
+        "narHash": "sha256-AXk6mf9ySe44faNUGhD1mZud/kB7X+Nipzo2YxHet4s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "14c7f5f8968940d1730b5e935dd1d9f3e461a2d3",
+        "rev": "47dba84e0d068a2b8c07faa0ec737ea98a226537",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`47dba84e`](https://github.com/nix-community/nixvim/commit/47dba84e0d068a2b8c07faa0ec737ea98a226537) | `` flake/dev/flake.lock: Update `` |
| [`d4dff3f6`](https://github.com/nix-community/nixvim/commit/d4dff3f6b8c1bd99aec07895dc00623cae1f2d1a) | `` flake.lock: Update ``           |