### PR TITLE
chore(flake/nixvim): `e0b3d8bc` -> `1b08a4d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1749496904,
-        "narHash": "sha256-eNDMzrcDBOprdJs7DpMOJfCEcxribxDJP2OjozSC3Wo=",
+        "lastModified": 1749685505,
+        "narHash": "sha256-qAyDUuYvVoSl4hAq3Ho8vTKG/ms7i7qx+8jqS6beUuw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e0b3d8bc3a0ab5a7cc0792c7705e92f9c5c598f3",
+        "rev": "1b08a4d97632a8c3500469ae7e2db91769425ddf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`1b08a4d9`](https://github.com/nix-community/nixvim/commit/1b08a4d97632a8c3500469ae7e2db91769425ddf) | `` lib/builders: pass text as file ``                         |
| [`64f0d3c8`](https://github.com/nix-community/nixvim/commit/64f0d3c86a7894cad9b09bb1015375ffb9949d70) | `` ci/mergify: drop ``                                        |
| [`45441d87`](https://github.com/nix-community/nixvim/commit/45441d876c061048ad00960127ec857e05153244) | `` dev/tests: run tests in groups ``                          |
| [`46ad5ec0`](https://github.com/nix-community/nixvim/commit/46ad5ec05c7e224c85096f5bac8344883b255e79) | `` user-configs: add @wverac's config ``                      |
| [`d025ea6b`](https://github.com/nix-community/nixvim/commit/d025ea6be35f002a10ac7e286b6d821cf83b4084) | `` tests/easy-dotnet: dont run nvim ``                        |
| [`6e8d9f84`](https://github.com/nix-community/nixvim/commit/6e8d9f84b8acc940aafa0b557a5cc64d9324ee11) | `` plugins/avante: providers migration ``                     |
| [`e89eb154`](https://github.com/nix-community/nixvim/commit/e89eb154566a8ce48e3fd4e9402881c22f5c0fba) | `` tests/parrot: do not run nvim as it requires an api_key `` |
| [`14347a61`](https://github.com/nix-community/nixvim/commit/14347a615eb225487475bea9d2051f9cde4c9ddc) | `` generated: Updated rust-analyzer.nix ``                    |
| [`2c6f148d`](https://github.com/nix-community/nixvim/commit/2c6f148ddc33f832b9d4c020a1605464b11fbe37) | `` flake/dev/flake.lock: Update ``                            |
| [`235d20db`](https://github.com/nix-community/nixvim/commit/235d20db0c05b7207ecae667bf455b79d1e56cc4) | `` flake.lock: Update ``                                      |
| [`7eb08d84`](https://github.com/nix-community/nixvim/commit/7eb08d84a839bbda9aa30c3dd6f15865728755aa) | `` add @XhuyZ config ``                                       |