### PR TITLE
chore(flake/nixpkgs): `9e83b64f` -> `4b1164c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750134718,
-        "narHash": "sha256-v263g4GbxXv87hMXMCpjkIxd/viIF7p3JpJrwgKdNiI=",
+        "lastModified": 1750741721,
+        "narHash": "sha256-Z0djmTa1YmnGMfE9jEe05oO4zggjDmxOGKwt844bUhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9e83b64f727c88a7711a2c463a7b16eedb69a84c",
+        "rev": "4b1164c3215f018c4442463a27689d973cffd750",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`52361281`](https://github.com/NixOS/nixpkgs/commit/523612816bda21e78f190356459387d9d0a99e24) | `` az-pim-cli: use versionCheckHook ``                                          |
| [`794e7a17`](https://github.com/NixOS/nixpkgs/commit/794e7a17c13f6bdc0e06020949cd22e0ab433871) | `` gh: 2.74.1 -> 2.74.2 ``                                                      |
| [`c7aef91f`](https://github.com/NixOS/nixpkgs/commit/c7aef91feb8aa82f5d3ff968fe17fe8cf2c403c6) | `` garage_0_x: disable tests ``                                                 |
| [`fcc7e04c`](https://github.com/NixOS/nixpkgs/commit/fcc7e04c6970b79b654b0ac23acd866936381720) | `` python312Packages.netbox-attachments: fix ``                                 |
| [`a0cf5b7d`](https://github.com/NixOS/nixpkgs/commit/a0cf5b7d10e8d3eb4f1ac5d108b69949a3f00e10) | `` python312Packages.netbox-contract: fix ``                                    |
| [`cd28da24`](https://github.com/NixOS/nixpkgs/commit/cd28da246134d66128e76ce2110aca72226a11e4) | `` python312Packages.netbox-floorplan-plugin: fix ``                            |
| [`3b51de60`](https://github.com/NixOS/nixpkgs/commit/3b51de60e99300e67722f21b15f9917d3bf8f9c3) | `` python312Packages.netbox-napalm-plugin: fix ``                               |
| [`86d9cfd5`](https://github.com/NixOS/nixpkgs/commit/86d9cfd59885ee9aef42296b9fdad1e0a1a410de) | `` python312Packages.netbox-topology-views: fix ``                              |
| [`fdb24670`](https://github.com/NixOS/nixpkgs/commit/fdb246701566109fbdea47a14c0b91482fc16087) | `` magento-cloud: use versionCheckHook ``                                       |
| [`aad68ab9`](https://github.com/NixOS/nixpkgs/commit/aad68ab9fbbe7da256c0b5979733869a4501f223) | `` python3Packages.gliner: 0.2.20 -> 0.2.21 ``                                  |
| [`bfefc8d2`](https://github.com/NixOS/nixpkgs/commit/bfefc8d2f32a4f9d60da1cec33f67d2957a42f6d) | `` gnat-bootstrap: remove ld binaries ``                                        |
| [`10a5a91b`](https://github.com/NixOS/nixpkgs/commit/10a5a91bc0a8093d22b2d7d8f696dd084ddf47ca) | `` vectorcode: add bundled chromadb to path ``                                  |
| [`5810a0aa`](https://github.com/NixOS/nixpkgs/commit/5810a0aaaa00c883ac81689d8bad30765f631858) | `` avrdude: 8.0 -> 8.1 ``                                                       |
| [`9d644e7e`](https://github.com/NixOS/nixpkgs/commit/9d644e7eedb4abfb24b34185f9c27bfd1a99fb6f) | `` qrencode: adopt, cleanup ``                                                  |
| [`8697db82`](https://github.com/NixOS/nixpkgs/commit/8697db8260ae53074d5837ccfe092a2cce3fab58) | `` circleci-cli: 0.1.32367 -> 0.1.32580 ``                                      |
| [`994be05a`](https://github.com/NixOS/nixpkgs/commit/994be05a7667876e58b69ec5122a878a50abd42d) | `` doppler: 3.75.0 -> 3.75.1 ``                                                 |
| [`bee4a14c`](https://github.com/NixOS/nixpkgs/commit/bee4a14cc7a78dff7d9457506f9ce3ece4ed5fbc) | `` diesel-cli: 2.2.10 -> 2.2.11 ``                                              |
| [`59eafaa9`](https://github.com/NixOS/nixpkgs/commit/59eafaa9409923969fc29204cddd1c0aa950513e) | `` mailutils: move to pkgs/by-name ``                                           |
| [`e2a57232`](https://github.com/NixOS/nixpkgs/commit/e2a57232aaa7a7ec4ec28dd7d23e8daa7110b9da) | `` mailutils: explicitly use gsasl ``                                           |
| [`66f7d2de`](https://github.com/NixOS/nixpkgs/commit/66f7d2de7441d4e17b751adc56d548c5800387ed) | `` mailutils: allow all hardening flags ``                                      |
| [`1fa31845`](https://github.com/NixOS/nixpkgs/commit/1fa3184541f146b0e32e664156306abd09f5d483) | `` mailutils: unpin guile ``                                                    |
| [`b298fd73`](https://github.com/NixOS/nixpkgs/commit/b298fd73d3c8e9067868070c4b0567db175d8764) | `` mailutils: remove crufty workarounds ``                                      |
| [`ead178c6`](https://github.com/NixOS/nixpkgs/commit/ead178c65449968cbb25816cfa542e5666adb1ff) | `` mailutils: modernize derivation ``                                           |
| [`caa29e79`](https://github.com/NixOS/nixpkgs/commit/caa29e794a70a12518ab3dc7506f3273272665b2) | `` mailutils: 3.18 -> 3.19 ``                                                   |
| [`79df31ad`](https://github.com/NixOS/nixpkgs/commit/79df31ad38c6ccbc024ad5558b7a895b056849b1) | `` python3Packages.pygmt: 0.15.0 -> 0.16.0 ``                                   |
| [`7884233b`](https://github.com/NixOS/nixpkgs/commit/7884233bbc571b2c8f24d5722e3c3f08411949e4) | `` gum: 0.16.1 -> 0.16.2 ``                                                     |
| [`e7fc9fbc`](https://github.com/NixOS/nixpkgs/commit/e7fc9fbca2599dc0889df574c4bdfdef23f176f2) | `` openfga: 1.8.15 -> 1.8.16 ``                                                 |
| [`f27fdfde`](https://github.com/NixOS/nixpkgs/commit/f27fdfdef425394b3a4a806d77edc19d29693689) | `` jumppad: 0.20.1 -> 0.21.0 ``                                                 |
| [`9eda4e04`](https://github.com/NixOS/nixpkgs/commit/9eda4e0497e24eea2c1481bdc5be3832c647d4f1) | `` dolt: 1.55.1 -> 1.55.2 ``                                                    |
| [`7676e88c`](https://github.com/NixOS/nixpkgs/commit/7676e88c94f4ec396bc025d9b90b8821d324cafd) | `` rasm: 2.3.6 -> 2.3.7 ``                                                      |
| [`b8b9cab6`](https://github.com/NixOS/nixpkgs/commit/b8b9cab64ec2cefb1b51d8e6b14eac6ea2b48616) | `` runme: 3.14.0 -> 3.14.1 ``                                                   |
| [`9fec8d17`](https://github.com/NixOS/nixpkgs/commit/9fec8d171986c464698849dfc56d67619484b17e) | `` python3Packages.openai: 1.87.0 -> 1.91.0 ``                                  |
| [`0449b4bd`](https://github.com/NixOS/nixpkgs/commit/0449b4bda4d91031193561d2a66c9fcc18c2ef02) | `` libxeddsa: 2.0.0 -> 2.0.1 ``                                                 |
| [`c841e4ba`](https://github.com/NixOS/nixpkgs/commit/c841e4ba74581a9a263a0bfb73b667435ea9b49e) | `` vectorcode: add python-dotenv to allow use with .env files ``                |
| [`5140786a`](https://github.com/NixOS/nixpkgs/commit/5140786aa0f86a93092c144a24fc6fbf93ab40c7) | `` seppo: init at 0-unstable-2025-06-03 ``                                      |
| [`f42e6417`](https://github.com/NixOS/nixpkgs/commit/f42e6417991a6aa331456bcc8b526d45f54adeff) | `` python3Packages.qdrant-client: 1.14.2 -> 1.14.3 ``                           |
| [`bee86124`](https://github.com/NixOS/nixpkgs/commit/bee861240dd68621cdb4b48321d45595854fd0dd) | `` dprint: prefer versionCheckHook ``                                           |
| [`ac8cc910`](https://github.com/NixOS/nixpkgs/commit/ac8cc9101171dfb12823352e7408d2e82ef77c3e) | `` lima: prefer versionCheckHook ``                                             |
| [`e0b5037a`](https://github.com/NixOS/nixpkgs/commit/e0b5037a58bd048e22750683800fc6073a2dde05) | `` home-assistant-custom-components.localtuya: 2025.5.1 -> 2025.6.0 ``          |
| [`2fcf435b`](https://github.com/NixOS/nixpkgs/commit/2fcf435b8854acd692467a4df39600aed7ba540c) | `` phpdocumentor: 3.7.1 -> 3.8.0 ``                                             |
| [`3597a760`](https://github.com/NixOS/nixpkgs/commit/3597a760ec0946022450a8eb97feb1af5f9d3660) | `` libretro.play: 0-unstable-2025-06-13 -> 0-unstable-2025-06-18 ``             |
| [`11491149`](https://github.com/NixOS/nixpkgs/commit/114911496ecb5e3b4d6d09a2e93a3b2721e43c41) | `` pykickstart: 3.64 -> 3.65 ``                                                 |
| [`a2b5af47`](https://github.com/NixOS/nixpkgs/commit/a2b5af4710f1f9011a1ac5896b396c39debda090) | `` limine-install: cleanup, improve type hinting (#416188) ``                   |
| [`8884e1b1`](https://github.com/NixOS/nixpkgs/commit/8884e1b147a1394a5c9b4cc5c3c3a48abd3fbe70) | `` nixos/plasma6: install ktexteditor explicitly ``                             |
| [`3d23a55d`](https://github.com/NixOS/nixpkgs/commit/3d23a55dbc341d0a324eb4003b6d6805b78b09cd) | `` python3Packages.fedora-messaging: 3.7.1 -> 3.8.0 ``                          |
| [`b850eb81`](https://github.com/NixOS/nixpkgs/commit/b850eb81e21438f79928e9ce62a17c948db22ee1) | `` buildstream: Add `buildbox` as a dependency ``                               |
| [`ed9275ad`](https://github.com/NixOS/nixpkgs/commit/ed9275adcb12a840e50a2afec72df2655b440c1f) | `` python3Packages.uiprotect: 7.13.0 -> 7.14.1 (#419323) ``                     |
| [`de22d88a`](https://github.com/NixOS/nixpkgs/commit/de22d88acafc95e7d586b9c998485d51c4a8937f) | `` waybar: 0.12.0-unstable-2025-06-13 -> 0.13.0 ``                              |
| [`aa3ffdc2`](https://github.com/NixOS/nixpkgs/commit/aa3ffdc2f9c932508fc2a91bf861ce4eb6465107) | `` phpunit: 12.2.2 -> 12.2.3 ``                                                 |
| [`687ce946`](https://github.com/NixOS/nixpkgs/commit/687ce9463bc21af5abf2ba88bec657fb9a6834ec) | `` ghostfolio: 2.170.0 -> 2.173.0 ``                                            |
| [`177f922f`](https://github.com/NixOS/nixpkgs/commit/177f922fcc427f67a7e8f16a0634f235dc30f6ee) | `` memray: skip failing tests ``                                                |
| [`aed02e7a`](https://github.com/NixOS/nixpkgs/commit/aed02e7af1bc3073f8e5baa8c01d729c290e12ae) | `` python3Packages.textual: 3.4.0 -> 3.5.0 ``                                   |
| [`0480b545`](https://github.com/NixOS/nixpkgs/commit/0480b545101520d4d37ccbb64683968d9332f500) | `` quodlibet: clean up derivation ``                                            |
| [`c9bd45f6`](https://github.com/NixOS/nixpkgs/commit/c9bd45f6dc65f0005f9632d3bc367b82e9ce3f41) | `` quodlibet: 4.6.0-unstable-2024-08-08 -> 4.7.1 ``                             |
| [`f31b7313`](https://github.com/NixOS/nixpkgs/commit/f31b7313b87edfc41052635334525d1a65411460) | `` libcosmicAppHook: Fix cross-compilation ``                                   |
| [`7aa3d675`](https://github.com/NixOS/nixpkgs/commit/7aa3d675200b7eb3914ae39ec19ccf4340f67134) | `` taterclient-ddnet: 10.3.0 -> 10.4.0 ``                                       |
| [`00734170`](https://github.com/NixOS/nixpkgs/commit/00734170e272760a1d9adc182180ac19a77dc2fa) | `` python3Packages.dvc-s3: 3.2.1 -> 3.2.2 ``                                    |
| [`3e03b7bc`](https://github.com/NixOS/nixpkgs/commit/3e03b7bcc55e3fc8874c2f408e73fd45904ab313) | `` python3Packages.aioautomower: 2025.5.1 -> 2025.6.0 ``                        |
| [`577bb801`](https://github.com/NixOS/nixpkgs/commit/577bb801ec758641bc5b8f5d4d6e9a95d6146cbe) | `` vscode-extensions.devsense.composer-php-vscode: 1.59.17466 -> 1.59.17515 ``  |
| [`1e9b8283`](https://github.com/NixOS/nixpkgs/commit/1e9b82839c1a2449e8e050caac9c9c71c8fa248c) | `` itgmania: 1.0.2 -> 1.1.0 ``                                                  |
| [`1fa65046`](https://github.com/NixOS/nixpkgs/commit/1fa650463cf0f5abad01667859175c3092f7aa09) | `` ci/OWNERS: add kernel team to relevant files ``                              |
| [`c65d54a7`](https://github.com/NixOS/nixpkgs/commit/c65d54a793af7d8a9f996a80924f94e385f5779b) | `` seagoat: 1.0.8 -> 1.0.9 ``                                                   |
| [`7e71204f`](https://github.com/NixOS/nixpkgs/commit/7e71204f2ccd0ef91acd103d6c4a76b8697cd019) | `` tauno-monitor: 0.2.0 -> 0.2.1 ``                                             |
| [`411e69f2`](https://github.com/NixOS/nixpkgs/commit/411e69f2d1073c7a1f1eae668d7fb19600811447) | `` ceph-csi: 3.14.0 -> 3.14.1 ``                                                |
| [`ba4405a5`](https://github.com/NixOS/nixpkgs/commit/ba4405a58dcfc6598e0cc20fb588ee882fd631d7) | ``  python312Packages.tensorflow-datasets: adjust dependencies  (#419210) ``    |
| [`dcdbad28`](https://github.com/NixOS/nixpkgs/commit/dcdbad28aa05996406f06433bfec1315d62239c6) | `` terraform-providers.equinix: 3.9.0 -> 3.10.0 ``                              |
| [`3c1b4354`](https://github.com/NixOS/nixpkgs/commit/3c1b4354271e640af32f4760d24c9ce2b34bcaed) | `` ffsubsync: update ffmpeg dependency handling and adjust wrapper arguments `` |
| [`c249aba2`](https://github.com/NixOS/nixpkgs/commit/c249aba29ec883896c21821ebaef26123bc0ae23) | `` vcsh: 2.0.8 -> 2.0.10 ``                                                     |
| [`2d808017`](https://github.com/NixOS/nixpkgs/commit/2d808017a795d48ce668acf68cb75b0d192c8df7) | `` vcsh: use finalAttrs ``                                                      |
| [`86450d70`](https://github.com/NixOS/nixpkgs/commit/86450d70fede84144fc77b353c4facd91b6ad9fc) | `` python3Packages.bambi: skip failing test ``                                  |
| [`b9ca25a0`](https://github.com/NixOS/nixpkgs/commit/b9ca25a0820af957d3d2e1c863d9872a0722210f) | `` terraform-providers.spotinst: 1.220.2 -> 1.220.3 ``                          |
| [`3f2e885e`](https://github.com/NixOS/nixpkgs/commit/3f2e885ebafe84b78f0be504c75ef33135601406) | `` vscode-extensions.bierner.color-info: init at 0.7.2 ``                       |
| [`aa4026ae`](https://github.com/NixOS/nixpkgs/commit/aa4026ae93eaaa0212316afdbf7a2a0e7a2d5629) | `` python313Packages.jwt: refactor ``                                           |
| [`c79710eb`](https://github.com/NixOS/nixpkgs/commit/c79710eb5b275c08a637af55ce4dc2595f2984de) | `` python313Packages.jwt: 1.3.1 -> 1.4.0 ``                                     |
| [`842e50a0`](https://github.com/NixOS/nixpkgs/commit/842e50a0fb2385f104645bd4d26990d0c1a76a66) | `` vscode-extensions.miguelsolorio.min-theme: init at 1.5.0 ``                  |
| [`75d0c240`](https://github.com/NixOS/nixpkgs/commit/75d0c240aca1d3634c941fe42ac9a2ebae3cbd3c) | `` microsoft-edge: 137.0.3296.83 -> 137.0.3296.93 ``                            |
| [`28ad8219`](https://github.com/NixOS/nixpkgs/commit/28ad82198a2432974e9a27256c244f9d90ec27f8) | `` voxinput: 0.3.0 -> 0.4.0 ``                                                  |
| [`bb418688`](https://github.com/NixOS/nixpkgs/commit/bb418688f22d7c5081c03e2432e3701a1130dfb2) | `` masterpdfeditor: 5.9.86 -> 5.9.89 ``                                         |
| [`e09e9cec`](https://github.com/NixOS/nixpkgs/commit/e09e9cec67b3f05e34dad75a0dab68c876c61796) | `` msolve: 0.8.0 -> 0.9.0 ``                                                    |
| [`305503a5`](https://github.com/NixOS/nixpkgs/commit/305503a566df7e86e66a31b15a0168a99eee844b) | `` masterpdfeditor: refactor ``                                                 |
| [`30be696d`](https://github.com/NixOS/nixpkgs/commit/30be696d9146a2898f0c312985e8cb749449b560) | `` python3Packages.pytensor: skip failing tests ``                              |
| [`6418fbd1`](https://github.com/NixOS/nixpkgs/commit/6418fbd1e508775e987138ab1b3553cc421c61ce) | `` artichoke: 0-unstable-2025-06-01 -> 0-unstable-2025-06-18 ``                 |
| [`02e712b5`](https://github.com/NixOS/nixpkgs/commit/02e712b55419d3b9b69d4366f6c1aa52c97784fd) | `` app2unit: 0.9.0 -> 0.9.2 ``                                                  |