### PR TITLE
chore(flake/nixvim): `9328f443` -> `1d872414`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1748942960,
-        "narHash": "sha256-gJf3WxvDbvCpzIBVju/5GY/olW7zs/B1zDmB52AWMUM=",
+        "lastModified": 1749028068,
+        "narHash": "sha256-ebxyRA7rK6Jb3eXvz+0QcyKLHzUnUQWRFDbKleLdLZ8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "9328f4437d5f788d1c066b274a0aea492dc5fde2",
+        "rev": "1d8724144cef98dad6638e0b6333cc84d0b2f5c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`1d872414`](https://github.com/nix-community/nixvim/commit/1d8724144cef98dad6638e0b6333cc84d0b2f5c3) | `` lib/options: add TODO regarding `lua-types` `` |
| [`57b61e42`](https://github.com/nix-community/nixvim/commit/57b61e4267d33cb34115dd531c4a49d13cc63733) | `` lib/lua-types: init ``                         |