### PR TITLE
chore(flake/nixpkgs): `30e2e285` -> `3016b4b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751011381,
-        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
+        "lastModified": 1751271578,
+        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
+        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`19e48692`](https://github.com/NixOS/nixpkgs/commit/19e4869241080cea1a831a05c0298b61de944695) | `` coqPackages.*: better formatting fix ``                                                      |
| [`d74a76be`](https://github.com/NixOS/nixpkgs/commit/d74a76be1d3332ecc506a4808f70d1047fc34476) | `` llvmPackages_git: 21.0.0-unstable-2025-06-22 -> 21.0.0-unstable-2025-06-29 ``                |
| [`1771336a`](https://github.com/NixOS/nixpkgs/commit/1771336abe0d4899737c08039af2ce4a7c9f6648) | `` coqPackages.interval: 4.11.1 -> 4.11.2 ``                                                    |
| [`3efba99a`](https://github.com/NixOS/nixpkgs/commit/3efba99a6dfed75dbf030b783a9195c0af16dcb4) | `` warp-terminal: 0.2025.06.20.22.47.stable_05 -> 0.2025.06.25.08.12.stable_01 ``               |
| [`8121260f`](https://github.com/NixOS/nixpkgs/commit/8121260fd3cff9095cfa37c732de657e08cae453) | `` jellyfin-tui:1.1.3->1.2.1 ``                                                                 |
| [`eb11b0b0`](https://github.com/NixOS/nixpkgs/commit/eb11b0b07220b1f636c7774916de7630aef53810) | `` deepin.dde-shell: fix qml models import in qt 6.9 ``                                         |
| [`24a74cc5`](https://github.com/NixOS/nixpkgs/commit/24a74cc56223a9fee3010319e99fa1de7d367934) | `` buf: use finalAttrs ``                                                                       |
| [`81893394`](https://github.com/NixOS/nixpkgs/commit/8189339445c4ab5ee3ea9422af62b4cdcf438bea) | `` bibiman: 0.12.3 -> 0.12.4 ``                                                                 |
| [`f03c9c2e`](https://github.com/NixOS/nixpkgs/commit/f03c9c2ec1a19bd11d90dde4b1aa86f84ad8cd9c) | `` python3Packages.glyphslib: 6.10.3 -> 6.11.0 ``                                               |
| [`83087bcb`](https://github.com/NixOS/nixpkgs/commit/83087bcb93f7bd73757211fad8593c2c332a49e2) | `` lixPackageSets.lix_2_93: patch for the critical correctness bug ``                           |
| [`6d088d36`](https://github.com/NixOS/nixpkgs/commit/6d088d36d48a5c7b8960be989137db7e9163bcdf) | `` lixPackageSets.lix_2_92: patch for the critical correctness bug ``                           |
| [`4b41b583`](https://github.com/NixOS/nixpkgs/commit/4b41b58356f36117bd9261a687c3fbbbee43e78e) | `` lixPackageSets.lix_2_91: patch for the critical correctness bug ``                           |
| [`14ca9b99`](https://github.com/NixOS/nixpkgs/commit/14ca9b997a5ebb18f072a33e2f42c32015fc5864) | `` python3Packages.google-cloud-speech: 2.32.0 -> 2.33.0 ``                                     |
| [`3198b823`](https://github.com/NixOS/nixpkgs/commit/3198b82350147b5141b41d88e10209136a8599ad) | `` python3Packages.aioftp: 0.25.1 -> 0.25.2 ``                                                  |
| [`0db7aecc`](https://github.com/NixOS/nixpkgs/commit/0db7aecca9c682550246c73a32e7afd8d2eb342a) | `` python3Packages.pyezvizapi: 1.0.0.9 -> 1.0.1.0 ``                                            |
| [`aaa6f379`](https://github.com/NixOS/nixpkgs/commit/aaa6f379af77baa169cb373b4af22c4441db8237) | `` python3Packages.certbot-dns-inwx: 3.0.2 -> 3.0.3 ``                                          |
| [`84a111a2`](https://github.com/NixOS/nixpkgs/commit/84a111a2df01fe7601cafc5a53c7b5e3baa09357) | `` python3Packages.azure-mgmt-web: 8.0.0 -> 9.0.0 ``                                            |
| [`382ae5ce`](https://github.com/NixOS/nixpkgs/commit/382ae5ceba97e95148324073676f8aa697ae217c) | `` tplay: 0.6.0 -> 0.6.l3 ``                                                                    |
| [`77db71b3`](https://github.com/NixOS/nixpkgs/commit/77db71b32d3b586c8a117d8f62332abea315ba79) | `` libretro.puae: 0-unstable-2025-05-24 -> 0-unstable-2025-06-14 ``                             |
| [`16be21b1`](https://github.com/NixOS/nixpkgs/commit/16be21b1e4f42809abdcf4714eb34e58690f8cf3) | `` python3Packages.pytest-cases: 3.8.6 -> 3.9.1 ``                                              |
| [`80e74d26`](https://github.com/NixOS/nixpkgs/commit/80e74d26a5a4a23c6076643914ecb70ed2208b8c) | `` grafana-alloy: 1.9.1 -> 1.9.2 ``                                                             |
| [`60d3651e`](https://github.com/NixOS/nixpkgs/commit/60d3651e0f71adead02f0ed5440de16a1ceea0e6) | `` python3Packages.semchunk: 3.2.1 -> 3.2.2 ``                                                  |
| [`772b4721`](https://github.com/NixOS/nixpkgs/commit/772b47210b4fc0ce66e7cf13562c0fa3d8eab22e) | `` python3Packages.google-cloud-artifact-registry: 1.16.0 -> 1.16.1 ``                          |
| [`7cd965e7`](https://github.com/NixOS/nixpkgs/commit/7cd965e7748f48db01c7c106cb7d3454aa479d3f) | `` Revert "python3Packages.pathvalidate: 3.2.3 -> 3.3.1" ``                                     |
| [`4ccba358`](https://github.com/NixOS/nixpkgs/commit/4ccba35866ee2ce284a9f46509fd341b581c68a1) | `` cloc: 2.04 -> 2.06 ``                                                                        |
| [`4e3354b6`](https://github.com/NixOS/nixpkgs/commit/4e3354b6f931c595b989925fcf4c5b7ee85108de) | `` python312Packages.aggregate6: 1.0.12 -> 1.0.14 ``                                            |
| [`da6ed8ac`](https://github.com/NixOS/nixpkgs/commit/da6ed8ace7106d016e18c911dcb5e32dff470930) | `` python3Packages.pymunk: drop support for python 3.8 ``                                       |
| [`b93056a6`](https://github.com/NixOS/nixpkgs/commit/b93056a63e86d7de221b83536889f4b2921c3976) | `` grafana-metricsdrilldown-app: init at 1.0.4 ``                                               |
| [`59f235c7`](https://github.com/NixOS/nixpkgs/commit/59f235c79d3844a5c8baa9b1c9eacfc934561283) | `` nixos/wyoming/faster-whisper: fix eval ``                                                    |
| [`747b83f4`](https://github.com/NixOS/nixpkgs/commit/747b83f4768f39cdb00b35a88539a8cd32d43e22) | `` rspamd: 3.12.0 -> 3.12.1 ``                                                                  |
| [`6d4b8603`](https://github.com/NixOS/nixpkgs/commit/6d4b8603d1ce4ed8bb7964c1c715a26aa91bc45f) | `` python3Packages.azure-mgmt-network: 28.1.0 -> 29.0.0 ``                                      |
| [`a65c2670`](https://github.com/NixOS/nixpkgs/commit/a65c267047765b5ced6bd8b5dac29ac162fc16f1) | `` python3Packages.dlib: 19.24.9 -> 20.0 ``                                                     |
| [`0cbe63b0`](https://github.com/NixOS/nixpkgs/commit/0cbe63b03b737bd2413dab3b92f5385c49aeab68) | `` .git-blame-ignore-revs: add formatting change for READMEs ``                                 |
| [`6193b8d0`](https://github.com/NixOS/nixpkgs/commit/6193b8d04ba5a5358cac7402b51948fe70b33b19) | `` python3Packages.aiorussound: 4.6.0 -> 4.6.1 (#421068) ``                                     |
| [`3d505c03`](https://github.com/NixOS/nixpkgs/commit/3d505c03610b6102af6d870ae3506a151cef1f68) | `` .github/workflows/README.md: one sentence per line ``                                        |
| [`60e35e4d`](https://github.com/NixOS/nixpkgs/commit/60e35e4ded6e91524364a74b3b4ec233ed9321f2) | `` ci/eval/README.md: one sentence per line ``                                                  |
| [`99f2e655`](https://github.com/NixOS/nixpkgs/commit/99f2e655d9db009ee0b4ede3edced5f6c882c7f4) | `` ci/README.md: one sentence per line ``                                                       |
| [`b4532efe`](https://github.com/NixOS/nixpkgs/commit/b4532efe93882ae2e3fc579929a42a5a56544146) | `` **/README.md: one sentence per line ``                                                       |
| [`775af4de`](https://github.com/NixOS/nixpkgs/commit/775af4dea00800b263fcef844185c335ef000625) | `` python3Packages.magicgui: 0.10.0 -> 0.10.1 ``                                                |
| [`052e636b`](https://github.com/NixOS/nixpkgs/commit/052e636b52f5150179d24beeb3d1bf270392006d) | `` litellm: 1.72.6 -> 1.73.0 ``                                                                 |
| [`6c6eaf26`](https://github.com/NixOS/nixpkgs/commit/6c6eaf262dab83937dbcddb4cdea8e1bc1266894) | `` python3Packages.google-cloud-automl: 2.16.3 -> 2.16.4 ``                                     |
| [`159dc242`](https://github.com/NixOS/nixpkgs/commit/159dc242d51ffda5690236780db6f6fa1546a89f) | `` guacamole-server: 1.6.0-unstable-2025-05-16 -> 1.6.0-unstable-2025-06-29 ``                  |
| [`c757b757`](https://github.com/NixOS/nixpkgs/commit/c757b757a98e2a2c135799d937e389dcfdc2cf99) | `` guacamole-server: unbreak, update CFLAGS ``                                                  |
| [`b49d9f84`](https://github.com/NixOS/nixpkgs/commit/b49d9f84d4b7e7ca3689ee8ca22d0c6338388732) | `` vscode-extensions.pkief.material-icon-theme: 5.23.0 -> 5.24.0 and  moved to own directory `` |
| [`47c85f6f`](https://github.com/NixOS/nixpkgs/commit/47c85f6f36941489462e04ca5b9e23fda1d070ea) | `` mdns-scanner: 0.15.0 -> 0.16.1 ``                                                            |
| [`297ed1a6`](https://github.com/NixOS/nixpkgs/commit/297ed1a686df98c980557de8eea431ad6a829f96) | `` gamemode: update 1.8.2 hash to include an additional commit ``                               |
| [`96fb0d67`](https://github.com/NixOS/nixpkgs/commit/96fb0d676476fcb42bb2e7429f37af5e2d490c74) | `` got: 0.113 -> 0.115 ``                                                                       |
| [`c61e6e95`](https://github.com/NixOS/nixpkgs/commit/c61e6e95e5bbfb7fe1ba97f941933b771eea76bd) | `` signal-desktop: 7.58.0 -> 7.59.0 ``                                                          |
| [`7993b314`](https://github.com/NixOS/nixpkgs/commit/7993b314a4041577b9fcd0caaed70bd36a18b4f1) | `` gojo: 0.3.2 -> 0.3.3 ``                                                                      |
| [`f974807c`](https://github.com/NixOS/nixpkgs/commit/f974807cf8fbac7775d1b8a9dd40b3204c0dbaaa) | `` bitrise: 2.31.2 -> 2.31.3 ``                                                                 |
| [`de113bb4`](https://github.com/NixOS/nixpkgs/commit/de113bb486de05a6790b351b01b326f449d75a76) | `` vscode-extensions.mkhl.shfmt: init at 1.3.1 ``                                               |
| [`182efe79`](https://github.com/NixOS/nixpkgs/commit/182efe799a4097e7dc797568c964f856f6a94752) | `` windsurf: 1.10.3 -> 1.10.5 ``                                                                |
| [`10e0be92`](https://github.com/NixOS/nixpkgs/commit/10e0be92db6947eba3ca5dfd9c21bad22520d24f) | `` rebuilderd: 0.23.1 -> 0.24.0 ``                                                              |
| [`22c3b2e3`](https://github.com/NixOS/nixpkgs/commit/22c3b2e39ff1e2b112319418450c1874103e20ae) | `` release-python: drop lib-tests ``                                                            |
| [`3638d7cf`](https://github.com/NixOS/nixpkgs/commit/3638d7cf50c18453e1cd2f38ab50bcc1fc28a06b) | `` memogram: 0.2.5 -> 0.2.6 ``                                                                  |
| [`6ac1f3f6`](https://github.com/NixOS/nixpkgs/commit/6ac1f3f61bb645c21f940839c54c18c602a2c0a8) | `` python3Packages.fugashi: 1.3.0 -> 1.5.1 ``                                                   |
| [`39c70b43`](https://github.com/NixOS/nixpkgs/commit/39c70b43853372c5f521bb4a104a5e31b041679c) | `` metabigor: 2.0.0 -> 2.0.1 ``                                                                 |
| [`0d637078`](https://github.com/NixOS/nixpkgs/commit/0d6370788afe04913e91234f130868cd7c0cfc92) | `` qmmp: 2.2.6 -> 2.2.7 ``                                                                      |
| [`a2a53671`](https://github.com/NixOS/nixpkgs/commit/a2a5367191218126e63cbda85bbb203d192155af) | `` rstudio: bump electron version ``                                                            |
| [`28fa84c9`](https://github.com/NixOS/nixpkgs/commit/28fa84c9d3d2fa22be1b0af963812a4e8d15f0ca) | `` gitu: 0.33.0 -> 0.34.0 ``                                                                    |
| [`388426df`](https://github.com/NixOS/nixpkgs/commit/388426df26b8e2c21c9bddf302c19cdbd2e4f17d) | `` typeinc: 1.0.1 -> 1.0.3 ``                                                                   |
| [`a227d052`](https://github.com/NixOS/nixpkgs/commit/a227d0520eb7c066d669d301df2108a5b61e529f) | `` python3Packages.rq: 2.3.3 -> 2.4 ``                                                          |
| [`dbbf70e0`](https://github.com/NixOS/nixpkgs/commit/dbbf70e0a873fc50d5e27d476220b9a16e840edf) | `` doc/packages/python-tree-sitter: fix typo ``                                                 |
| [`82b32690`](https://github.com/NixOS/nixpkgs/commit/82b326909698282d188306ad36691ee2ef92f446) | `` python3Packages.tree-sitter-grammars: fix setup.py deprecation warning ``                    |
| [`5f3bdd5d`](https://github.com/NixOS/nixpkgs/commit/5f3bdd5d573d1d3f5a6272e033ccca7fcccfd491) | `` python3Packages.tree-sitter-grammars: address dynamic linking issue ``                       |
| [`1e13a930`](https://github.com/NixOS/nixpkgs/commit/1e13a930380ad6521fab77971eca52e9a09c4b7f) | `` Revert "speakersafetyd: 1.0.2 → 1.1.2; refactor package; add myself as maintainer" ``        |
| [`53bc90c0`](https://github.com/NixOS/nixpkgs/commit/53bc90c0b0af9af718080e46bf402fca92d55fe1) | `` tilix: fix build ``                                                                          |
| [`7c934589`](https://github.com/NixOS/nixpkgs/commit/7c934589b3a7a4cc8ec30416bcca8dd44726d13a) | `` gtkd: use finalAttrs ``                                                                      |
| [`aa18ed26`](https://github.com/NixOS/nixpkgs/commit/aa18ed262ed46734ba689ecc1f70538da958e972) | `` gtkd: 3.10.0 -> 3.11.0 ``                                                                    |
| [`b9b5b747`](https://github.com/NixOS/nixpkgs/commit/b9b5b7471529af11f2982ab83c0c9d07be4d5e76) | `` protobuf_26: remove ``                                                                       |
| [`4f46aa8a`](https://github.com/NixOS/nixpkgs/commit/4f46aa8a7263281fa8b8409307f4cbf12e17216f) | `` buf: 1.53.0 -> 1.55.1 ``                                                                     |
| [`2c2bded3`](https://github.com/NixOS/nixpkgs/commit/2c2bded35f94e4793313d1591dd800d7f8a54101) | `` clever-tools: 3.13.0 -> 3.13.1 ``                                                            |
| [`2db497a8`](https://github.com/NixOS/nixpkgs/commit/2db497a8ad06bb89250c288d89eb52f4a303ba85) | `` heynote: 2.2.2 -> 2.3.2 ``                                                                   |
| [`8f6be61b`](https://github.com/NixOS/nixpkgs/commit/8f6be61b615ed918d999af13fe21fadbf8d09db3) | `` eza: 0.21.5 -> 0.21.6 ``                                                                     |
| [`ef9cba93`](https://github.com/NixOS/nixpkgs/commit/ef9cba938b8d9728f0311f69181df2d063f40c2b) | `` glab: 1.60.2 -> 1.61.0 ``                                                                    |
| [`c8a1b81f`](https://github.com/NixOS/nixpkgs/commit/c8a1b81fa6f9a041df8920323dafbdb30193678b) | `` lmstudio: 0.3.16.8 -> 0.3.17.11 ``                                                           |
| [`1aff5d6e`](https://github.com/NixOS/nixpkgs/commit/1aff5d6e7ee4d833cea31763f0297fca2b53e1f5) | `` gemini-cli: fix file collisions ``                                                           |
| [`e185b875`](https://github.com/NixOS/nixpkgs/commit/e185b875739cb99f86c585af2c274bf0f925c332) | `` python3Packages.clldutils: modernize ``                                                      |
| [`5293ede2`](https://github.com/NixOS/nixpkgs/commit/5293ede2b611cfe21599928934b2a1932b8542f7) | `` python3Packages.clldutils: 3.21.0 -> 3.24.2 ``                                               |
| [`074b3338`](https://github.com/NixOS/nixpkgs/commit/074b333898343b3458cf9e4cc39f44704ef53d81) | `` python3Packages.bibtexparser_2: init at 2.0.0b8 ``                                           |
| [`d0c18c0a`](https://github.com/NixOS/nixpkgs/commit/d0c18c0adc86d4e38cd957708d55353e287bf133) | `` sccmhunter: use python3.12 ``                                                                |
| [`c82b750d`](https://github.com/NixOS/nixpkgs/commit/c82b750dd41543c06e224bf726fb768eee38f4bc) | `` teams/kodi: remove sephalon ``                                                               |
| [`74fc212d`](https://github.com/NixOS/nixpkgs/commit/74fc212df690cafced2496e801a84069d353e24c) | `` python3Packages.anyascii: 0.3.2 -> 0.3.3 ``                                                  |
| [`4baf968b`](https://github.com/NixOS/nixpkgs/commit/4baf968bb95f8b27f7a5339442791ac2cc3ff2ab) | `` kubexporter: 0.6.4 -> 0.6.5 ``                                                               |
| [`81c9af4c`](https://github.com/NixOS/nixpkgs/commit/81c9af4c4c58d25821292827cd74b28981db5c58) | `` gtkd: avoid with lib; ``                                                                     |