### PR TITLE
chore(flake/nixvim): `1d872414` -> `635a9e77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1749028068,
-        "narHash": "sha256-ebxyRA7rK6Jb3eXvz+0QcyKLHzUnUQWRFDbKleLdLZ8=",
+        "lastModified": 1749107808,
+        "narHash": "sha256-ohLHvWmAuH4aHOCAGP1UlwRRxX21/eW+N2e7eB0kQeo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1d8724144cef98dad6638e0b6333cc84d0b2f5c3",
+        "rev": "635a9e770f77a7c586c60f84b1debf054318034a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`635a9e77`](https://github.com/nix-community/nixvim/commit/635a9e770f77a7c586c60f84b1debf054318034a) | `` ci/flakestry-publish-rolling: add workflow name ``                                 |
| [`3085f864`](https://github.com/nix-community/nixvim/commit/3085f8647346fbf0616d7d699b2cc83318795201) | `` ci/flakehub-publish-rolling: use context for repo name ``                          |
| [`64dea700`](https://github.com/nix-community/nixvim/commit/64dea7008f5f0b36451884fbf6c8201234b2b94f) | `` ci: check repo before running publish jobs ``                                      |
| [`60f1c852`](https://github.com/nix-community/nixvim/commit/60f1c852377e617668bb2669056969bf896e8300) | `` plugins/treesitter: prevent mkRaw over-injection by removing injection.combined `` |