### PR TITLE
chore(flake/nixvim): `2f610f97` -> `2c0a9ff1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1748034126,
-        "narHash": "sha256-7nPv+Qi3PKxgeE4i9c4ErMCaBjVhnVYEzDmWA+8Kalw=",
+        "lastModified": 1748088865,
+        "narHash": "sha256-xfAT2ykSAWcYgxkyZN5n6xRHab93u56zbBjuhoDFKFg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2f610f97541a9cdebcdb485fe8f41e09bd46420d",
+        "rev": "2c0a9ff1e2bcc6aab15caa504a7c9670f6e0a929",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`2c0a9ff1`](https://github.com/nix-community/nixvim/commit/2c0a9ff1e2bcc6aab15caa504a7c9670f6e0a929) | `` flake/dev/flake.lock: Update ``                            |
| [`5a07d9e5`](https://github.com/nix-community/nixvim/commit/5a07d9e5fdc7bff03166ad6f5f1ba3302b7870a2) | `` flake.lock: Update ``                                      |
| [`764a9b8d`](https://github.com/nix-community/nixvim/commit/764a9b8ddafcff877be16908447b7bd84204cca6) | `` treewide: replace mentions of 24.11 with 25.05 ``          |
| [`f80d8d59`](https://github.com/nix-community/nixvim/commit/f80d8d5907f9b22dc5e35fb8e44c772a35e81a19) | `` ci/docs: build documentation for the nixos-25.05 branch `` |