### PR TITLE
chore(flake/nixpkgs): `ee930f97` -> `9e83b64f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749794982,
-        "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
+        "lastModified": 1750134718,
+        "narHash": "sha256-v263g4GbxXv87hMXMCpjkIxd/viIF7p3JpJrwgKdNiI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ee930f9755f58096ac6e8ca94a1887e0534e2d81",
+        "rev": "9e83b64f727c88a7711a2c463a7b16eedb69a84c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`15b96b38`](https://github.com/NixOS/nixpkgs/commit/15b96b3890528c7e0f325ab08485732b4ed4099e) | `` nezha-theme-admin: 1.12.0 -> 1.13.0 ``                                           |
| [`6dbf9151`](https://github.com/NixOS/nixpkgs/commit/6dbf9151f2987663d0cddb4d7bc6639bab6fa078) | `` telegraf: 1.34.4 -> 1.35.0 ``                                                    |
| [`9ed0d855`](https://github.com/NixOS/nixpkgs/commit/9ed0d85541f06b2a8a4a0cefc673643d4fb31282) | `` sarabun-font: version prefix 0 ``                                                |
| [`939e7073`](https://github.com/NixOS/nixpkgs/commit/939e7073d3de41207f79c5d408c4478550454fee) | `` sqlitestudio: specify the license more precisely as gpl3only rather than gpl3 `` |
| [`c595023b`](https://github.com/NixOS/nixpkgs/commit/c595023bee8ec5df55d0a67ba51d41515cd48970) | `` sqlitestudio: include official plugins ``                                        |
| [`58cbbb74`](https://github.com/NixOS/nixpkgs/commit/58cbbb74136947b8079e687bfc67dd0abaf8b11d) | `` sqlitestudio-plugins: init at 3.4.17 ``                                          |
| [`5c799d4b`](https://github.com/NixOS/nixpkgs/commit/5c799d4b3abacca61e07eebf8b1788bde9a74ee8) | `` mark: 12.2.0 -> 14.0.4 (#417215) ``                                              |
| [`c191e958`](https://github.com/NixOS/nixpkgs/commit/c191e958f2b40808b82d48be76c422c0bd864106) | `` libpromhttp: drop ``                                                             |
| [`dbec3661`](https://github.com/NixOS/nixpkgs/commit/dbec366183a86892e34be0550ad884a5c6864958) | `` albyhub:`rec` -> `finalAttrs` ``                                                 |
| [`ffb1eb55`](https://github.com/NixOS/nixpkgs/commit/ffb1eb55aeda38eec3608dfa8b623798d38fad04) | `` python313Packages.pyside6-fluent-widgets: init at 1.8.1 ``                       |
| [`58ba1841`](https://github.com/NixOS/nixpkgs/commit/58ba1841982939d6d62bd50627916b3e863ff00f) | `` python313Packages.pysidesix-frameless-window: init at 0.7.3 ``                   |
| [`eb20c231`](https://github.com/NixOS/nixpkgs/commit/eb20c2314c63a6c8a2407c18b5db4a2ea8dec69e) | `` kamal: init at 2.5.3 ``                                                          |
| [`31c4138c`](https://github.com/NixOS/nixpkgs/commit/31c4138c1644720077f1a1c16428fac7f75b4ee9) | `` labwc-tweaks-gtk: 0-unstable-2025-04-01 -> 0-unstable-2025-06-14 ``              |
| [`5b0d385d`](https://github.com/NixOS/nixpkgs/commit/5b0d385d5744bb7b0aff55d04a6bc0090cc8d87f) | `` terraform-providers.migadu: 2025.5.22 -> 2025.6.12 ``                            |
| [`97928c45`](https://github.com/NixOS/nixpkgs/commit/97928c45678444da701b20feac4d023619f4097b) | `` python3Packages.hf-xet: 1.1.3 -> 1.1.4 ``                                        |
| [`b3726e41`](https://github.com/NixOS/nixpkgs/commit/b3726e412a2a11efd8de8ed4387ac2054a1d6c02) | `` python3Packages.google-cloud-trace: 1.16.1 -> 1.16.2 ``                          |
| [`6bae7aae`](https://github.com/NixOS/nixpkgs/commit/6bae7aae516814d99d6b3b67348c92ccb88f85f9) | `` chglog: 0.7.0 -> 0.7.3 ``                                                        |
| [`6a1f1556`](https://github.com/NixOS/nixpkgs/commit/6a1f1556a32b5dc5ba88c740f231a808451de3b0) | `` glooctl: 1.18.17 -> 1.19.0 ``                                                    |
| [`983f0c51`](https://github.com/NixOS/nixpkgs/commit/983f0c514503124048994ccaf11d809f89bbe6d5) | `` home-assistant-custom-lovelace-modules.sankey-chart: 3.8.1 -> 3.9.0 (#417340) `` |
| [`c278dfd3`](https://github.com/NixOS/nixpkgs/commit/c278dfd3e770e97bc5448be9dd253cff9c3455cf) | `` unityhub: add missing dependencies for font rendering ``                         |
| [`ec556edd`](https://github.com/NixOS/nixpkgs/commit/ec556edd9d2b27b49052274657bb7660be6a2db2) | `` surrealdb: 2.3.3 -> 2.3.4 ``                                                     |
| [`38a4f597`](https://github.com/NixOS/nixpkgs/commit/38a4f5971d87975a84f61fb97fb6d1ed944360bd) | `` python313Packages.pybotvac: 0.0.27 -> 0.0.28 ``                                  |
| [`0b2ed99a`](https://github.com/NixOS/nixpkgs/commit/0b2ed99afc970a4d369d07e7139a6208b1aa0592) | `` python313Packages.mcpadapt: 0.1.9 -> 0.1.10 ``                                   |
| [`348d33d0`](https://github.com/NixOS/nixpkgs/commit/348d33d018c66269538e0d671908a5e824ea8dae) | `` cdncheck: 1.1.22 -> 1.1.23 ``                                                    |
| [`7a80d207`](https://github.com/NixOS/nixpkgs/commit/7a80d20772be4c738bb0dcb577b60cebcac3090c) | `` checkov: 3.2.441 -> 3.2.442 ``                                                   |
| [`02f4cb45`](https://github.com/NixOS/nixpkgs/commit/02f4cb452d1c3798df29f229131997d13590ef6b) | `` python313Packages.tencentcloud-sdk-python: 3.0.1400 -> 3.0.1401 ``               |
| [`543b0048`](https://github.com/NixOS/nixpkgs/commit/543b004806947ce8c1f3db19ca4158d5cfc43e3a) | `` exploitdb: 2025-06-10 -> 2025-06-14 ``                                           |
| [`38768420`](https://github.com/NixOS/nixpkgs/commit/38768420c22a0e8f58f8c786b7cbe84378305683) | `` python3Packages.ical: 10.0.1 -> 10.0.3 ``                                        |
| [`f2ebc969`](https://github.com/NixOS/nixpkgs/commit/f2ebc9699208704893dd5a74e754be14fe41c63f) | `` exploitdb: 2025-06-06 -> 2025-06-10 ``                                           |
| [`ffcb49ce`](https://github.com/NixOS/nixpkgs/commit/ffcb49cecba7c2ed7dcb206aa7bef24740b5c4a4) | `` python3Packages.duckduckgo-search: 8.0.2 -> 8.0.4 ``                             |
| [`68358a82`](https://github.com/NixOS/nixpkgs/commit/68358a8275d00d6f723f5ebf0a948b91bce46ccd) | `` terraform-providers.huaweicloud: 1.74.1 -> 1.75.3 ``                             |
| [`b4286452`](https://github.com/NixOS/nixpkgs/commit/b4286452f20ef8fe7ead614963f08ad79305fc1b) | `` python3Packages.bagit: 1.9b2 -> 1.9.0 ``                                         |
| [`5346da3f`](https://github.com/NixOS/nixpkgs/commit/5346da3f5005a1a93d628f57cc0f40a1441c9319) | `` python3Packages.google-cloud-tasks: 2.19.2 -> 2.19.3 ``                          |
| [`bcebb4f7`](https://github.com/NixOS/nixpkgs/commit/bcebb4f77218c1e2f841ecbe5754deca2c1f716b) | `` azahar: 2121.2 -> 2122 ``                                                        |
| [`6b20615e`](https://github.com/NixOS/nixpkgs/commit/6b20615eb927f7a381c0f6504fad2fb25214e511) | `` fwup: 1.12.0 -> 1.13.0 ``                                                        |
| [`9568033b`](https://github.com/NixOS/nixpkgs/commit/9568033b5a89b4a6e554897b1a634d8020ef70a2) | `` python3Packages.pymorphy3: 2.0.3 -> 2.0.4 ``                                     |
| [`77e7c3dc`](https://github.com/NixOS/nixpkgs/commit/77e7c3dc942fa38b39e6a0a56fb0a926376390fc) | `` gql: 0.38.0 -> 0.39.0 ``                                                         |
| [`48ad36a6`](https://github.com/NixOS/nixpkgs/commit/48ad36a650a4d39fc7ac2e14e16b86eb0fa551b1) | `` eigenlayer: 0.11.2 -> 0.13.1 ``                                                  |
| [`18a16852`](https://github.com/NixOS/nixpkgs/commit/18a168521e3396289789f54152e8f41613b8d4b6) | `` openomf: 0.8.2 -> 0.8.3 ``                                                       |
| [`2803234b`](https://github.com/NixOS/nixpkgs/commit/2803234b39a4fa4f08b62ef9b7f10d98c3eeae0a) | `` mdbook-admonish: 1.19.0 -> 1.20.0 ``                                             |
| [`9864f075`](https://github.com/NixOS/nixpkgs/commit/9864f075695cf338c7a62df910de1bcf6c2f6f6a) | `` omekasy: 1.3.1 -> 1.3.3 ``                                                       |
| [`45fa473b`](https://github.com/NixOS/nixpkgs/commit/45fa473b3c70f80c476b8c5409e7ef934481c570) | `` hawkeye: 6.0.4 -> 6.1.1 ``                                                       |
| [`26b303bf`](https://github.com/NixOS/nixpkgs/commit/26b303bffdde096f52a4a4cfc7be15a92e16fc2f) | `` svix-server: 1.66.0 -> 1.67.0 ``                                                 |
| [`cf25a001`](https://github.com/NixOS/nixpkgs/commit/cf25a0014a45f551fa93752e9389dace663e8598) | `` fedigroups: 0.4.5 -> 0.4.6 ``                                                    |
| [`06c6ed65`](https://github.com/NixOS/nixpkgs/commit/06c6ed653bf727ddfa7df949530deacd88b1c9b8) | `` vscode-extensions.shopify.ruby-lsp: 0.9.26 -> 0.9.28 ``                          |
| [`d8f9a63b`](https://github.com/NixOS/nixpkgs/commit/d8f9a63b9c258f09324a44b0fb6b4125b6ac49b5) | `` kubectl-view-allocations: 0.21.2 -> 0.22.0 ``                                    |
| [`de01c869`](https://github.com/NixOS/nixpkgs/commit/de01c86993b1c2bf09ba039060fcef4c25b14168) | `` mihomo-party: use finalAttrs ``                                                  |