### PR TITLE
chore(flake/nixvim): `18d838e8` -> `e114d442`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1749761870,
-        "narHash": "sha256-y+rCuxTylur4k2MbL8cJwOR3pHIamCxp8xG9Vuhwvgw=",
+        "lastModified": 1749924512,
+        "narHash": "sha256-IYv0yEFh86c+UnkcjrUAV0UeIE+9vMEeXDIF+YRlooc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "18d838e88945b554d059db5f1fff1daed4b7bf8f",
+        "rev": "e114d442b14f3a299307ca9b0f0eab20e821f419",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`e114d442`](https://github.com/nix-community/nixvim/commit/e114d442b14f3a299307ca9b0f0eab20e821f419) | `` flake/dev/flake.lock: Update `` |
| [`eb727ef0`](https://github.com/nix-community/nixvim/commit/eb727ef065fe0cc2838946c9109ab46767d71af0) | `` flake.lock: Update ``           |