### PR TITLE
chore(flake/nixvim): `d2c3b26b` -> `1f3e5741`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1750619045,
-        "narHash": "sha256-ucgldLHtLTbtk09NadxBWi8m4tE07VinTSECR+m9lN4=",
+        "lastModified": 1750691276,
+        "narHash": "sha256-F507hXG4ORVpvuFeuoyDo/bmO/rR2PJRB7XhtDuBnBE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d2c3b26bf739686bcb08247692a99766f7c44a3b",
+        "rev": "1f3e5741a927b5b0a983f08ab9d3bcf313bc141e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`1f3e5741`](https://github.com/nix-community/nixvim/commit/1f3e5741a927b5b0a983f08ab9d3bcf313bc141e) | `` flake/dev/flake.lock: Update `` |
| [`895fdc24`](https://github.com/nix-community/nixvim/commit/895fdc248de77e44e8d86ac92068cb6c710b998b) | `` flake.lock: Update ``           |