### PR TITLE
chore(flake/nixpkgs): `4b1164c3` -> `30e2e285`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750741721,
-        "narHash": "sha256-Z0djmTa1YmnGMfE9jEe05oO4zggjDmxOGKwt844bUhE=",
+        "lastModified": 1751011381,
+        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4b1164c3215f018c4442463a27689d973cffd750",
+        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`1f7e4b19`](https://github.com/NixOS/nixpkgs/commit/1f7e4b19fe9fcdc1e50c18a3a8a3a4797c8de3aa) | `` comrak: 0.39.0 -> 0.39.1 ``                                                  |
| [`d56aed83`](https://github.com/NixOS/nixpkgs/commit/d56aed834e44db11cd35ca9db6b6013de336e12c) | ``  pkgs/by-name/README: remove irrelevant link to workflow ``                  |
| [`1a850b79`](https://github.com/NixOS/nixpkgs/commit/1a850b79b88bdacdacd8852f4ecc1688e9f6a38a) | `` basex: 11.9 -> 12.0 ``                                                       |
| [`64adabab`](https://github.com/NixOS/nixpkgs/commit/64adabab6c724b654be6ae61c5cb152231fb2928) | `` git-stack: add zlib to build input to fix darwin build (#419580) ``          |
| [`4670b06d`](https://github.com/NixOS/nixpkgs/commit/4670b06dff171a923a397ea73c577c5ffba829f0) | `` fyne: 2.6.1 -> 1.26.1 (#417095) ``                                           |
| [`8d040fa6`](https://github.com/NixOS/nixpkgs/commit/8d040fa632f8ec161af61eb53828db232ad8dd58) | `` opengamepadui: 0.39.2 -> 0.40.1 ``                                           |
| [`6511342e`](https://github.com/NixOS/nixpkgs/commit/6511342e44715cd57af40d776e0f6ab2b47f32b8) | `` servo: unstable-2025-06-04 -> unstable-2025-06-26 ``                         |
| [`da232b99`](https://github.com/NixOS/nixpkgs/commit/da232b9973273b496944b45b0b76dc436fd48e23) | `` asciinema_3: 3.0.0-rc.4 -> 3.0.0-rc.5 ``                                     |
| [`766b7151`](https://github.com/NixOS/nixpkgs/commit/766b71511e2b5e9d81bb6e6ada9e9336e0fab6c5) | `` inputplumber: 0.58.6 -> 0.59.1 ``                                            |
| [`fc2a3ffb`](https://github.com/NixOS/nixpkgs/commit/fc2a3ffb4ba81250ad4426c6cba5dde45be7b126) | `` photoqt: 4.9.1 -> 4.9.2 ``                                                   |
| [`6a109702`](https://github.com/NixOS/nixpkgs/commit/6a109702859fdbc3d2c0133dd93f013e22980aa5) | `` python3Packages.anndata: init at 0.11.4 (#418562) ``                         |
| [`be3ad66d`](https://github.com/NixOS/nixpkgs/commit/be3ad66d60fa3cded3be51c4862908a58ba75d91) | `` hyprshell: update description and platforms ``                               |
| [`d812d228`](https://github.com/NixOS/nixpkgs/commit/d812d228f762a6931ad6505bb0918674436f0b25) | `` bento: 1.8.1 -> 1.8.2 ``                                                     |
| [`ab0558d5`](https://github.com/NixOS/nixpkgs/commit/ab0558d53293a2f20ff1d20c9e6634a4f940b6c9) | `` ceph: Add patch to fix CVE-2025-52555 ``                                     |
| [`e9e2c9d8`](https://github.com/NixOS/nixpkgs/commit/e9e2c9d83d8a46daede01b4d05ffca04a401aec3) | `` calligraphy: add awwpotato as maintainer ``                                  |
| [`522b7013`](https://github.com/NixOS/nixpkgs/commit/522b70138fcde6c6726a862bf125aeeefcb02759) | `` calligraphy: add update-script ``                                            |
| [`bf9cef12`](https://github.com/NixOS/nixpkgs/commit/bf9cef120b2cf3bc5730c85cb2dd3230d00fb064) | `` calligraphy: use tag instead of rev ``                                       |
| [`54f3721c`](https://github.com/NixOS/nixpkgs/commit/54f3721c45e8f71d62a812f5831b8e7f8adbc883) | `` vimPlugins.freeze-nvim: init at 2025-03-25 ``                                |
| [`a7cf1675`](https://github.com/NixOS/nixpkgs/commit/a7cf16754c79f5bd2ce3e57f39a1470ca12a3265) | `` calligraphy: 1.0.1 -> 1.2.0 ``                                               |
| [`0e6adc7b`](https://github.com/NixOS/nixpkgs/commit/0e6adc7b5b85490a8ae9a1d40d975f4660c69a11) | `` simdutf: 7.3.1 -> 7.3.2 ``                                                   |
| [`cafd795e`](https://github.com/NixOS/nixpkgs/commit/cafd795ebdefc423113b69dcaf878260a9c00b77) | `` python312Packages.llama-index-core: 0.12.42 -> 0.12.44 ``                    |
| [`3addb08d`](https://github.com/NixOS/nixpkgs/commit/3addb08d161420925d25369f8bbea8582b066ef9) | `` python313Packages.llama-index-workflows: init at 1.0.1 ``                    |
| [`aa242846`](https://github.com/NixOS/nixpkgs/commit/aa2428466ee34d842d4aef72e5bec9511dad7763) | `` python313Packages.llama-index-instrumentation: init at 0.2.0 ``              |
| [`9d3fde17`](https://github.com/NixOS/nixpkgs/commit/9d3fde1795b3739fe6f37b6a912fdb95876f4763) | `` ollama: 0.9.2 -> 0.9.3 ``                                                    |
| [`b4b3ae49`](https://github.com/NixOS/nixpkgs/commit/b4b3ae49af4c14438484de83c56d2ec284d9e6e7) | `` python3Packages.openai-whisper: remove me from maintainers ``                |
| [`b9341d30`](https://github.com/NixOS/nixpkgs/commit/b9341d3020da02532387da199becbdd07179e86a) | `` python3Packages.openai-whisper: 20240930-unstable-2025-01-04 -> 20250625 ``  |
| [`fce68634`](https://github.com/NixOS/nixpkgs/commit/fce68634c523157701fe868d5a782db33789fb8a) | `` firefox-bin-unwrapped: 140.0 -> 140.0.1 ``                                   |
| [`484e2f24`](https://github.com/NixOS/nixpkgs/commit/484e2f243a29d3be86c33c44b233ef26a36e695b) | `` firefox-unwrapped: 140.0 -> 140.0.1 ``                                       |
| [`db60db45`](https://github.com/NixOS/nixpkgs/commit/db60db45800aa8f11ffb179071005c80a6615a6a) | `` python313Packages.llama-parse: 0.6.33 -> 0.6.37 ``                           |
| [`bf16efe8`](https://github.com/NixOS/nixpkgs/commit/bf16efe84935a6ce5cfec54d671cba5b3d7f76c0) | `` python313Packages.llama-index-indices-managed-llama-cloud: 0.7.2 -> 0.7.7 `` |
| [`084a12f3`](https://github.com/NixOS/nixpkgs/commit/084a12f3f3a88e8aab8a9172cfd9c52e787fd57c) | `` dsda-doom: use finalAttrs ``                                                 |
| [`3dd0faac`](https://github.com/NixOS/nixpkgs/commit/3dd0faac5107c6f5493b034ed48499f0815007e7) | `` dsda-doom: 0.29.0 -> 0.29.2 ``                                               |
| [`9332bbfe`](https://github.com/NixOS/nixpkgs/commit/9332bbfe6a87e5594ce3decfbdb2d4abead90d84) | `` python3Packages.transformers: 4.52.4 -> 4.53.0 ``                            |
| [`c1c7aa28`](https://github.com/NixOS/nixpkgs/commit/c1c7aa280913f3b84af1880b3bd58420b189e30b) | `` python3Packages.huggingface-hub: 0.32.3 -> 0.33.1 ``                         |
| [`e9035975`](https://github.com/NixOS/nixpkgs/commit/e90359756b889818289540fa36c42d99acf1c0ba) | `` python313Packages.llama-index-embeddings-huggingface: 0.5.4 -> 0.5.5 ``      |
| [`292e8696`](https://github.com/NixOS/nixpkgs/commit/292e869674f337c5a6a41aa8cd85b33712ba8dca) | `` python3Packages.timm: 1.0.15 -> 1.0.16 ``                                    |
| [`a7dad7a5`](https://github.com/NixOS/nixpkgs/commit/a7dad7a5658e32d9ff368258424b100fa0fa8845) | `` python3Packages.whenever: update meta.changelog ``                           |
| [`5f656666`](https://github.com/NixOS/nixpkgs/commit/5f6566665b4433076c12bc622f1bdceea66adf05) | `` plasma-panel-colorizer: 4.3.1 -> 4.3.2 ``                                    |
| [`f6656207`](https://github.com/NixOS/nixpkgs/commit/f6656207455223aa0277e520ec0999944133bbc1) | `` vimPlugins.thanks-nvim: init at 2025-03-08 ``                                |
| [`24df1ab4`](https://github.com/NixOS/nixpkgs/commit/24df1ab44ac69266e1728cd7d92a0fa244c6c020) | `` neovim: Make it possible to configure using Lua ``                           |
| [`34c95df2`](https://github.com/NixOS/nixpkgs/commit/34c95df253fa4de395b0387132c0fef0566c30fd) | `` vimPlugins.spellwarn-nvim: init at 2024-11-03 ``                             |
| [`f3a931c6`](https://github.com/NixOS/nixpkgs/commit/f3a931c6cd62cb89108dacfc44316ec7b339b38a) | `` fastp: 1.0.0 -> 1.0.1 ``                                                     |
| [`90922fae`](https://github.com/NixOS/nixpkgs/commit/90922faedf17af15f2b427487d5a12b748ab10b8) | `` narsil: remove unused SDL2_sound dependency ``                               |
| [`27f936a5`](https://github.com/NixOS/nixpkgs/commit/27f936a533e77b04787fc01f56c9317688a41d69) | `` vimPlugins.lazyjj-nvim: init at 2024-11-28 ``                                |
| [`8bb02cee`](https://github.com/NixOS/nixpkgs/commit/8bb02cee0e6cdff2f6ea91cf810570efd7c77e19) | `` angband: remove unused SDL2_sound dependency ``                              |
| [`c29d2934`](https://github.com/NixOS/nixpkgs/commit/c29d2934dd60ba812a025ee8733f2da36cdf6bb1) | `` wivrn: 0.25 -> 25.6 ``                                                       |
| [`7d92af28`](https://github.com/NixOS/nixpkgs/commit/7d92af280de3a5e182f68a4d991494fc548b912e) | `` python313Packages.llama-cloud-services: 0.6.36 -> 0.6.37 ``                  |
| [`6e1d3b31`](https://github.com/NixOS/nixpkgs/commit/6e1d3b314f92afb3d7691fbcf80b39f65d3aa0ab) | `` python313Packages.llama-cloud: 0.1.26 -> 0.1.29 ``                           |
| [`05572e0f`](https://github.com/NixOS/nixpkgs/commit/05572e0f97be50dea2bb3ecbaaf25a7e4c1d6e9e) | `` python313Packages.llama-index-question-gen-openai: 0.3.0 -> 0.3.1 ``         |
| [`e9415672`](https://github.com/NixOS/nixpkgs/commit/e9415672dfd510c72feddb52817a1761a0fe4278) | `` python313Packages.llama-index-program-openai: 0.3.1 -> 0.3.2 ``              |
| [`dde312ee`](https://github.com/NixOS/nixpkgs/commit/dde312ee28771213f2a66e9321b1cd8921569012) | `` python313Packages.llama-index-multi-modal-llms-openai: 0.5.0 -> 0.5.1 ``     |
| [`8647277a`](https://github.com/NixOS/nixpkgs/commit/8647277a13782da6f3ef4f1e9dc18b078528fea4) | `` python313Packages.llama-index-llms-openai-like: 0.3.5 -> 0.4.0 ``            |
| [`7ad55be4`](https://github.com/NixOS/nixpkgs/commit/7ad55be4870aceafa7660104fe355a2b1fdd1cb2) | `` python313Packages.llama-index-llms-openai: 0.3.44 -> 0.4.7 ``                |
| [`73744b8c`](https://github.com/NixOS/nixpkgs/commit/73744b8c5bab1d56784fafb02f013a7c01bc1178) | `` python313Packages.llama-index-cli: 0.4.1 -> 0.4.3 ``                         |
| [`8be3a106`](https://github.com/NixOS/nixpkgs/commit/8be3a1062f7de4b4006ebb1a39dc17d373452817) | `` python313Packages.llama-index-core: 0.12.39 -> 0.12.42 ``                    |
| [`702b5aba`](https://github.com/NixOS/nixpkgs/commit/702b5aba0646f064bf9c282ec678b44a601f1803) | `` python313Packages.llama-cloud: 0.1.23 -> 0.1.26 ``                           |
| [`20124414`](https://github.com/NixOS/nixpkgs/commit/20124414045aa94f47207f945b8c461aafe7b4df) | `` python313Packages.llama-index-llms-ollama: 0.5.6 -> 0.6.2 ``                 |
| [`b30bd2af`](https://github.com/NixOS/nixpkgs/commit/b30bd2af89680132c5ba70fa0054b743fe26f0a8) | `` python313Packages.llama-index-vector-stores-chroma: 0.4.1 -> 0.4.2 ``        |
| [`b61b4c3f`](https://github.com/NixOS/nixpkgs/commit/b61b4c3fafba214f9d0dd5a4cee3cb54369dad7a) | `` python313Packages.llama-parse: 0.6.25 -> 0.6.33 ``                           |
| [`9c72de4b`](https://github.com/NixOS/nixpkgs/commit/9c72de4b912fd4422e7315ddb136711d2ddec549) | `` python312Packages.llama-parse: 0.6.23 -> 0.6.25 ``                           |
| [`8bc37176`](https://github.com/NixOS/nixpkgs/commit/8bc371766b16fe100a179feff5e786087bb4545f) | `` python312Packages.llama-index-indices-managed-llama-cloud: 0.7.1 -> 0.7.2 `` |
| [`db3e7a42`](https://github.com/NixOS/nixpkgs/commit/db3e7a4252888222d038e306269e746e7fd22212) | `` python312Packages.llama-index-core: update disabled ``                       |
| [`fb5ce52c`](https://github.com/NixOS/nixpkgs/commit/fb5ce52c38345e2af0ff4dd5bb0202366d8cb35f) | `` python312Packages.llama-index-core: 0.12.37 -> 0.12.39 ``                    |
| [`39e96cba`](https://github.com/NixOS/nixpkgs/commit/39e96cba23894277c8c1c642d7973c04f65c4039) | `` dnsproxy: 0.75.6 -> 0.76.0 ``                                                |
| [`7a61ac36`](https://github.com/NixOS/nixpkgs/commit/7a61ac36c7ac6588932a0563ea645f428446f5dd) | `` input-leap: 3.0.2 -> 3.0.3 ``                                                |
| [`0a4f9d60`](https://github.com/NixOS/nixpkgs/commit/0a4f9d60c16a667c8d3ba7a6a4d9e82929a79805) | `` whalebird: 6.2.0-unstable-2025-02-26 -> 6.2.2-unstable-2025-06-12 ``         |
| [`51b1f250`](https://github.com/NixOS/nixpkgs/commit/51b1f250fe4b715e894ee78ba3cd18954b3293e7) | `` maintainer.jwiegley: add key fingerprint ``                                  |
| [`18c8e8fc`](https://github.com/NixOS/nixpkgs/commit/18c8e8fc82997b2de32ffbab93ba8a08b534be0e) | `` temporalite: remove ``                                                       |
| [`ee6cfad3`](https://github.com/NixOS/nixpkgs/commit/ee6cfad313d6beb553a9c42d37f38b21fc7ebed5) | `` python312Packages.paddlex: 3.0.1 -> 3.0.3 ``                                 |
| [`4574b741`](https://github.com/NixOS/nixpkgs/commit/4574b7412829bf08e0e33a415dfc326259d1c1ca) | `` python313Packages.dissect: 3.18 -> 3.19 ``                                   |
| [`30a9441f`](https://github.com/NixOS/nixpkgs/commit/30a9441ffaa8a3ea781a9b4e32bad3e96225db2c) | `` python313Packages.dissect-qnxfs: init at 1.0 ``                              |
| [`d103e676`](https://github.com/NixOS/nixpkgs/commit/d103e67626d85a588402264d09cde14b2426b11c) | `` qgrx: remove with lib ``                                                     |
| [`a10bca57`](https://github.com/NixOS/nixpkgs/commit/a10bca57bb2e8146513de8cf09e8ca4092f39c0d) | `` gqrx: move to by-name ``                                                     |
| [`1c4aa0d6`](https://github.com/NixOS/nixpkgs/commit/1c4aa0d63fe2e67453e43dbc9a71e8e437b29184) | `` qdmr: move to by-name ``                                                     |
| [`694c4b21`](https://github.com/NixOS/nixpkgs/commit/694c4b2180407f447d2d4e3432de378cf3101bad) | `` btlejack: move to by-name ``                                                 |
| [`0f5c3276`](https://github.com/NixOS/nixpkgs/commit/0f5c327603514cc7d36f7ebd117829df4b437986) | `` btlejack: remove with lib ``                                                 |
| [`214fb8c6`](https://github.com/NixOS/nixpkgs/commit/214fb8c6d39dd6aec976018cef5286237f35a860) | `` btlejack: use callPackage ``                                                 |
| [`ff28f796`](https://github.com/NixOS/nixpkgs/commit/ff28f7962a268f3df904c7339f99a8cd2e7a0e3c) | `` signalbackup-tools: 20250622-1 -> 20250626 ``                                |
| [`5d601017`](https://github.com/NixOS/nixpkgs/commit/5d601017009b6f3e7ae93e85f4894b30017a8e3d) | `` python3Packages.whenever: 0.8.5 -> 0.8.6 ``                                  |
| [`d9797a40`](https://github.com/NixOS/nixpkgs/commit/d9797a40c8f65cb1b5b4b05f35a4638f18ac2400) | `` aptakube: init at 1.11.10 ``                                                 |
| [`fa06e1a9`](https://github.com/NixOS/nixpkgs/commit/fa06e1a90d255e7d038ce6d33daebd911796d592) | `` maintainers: add juliamertz ``                                               |
| [`1bf169c3`](https://github.com/NixOS/nixpkgs/commit/1bf169c386785cad70ac3e17eca5d2082766bd44) | `` python313Packages.acquire: 3.18 -> 3.19 ``                                   |
| [`f88435d0`](https://github.com/NixOS/nixpkgs/commit/f88435d01a84e67a9f39de51459c272c56e6c038) | `` python313Packages.dissect-target: 3.20.1 -> 3.22 ``                          |
| [`1ba4241c`](https://github.com/NixOS/nixpkgs/commit/1ba4241cbd61c5a5efff6e66cea28624320c9d70) | `` qnial: drop ``                                                               |
| [`1d47edfe`](https://github.com/NixOS/nixpkgs/commit/1d47edfe951b1edd0a97d08d989a63cbdfc6bada) | `` ungoogled-chromium: 137.0.7151.119-1 -> 138.0.7204.49-1 ``                   |
| [`74c78f98`](https://github.com/NixOS/nixpkgs/commit/74c78f981f1002d4ebef2096f85dbb2a97fd718c) | `` lcov: add versionCheckHook ``                                                |
| [`27309c13`](https://github.com/NixOS/nixpkgs/commit/27309c13992ce136e44cbf034f33fae5dca5203d) | `` lcov: set correct version ``                                                 |