### PR TITLE
chore(flake/nixvim): `ef0fa015` -> `28f818b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1751746175,
-        "narHash": "sha256-6JABU+UMkaL4c+ZJRQYyFyIkm9ry1fOkhNQgSSjK5OM=",
+        "lastModified": 1751824405,
+        "narHash": "sha256-8lgBIofI1lQXs4skivRnPJ/S8Tqduv4bXq/8Rc/ns8o=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ef0fa015a8236241bdcc27f32e6a4aa537d96cf8",
+        "rev": "28f818b57bb68d91891d23952490b1e19055d63c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`28f818b5`](https://github.com/nix-community/nixvim/commit/28f818b57bb68d91891d23952490b1e19055d63c) | `` user-configs: add @r17x's config ``                                        |
| [`19aab2f9`](https://github.com/nix-community/nixvim/commit/19aab2f935171faa6efd10282138706775543bad) | `` colorschemes/gruvbox-material: update default config due to lib changes `` |