### PR TITLE
chore(flake/nixvim): `7e3a0f4e` -> `46fd0b18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1747845951,
-        "narHash": "sha256-wTmZS30RIM6ELx9JFH5XSI5bjI4GzjtpodjHTSZBY3g=",
+        "lastModified": 1747945641,
+        "narHash": "sha256-Ts16c+kptbC3YDwPcB/NqXFVMHPNYKeFD7LkiawbWCU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7e3a0f4e97c0906a276a860975888db96106b75e",
+        "rev": "46fd0b184cbc5f1bdc5a8325cb973fc54e49ab68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`46fd0b18`](https://github.com/nix-community/nixvim/commit/46fd0b184cbc5f1bdc5a8325cb973fc54e49ab68) | `` version-info: init ``                                            |
| [`cd7a41c2`](https://github.com/nix-community/nixvim/commit/cd7a41c23c2a357dddea623863d753254a16150f) | `` update-scripts/update: write version-info during update ``       |
| [`132c1611`](https://github.com/nix-community/nixvim/commit/132c1611f6ac83adc2d9e9f37261c985506189fc) | `` update-scripts: move update logic from CI to dedicated script `` |
| [`7a4c70c5`](https://github.com/nix-community/nixvim/commit/7a4c70c55f5db77da15364d822dfd3660cf4bd0a) | `` update-scripts/version-info: init ``                             |
| [`bfee503e`](https://github.com/nix-community/nixvim/commit/bfee503e0fac061bd8e5958e22ea76d4a1a64758) | `` update-scripts: get nixpkgs using flak-compat ``                 |
| [`e385bec7`](https://github.com/nix-community/nixvim/commit/e385bec735ea03d2e009cde443cf77f3d0aea40e) | `` contributing: add note on testing the docs ``                    |
| [`1ff5e1a3`](https://github.com/nix-community/nixvim/commit/1ff5e1a33b12dfe939ff7ddc5fbe881c28ec7b78) | `` docs/server: open browser using xdg-open ``                      |
| [`601d4309`](https://github.com/nix-community/nixvim/commit/601d4309ed6450b19e146e8896da534ba175007b) | `` docs/server: print the URL once serving ``                       |
| [`f3342bdb`](https://github.com/nix-community/nixvim/commit/f3342bdbd42488148cbf77226b2c915546653ffb) | `` docs: refactor `serve-docs`; add `nix run .#docs` ``             |
| [`5c49988a`](https://github.com/nix-community/nixvim/commit/5c49988a7c49785ca5bd4be317a8954636e079d5) | `` flake/dev/flake.lock: Update ``                                  |
| [`b288a5ff`](https://github.com/nix-community/nixvim/commit/b288a5ff894a2b3dcf9fdb153ad9cbd1a80efa98) | `` flake/dev/flake.lock: Update ``                                  |
| [`3713ef9e`](https://github.com/nix-community/nixvim/commit/3713ef9e61c407305b2d2e0ec43cabfb8c3ff1d9) | `` flake.lock: Update ``                                            |