### PR TITLE
chore(flake/nixvim): `91ee94cd` -> `65b1bffd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1748261770,
-        "narHash": "sha256-X+QUzjjZ64lZzzd1dkxIGoLHkJvmDqoEHhx81Mmx0rw=",
+        "lastModified": 1748348238,
+        "narHash": "sha256-etRxo4m9zbKuZbb1Tjt20mab7hc9bQGIlm+U5X4sctc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "91ee94cde3d5fdde68550ac861fd0644ff47109f",
+        "rev": "65b1bffd3d36e9392083c6efcf2e087921afa86e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`65b1bffd`](https://github.com/nix-community/nixvim/commit/65b1bffd3d36e9392083c6efcf2e087921afa86e) | `` flake/dev/flake.lock: Update `` |
| [`4876c32a`](https://github.com/nix-community/nixvim/commit/4876c32a4f99fff883c68ca8876684289b906864) | `` flake.lock: Update ``           |