### PR TITLE
chore(flake/nixvim): `7176d51a` -> `ab0a3682`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1750022650,
-        "narHash": "sha256-Dllcid/yOQYlsvy+Fne3JvGq85CAHpKkiLfh9wSMPrM=",
+        "lastModified": 1750105753,
+        "narHash": "sha256-reWddMyGkxjackE4VSZ2NjOQlAdfiofhCEWFHapblNI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7176d51a343c642d4cc6c4ac3f547b54850b0e82",
+        "rev": "ab0a3682cc40da89029dcb3f467b46ae3b8c0fd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`ab0a3682`](https://github.com/nix-community/nixvim/commit/ab0a3682cc40da89029dcb3f467b46ae3b8c0fd1) | `` ci/docs: use `version-info.toml` ``         |
| [`6a054de0`](https://github.com/nix-community/nixvim/commit/6a054de04dd2b0a3cc5fed1adab8e9f76c050b45) | `` plugins/lsp: add packageFallback option ``  |
| [`ee715541`](https://github.com/nix-community/nixvim/commit/ee715541ab343046a0ebc6ed88b7166bf6888d9c) | `` plugins/actions-preview: add description `` |
| [`831b503f`](https://github.com/nix-community/nixvim/commit/831b503f114c12b55197547ce1c379f67d0768b6) | `` flake/dev/flake.lock: Update ``             |
| [`95957f30`](https://github.com/nix-community/nixvim/commit/95957f306bf6d8e40f62fd0062cf326436bf011d) | `` ci/docs: fix build ref ``                   |