### PR TITLE
chore(flake/nixvim): `1b08a4d9` -> `18d838e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1749685505,
-        "narHash": "sha256-qAyDUuYvVoSl4hAq3Ho8vTKG/ms7i7qx+8jqS6beUuw=",
+        "lastModified": 1749761870,
+        "narHash": "sha256-y+rCuxTylur4k2MbL8cJwOR3pHIamCxp8xG9Vuhwvgw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1b08a4d97632a8c3500469ae7e2db91769425ddf",
+        "rev": "18d838e88945b554d059db5f1fff1daed4b7bf8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`18d838e8`](https://github.com/nix-community/nixvim/commit/18d838e88945b554d059db5f1fff1daed4b7bf8f) | `` ci/update-other: disable `fail-fast` matrix strategy ``        |
| [`d9a4a56d`](https://github.com/nix-community/nixvim/commit/d9a4a56dcf78efee85bc670efe10f55ce9decd44) | `` ci/update-other: generate branch list from version-info ``     |
| [`7e02029a`](https://github.com/nix-community/nixvim/commit/7e02029af60a5aa1877e7c26e30e6198555e0652) | `` ci/update-other: move branch list to a prepare job ``          |
| [`b5e0ed67`](https://github.com/nix-community/nixvim/commit/b5e0ed67fea1c715748f668c3312df7a2fead328) | `` ci/update-other: explicitly set `contents: read` permission `` |
| [`7f10688f`](https://github.com/nix-community/nixvim/commit/7f10688fe153f6d8b8ccf9854fea047f4c9ec955) | `` ci/update-other: tweak names ``                                |
| [`1b02a2eb`](https://github.com/nix-community/nixvim/commit/1b02a2eb86f5294e3442ee852c9f6fbefa53505f) | `` ci/update-other: run on ARM ``                                 |