### PR TITLE
chore(flake/nixvim): `1f3e5741` -> `6a15c2ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1750691276,
-        "narHash": "sha256-F507hXG4ORVpvuFeuoyDo/bmO/rR2PJRB7XhtDuBnBE=",
+        "lastModified": 1750788551,
+        "narHash": "sha256-7tQIndetzeVtTuYQ7vYTaABUS1muiigdXK3XyXuPzvg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1f3e5741a927b5b0a983f08ab9d3bcf313bc141e",
+        "rev": "6a15c2ffc50ca7998df2fd6b86c3c9f298e9137a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`6a15c2ff`](https://github.com/nix-community/nixvim/commit/6a15c2ffc50ca7998df2fd6b86c3c9f298e9137a) | `` colorschemes/gruvbox-material: init ``         |
| [`4cbb93da`](https://github.com/nix-community/nixvim/commit/4cbb93da8f0cfc2e3e80fa9aca05ee56c9da162d) | `` flake/dev/flake.lock: Update ``                |
| [`094537b6`](https://github.com/nix-community/nixvim/commit/094537b6bb3bb587bc22c6fa069cebd6f0bda911) | `` flake.lock: Update ``                          |
| [`3843b622`](https://github.com/nix-community/nixvim/commit/3843b6226193bd2c40de0aea1343065b1bf9d3e4) | `` maintaining: update to reflect version-info `` |
| [`a41559f0`](https://github.com/nix-community/nixvim/commit/a41559f0931eab14e3186059bd57591843e5cbe0) | `` treewide: add plugin descriptions ``           |