### PR TITLE
chore(flake/nixvim): `2b6f694b` -> `e0b3d8bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1749420898,
-        "narHash": "sha256-QiB3xDyHuj2VzS6AaALTeikLt6EsZyMjDRmzb4y2vFM=",
+        "lastModified": 1749496904,
+        "narHash": "sha256-eNDMzrcDBOprdJs7DpMOJfCEcxribxDJP2OjozSC3Wo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2b6f694b48f43bbd89dcc21e8aa7aa676eb18eb8",
+        "rev": "e0b3d8bc3a0ab5a7cc0792c7705e92f9c5c598f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`e0b3d8bc`](https://github.com/nix-community/nixvim/commit/e0b3d8bc3a0ab5a7cc0792c7705e92f9c5c598f3) | `` plugins/kitty-navigator: init `` |
| [`73417a76`](https://github.com/nix-community/nixvim/commit/73417a761ec28e6f30d4c3cfc469da9d0ab3140a) | `` plugins/ansiesc: init ``         |