### PR TITLE
chore(flake/nixvim): `2c0a9ff1` -> `b37d4294`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1748088865,
-        "narHash": "sha256-xfAT2ykSAWcYgxkyZN5n6xRHab93u56zbBjuhoDFKFg=",
+        "lastModified": 1748197130,
+        "narHash": "sha256-WkUknPbMYFeusz3GKkhnklGF0r9bz4Z4bpU8h0t1Ddc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2c0a9ff1e2bcc6aab15caa504a7c9670f6e0a929",
+        "rev": "b37d429468c1f5133743e967caf97d92dc35ef5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`b37d4294`](https://github.com/nix-community/nixvim/commit/b37d429468c1f5133743e967caf97d92dc35ef5b) | `` flake/wrappers: Deprecate homeManagerModules output `` |
| [`e4a27ae8`](https://github.com/nix-community/nixvim/commit/e4a27ae810e7efdc2a0d626cf46f027b53daa34f) | `` flake/wrappers: Make homeModules the canonical name `` |
| [`c10f60d0`](https://github.com/nix-community/nixvim/commit/c10f60d007ead7909d3ceb98b3a9aaa88ea9491b) | `` Migrate homeManagerModules uses to homeModules ``      |
| [`c1a14f8f`](https://github.com/nix-community/nixvim/commit/c1a14f8f5cbeaf14773c5ca148e5851776c111d7) | `` flake/wrappers: Add homeModules flake output ``        |
| [`1c5c991f`](https://github.com/nix-community/nixvim/commit/1c5c991fda4519db56c30c9d75ba29ba7097af83) | `` modules/lsp/servers: Fix lua_ls example ``             |
| [`f54941e3`](https://github.com/nix-community/nixvim/commit/f54941e333ea2afd0b03ba09f5cb90bb1c6f8130) | `` flake/dev/flake.lock: Update ``                        |