### PR TITLE
chore(flake/nixvim): `af5a0dea` -> `a9e45072`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1748460828,
-        "narHash": "sha256-XAxZ0fpfgMk6ZEsbccnSSUs4aSEseeG2cJsdzcEgHr0=",
+        "lastModified": 1748521000,
+        "narHash": "sha256-EnXH5PIrZBoe8U09hPQr2kOuPTZSqAJy78DqUVLmWXg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "af5a0deaddb54e7b2a787dca6d43724dd103945a",
+        "rev": "a9e45072d82374dd3f0d971795e7d7f99e5bc6c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`a9e45072`](https://github.com/nix-community/nixvim/commit/a9e45072d82374dd3f0d971795e7d7f99e5bc6c2) | `` flake/dev/flake.lock: Update ``              |
| [`1610b11b`](https://github.com/nix-community/nixvim/commit/1610b11b4775704fb7b6351dc095361079e624df) | `` flake.lock: Update ``                        |
| [`28a2abf8`](https://github.com/nix-community/nixvim/commit/28a2abf874c3ecbbf91edf1b2b9fe595f0f54099) | `` docs/server: simplify using `http-server` `` |