### PR TITLE
chore(flake/nixvim): `46fd0b18` -> `2f610f97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1747945641,
-        "narHash": "sha256-Ts16c+kptbC3YDwPcB/NqXFVMHPNYKeFD7LkiawbWCU=",
+        "lastModified": 1748034126,
+        "narHash": "sha256-7nPv+Qi3PKxgeE4i9c4ErMCaBjVhnVYEzDmWA+8Kalw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "46fd0b184cbc5f1bdc5a8325cb973fc54e49ab68",
+        "rev": "2f610f97541a9cdebcdb485fe8f41e09bd46420d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`2f610f97`](https://github.com/nix-community/nixvim/commit/2f610f97541a9cdebcdb485fe8f41e09bd46420d) | `` maintaining: initial "Releasing" section ``   |
| [`1350e87f`](https://github.com/nix-community/nixvim/commit/1350e87fa4d8801183fed2f2c3e9f001fc320fe7) | `` maintaining: add sub "Deprecation" section `` |
| [`f39dd428`](https://github.com/nix-community/nixvim/commit/f39dd428240174bc1d2cbdd07eceebff7c652c03) | `` maintaining: init ``                          |
| [`e3f4a57f`](https://github.com/nix-community/nixvim/commit/e3f4a57fb81644cdf71d334760b5713db168145a) | `` docs/mdbook: install directly to `$out` ``    |
| [`4dc8d1e9`](https://github.com/nix-community/nixvim/commit/4dc8d1e9186d7608545b39e49d64b7ccfaba60dc) | `` plugins/vim-test: init ``                     |
| [`c457fe94`](https://github.com/nix-community/nixvim/commit/c457fe942474c6888639c432a05f7cf200454d15) | `` plugins/dbee: init ``                         |
| [`d88fde18`](https://github.com/nix-community/nixvim/commit/d88fde1899c3bc2a254797e3e373ce23e93705e6) | `` ci/update-other: trigger updates for 25.05 `` |
| [`ad7e489a`](https://github.com/nix-community/nixvim/commit/ad7e489aa103e8b16ed63eb5318b9914e5ae3bdb) | `` ci/update: use nix-community GitHub App ``    |
| [`fb2d007f`](https://github.com/nix-community/nixvim/commit/fb2d007f95efd9b73bd14458b08bf4afcfc9681a) | `` ci/update-other: don't run on forks ``        |
| [`73c1a755`](https://github.com/nix-community/nixvim/commit/73c1a755f0ac6d09d312daffd13c1ce6572d6fe5) | `` flake/dev/new-plugin: add missing ';' ``      |
| [`380aabb9`](https://github.com/nix-community/nixvim/commit/380aabb981a9307c3236cf43442e0ae3b2950698) | `` flake/dev/flake.lock: Update ``               |
| [`d061f33d`](https://github.com/nix-community/nixvim/commit/d061f33d328c707fa628915c6c988c3b5a0c54da) | `` flake.lock: Update ``                         |