### PR TITLE
chore(flake/nixvim): `d063d0dd` -> `9328f443`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1748884506,
-        "narHash": "sha256-P/ldKE0SCGKH6pEVJoW2MJJo2dZCZe10d/h1ree66c0=",
+        "lastModified": 1748942960,
+        "narHash": "sha256-gJf3WxvDbvCpzIBVju/5GY/olW7zs/B1zDmB52AWMUM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d063d0dd5e0b82d8be4dd4bc00b887ac1f92e4b2",
+        "rev": "9328f4437d5f788d1c066b274a0aea492dc5fde2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`9328f443`](https://github.com/nix-community/nixvim/commit/9328f4437d5f788d1c066b274a0aea492dc5fde2) | `` update-scripts/version-info: get channel status for supported versions `` |
| [`a95db128`](https://github.com/nix-community/nixvim/commit/a95db128a65d2e4991c815d2f9d9d1620c5e383b) | `` update-scripts/version-info: convert to a script ``                       |
| [`80934be3`](https://github.com/nix-community/nixvim/commit/80934be3e934769249b9e6afcec31604f5426d9c) | `` ci/update: fix how 're-apply' finds the 'base' commit ``                  |
| [`2d60548a`](https://github.com/nix-community/nixvim/commit/2d60548ab1bd73490ab63f12aef16c4e4777b932) | `` ci/update: cleanup how we get nixvim-ci's user-info ``                    |