### PR TITLE
chore(flake/nixvim): `6a1a348a` -> `d2c3b26b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1750345447,
-        "narHash": "sha256-yOuSSfI4xovXQpSkZUK02CBcY1f0Nvm0RhnUN8xn2rY=",
+        "lastModified": 1750619045,
+        "narHash": "sha256-ucgldLHtLTbtk09NadxBWi8m4tE07VinTSECR+m9lN4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6a1a348ab1f00bd32d2392b5c2fc72489c699af3",
+        "rev": "d2c3b26bf739686bcb08247692a99766f7c44a3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`d2c3b26b`](https://github.com/nix-community/nixvim/commit/d2c3b26bf739686bcb08247692a99766f7c44a3b) | `` plugins/mini-colors: init ``                                             |
| [`3309a21b`](https://github.com/nix-community/nixvim/commit/3309a21be569ec78c3748f613f128df0679d3bdc) | `` plugins/mini-extra: init ``                                              |
| [`717508a1`](https://github.com/nix-community/nixvim/commit/717508a13230b6b1b82dfdf7e1011e9c24c2d679) | `` plugins/mini-align: init ``                                              |
| [`b8369280`](https://github.com/nix-community/nixvim/commit/b83692803286d21fbb3a1f47d3cdef09cd0617ee) | `` plugins/mini-icons: init ``                                              |
| [`660939f9`](https://github.com/nix-community/nixvim/commit/660939f942bc161d22183f986ea5486778b0eb59) | `` plugins/mini-ai: init ``                                                 |
| [`ee2c095d`](https://github.com/nix-community/nixvim/commit/ee2c095d406447ab9467d0dacb5ee28029aa2f01) | `` plugins/mini-bufremove: init ``                                          |
| [`79243692`](https://github.com/nix-community/nixvim/commit/79243692e92cd689641f313313787beff26f3933) | `` plugins/mini-keymap: init ``                                             |
| [`6b2e98bc`](https://github.com/nix-community/nixvim/commit/6b2e98bc471efb9e6a3796f2f77506dda160dc27) | `` plugins/mini-tabline: init ``                                            |
| [`d49df12b`](https://github.com/nix-community/nixvim/commit/d49df12b9d8c60ee297540a92dcd495ec9c407f5) | `` plugins/mini-trailspace: init ``                                         |
| [`0b948bd0`](https://github.com/nix-community/nixvim/commit/0b948bd0afaa772bb1d77d53a8f50b381ac6e7e5) | `` plugins/mini-fuzzy: init ``                                              |
| [`c59fad7e`](https://github.com/nix-community/nixvim/commit/c59fad7efb56fa7aef1501e3ff92baa72ea5ce23) | `` plugins/mini-git: init ``                                                |
| [`5aa94389`](https://github.com/nix-community/nixvim/commit/5aa94389c18d5c7afe27d64d6c8cbabdda54d026) | `` plugins/mini-cursorword: init ``                                         |
| [`65390e67`](https://github.com/nix-community/nixvim/commit/65390e677790208cd571c0f1db1078bab721879c) | `` plugins/mini-starter: init ``                                            |
| [`c1520693`](https://github.com/nix-community/nixvim/commit/c1520693f04539327fd7a3d6935286161f556df0) | `` plugins/mini-pairs: init ``                                              |
| [`f79250de`](https://github.com/nix-community/nixvim/commit/f79250de794fca8d0362a1c1467247568eb3d50c) | `` plugins/mini-statusline: init ``                                         |
| [`f93cdcb0`](https://github.com/nix-community/nixvim/commit/f93cdcb0341cd0270d7eb4911287c53bd849b68c) | `` plugins/mini-surround: init ``                                           |
| [`3b146040`](https://github.com/nix-community/nixvim/commit/3b146040d54095859324877573b4ef4beeae4a1c) | `` mdbook: add link to repo ``                                              |
| [`229079e3`](https://github.com/nix-community/nixvim/commit/229079e32a0b7c86be467b77cbae25891249e591) | `` tests/hurl: disable for now ``                                           |
| [`cd1f50b1`](https://github.com/nix-community/nixvim/commit/cd1f50b1e85fc43b2c49968a0bc3c6ad3a4a3270) | `` tests/lsp: improve vectorcode comment ``                                 |
| [`35708afc`](https://github.com/nix-community/nixvim/commit/35708afc63bef1e56930f9bdc64ccdaa8e87c2a5) | `` Revert "tests/lsp: disable vectorcode_server as vectorcode is broken" `` |
| [`2f28c81e`](https://github.com/nix-community/nixvim/commit/2f28c81eab6f82ce95c51600131b19b51576f443) | `` generated: Updated rust-analyzer.nix ``                                  |
| [`27e89e05`](https://github.com/nix-community/nixvim/commit/27e89e05463c9fa45ff5ba726f2875572b615658) | `` flake/dev/flake.lock: Update ``                                          |
| [`49ce77ad`](https://github.com/nix-community/nixvim/commit/49ce77ada01214564a85ef3cb314a496a887086c) | `` flake.lock: Update ``                                                    |