### PR TITLE
chore(flake/nixvim): `65b1bffd` -> `af5a0dea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1748348238,
-        "narHash": "sha256-etRxo4m9zbKuZbb1Tjt20mab7hc9bQGIlm+U5X4sctc=",
+        "lastModified": 1748460828,
+        "narHash": "sha256-XAxZ0fpfgMk6ZEsbccnSSUs4aSEseeG2cJsdzcEgHr0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "65b1bffd3d36e9392083c6efcf2e087921afa86e",
+        "rev": "af5a0deaddb54e7b2a787dca6d43724dd103945a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`af5a0dea`](https://github.com/nix-community/nixvim/commit/af5a0deaddb54e7b2a787dca6d43724dd103945a) | `` tests/openscad: disable on darwin (broken dependency) `` |
| [`138dd37c`](https://github.com/nix-community/nixvim/commit/138dd37c1fe61f7414f81aa9126e7039cce4f124) | `` flake/dev/flake.lock: Update ``                          |
| [`2bd55f13`](https://github.com/nix-community/nixvim/commit/2bd55f130ab7563890a3b7236213b6fdfe3a29a7) | `` flake.lock: Update ``                                    |