### PR TITLE
chore(flake/nixvim): `47dba84e` -> `7e3a0f4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1747743401,
-        "narHash": "sha256-AXk6mf9ySe44faNUGhD1mZud/kB7X+Nipzo2YxHet4s=",
+        "lastModified": 1747845951,
+        "narHash": "sha256-wTmZS30RIM6ELx9JFH5XSI5bjI4GzjtpodjHTSZBY3g=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "47dba84e0d068a2b8c07faa0ec737ea98a226537",
+        "rev": "7e3a0f4e97c0906a276a860975888db96106b75e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`7e3a0f4e`](https://github.com/nix-community/nixvim/commit/7e3a0f4e97c0906a276a860975888db96106b75e) | `` plugins/neo-tree: correct contentLayout allowed options `` |
| [`4936f85d`](https://github.com/nix-community/nixvim/commit/4936f85de347171f41fec9ca0e457da04fedbab7) | `` docs/mdbook: fix `user-guide/helpers.html` redirect ``     |