### PR TITLE
chore(flake/nixvim): `635a9e77` -> `00524c79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1749107808,
-        "narHash": "sha256-ohLHvWmAuH4aHOCAGP1UlwRRxX21/eW+N2e7eB0kQeo=",
+        "lastModified": 1749200997,
+        "narHash": "sha256-In+NjXI8kfJpamTmtytt+rnBzQ213Y9KW55IXvAAK/4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "635a9e770f77a7c586c60f84b1debf054318034a",
+        "rev": "00524c7935f05606fd1b09e8700e9abcc4af7be8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`00524c79`](https://github.com/nix-community/nixvim/commit/00524c7935f05606fd1b09e8700e9abcc4af7be8) | `` update-scripts/update: fix 'has changed' condition when not committing `` |
| [`743e7774`](https://github.com/nix-community/nixvim/commit/743e7774849c1eefe11cf56e36e15f69606d974d) | `` update-scripts/update: fix call to `version-info` ``                      |