### PR TITLE
chore(flake/nixpkgs): `5c724ed1` -> `1fd8bada`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751637120,
-        "narHash": "sha256-xVNy/XopSfIG9c46nRmPaKfH1Gn/56vQ8++xWA8itO4=",
+        "lastModified": 1751792365,
+        "narHash": "sha256-J1kI6oAj25IG4EdVlg2hQz8NZTBNYvIS0l4wpr9KcUo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5c724ed1388e53cc231ed98330a60eb2f7be4be3",
+        "rev": "1fd8bada0b6117e6c7eb54aad5813023eed37ccb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`8f408a61`](https://github.com/NixOS/nixpkgs/commit/8f408a61f1eabd6195752574acc88c766c6600d0) | `` pineapple-pictures: 1.0.0 -> 1.1.0 ``                                          |
| [`9cdcdf17`](https://github.com/NixOS/nixpkgs/commit/9cdcdf177e969ac0e8e1ea91b960223812214451) | `` python313Packages.ciscoconfparse2: relax tomlkit ``                            |
| [`81f1a10d`](https://github.com/NixOS/nixpkgs/commit/81f1a10daee3280f8832028187ce159e7b942a73) | `` cargo-udeps: 0.1.56 -> 0.1.57 ``                                               |
| [`c7dc028c`](https://github.com/NixOS/nixpkgs/commit/c7dc028c9a67194e1cafe012402be713bcf85245) | `` dalfox: 2.11.0 -> 2.12.0 ``                                                    |
| [`5a539047`](https://github.com/NixOS/nixpkgs/commit/5a539047436644a0301ea70ac997dec0ed5b26f4) | `` Revert "qtcreator: add missing gtk3 gsettings-schemas" ``                      |
| [`15bcfc69`](https://github.com/NixOS/nixpkgs/commit/15bcfc69bdbc9fc52ac40ff72f0d7aa07696d393) | `` certinfo-go: 0.1.43 -> 0.1.45 ``                                               |
| [`a8c581f7`](https://github.com/NixOS/nixpkgs/commit/a8c581f7b8ca2c9bc723a96bad82dfff65120b87) | `` vscode-extensions.tekumara.typos-vscode: 0.1.39 -> 0.1.40 ``                   |
| [`0a95d6d9`](https://github.com/NixOS/nixpkgs/commit/0a95d6d9a7ddb7bacb08be3b7dfc6cbf802adebc) | `` python3Packages.docling-serve: reomve dependency on unavailable mlx-vlm ``     |
| [`f8066d8a`](https://github.com/NixOS/nixpkgs/commit/f8066d8aec84324b8c791631a352862412c58989) | `` home-assistant: update component packages ``                                   |
| [`628f5df8`](https://github.com/NixOS/nixpkgs/commit/628f5df8ffa4dad51abe3e622fb6d408ba7bb2cd) | `` python313Packages.pyps4-2ndscreen: init at 1.3.1 ``                            |
| [`927a5388`](https://github.com/NixOS/nixpkgs/commit/927a5388ef39fccf7baf91879ed501ec45dfc7ad) | `` home-assistant: update component packages ``                                   |
| [`fa58891b`](https://github.com/NixOS/nixpkgs/commit/fa58891bba22f18128b95e1d4fb575acf245186f) | `` python313Packages.fastdotcom: init at 0.0.6 ``                                 |
| [`e27ba577`](https://github.com/NixOS/nixpkgs/commit/e27ba577c4d269911b5f6bcc7f37aa2a1389cfac) | `` sdl_gamecontrollerdb: 0-unstable-2025-06-14 -> 0-unstable-2025-07-03 ``        |
| [`a794031c`](https://github.com/NixOS/nixpkgs/commit/a794031c597bd8a1898a1305b70952508e2d3612) | `` Revert "nixos/dovecot: improve and harden systemd unit" ``                     |
| [`42d47129`](https://github.com/NixOS/nixpkgs/commit/42d47129a6ad0bf483d4271573af4215e337a1e5) | `` terraform-providers.pagerduty: 3.26.2 -> 3.26.3 ``                             |
| [`adca9c79`](https://github.com/NixOS/nixpkgs/commit/adca9c7950645e9ffb42ea9e695f877533d0586d) | `` terraform-providers.mongodbatlas: 1.36.0 -> 1.37.0 ``                          |
| [`a021549f`](https://github.com/NixOS/nixpkgs/commit/a021549fef25622b01f29698b813059da3bb2eaf) | `` terraform-providers.consul: 2.21.0 -> 2.22.0 ``                                |
| [`c0b7f398`](https://github.com/NixOS/nixpkgs/commit/c0b7f398fc3ce57e0f6cd931a5d39a3de9e8d949) | `` terraform-providers.tencentcloud: 1.82.2 -> 1.82.5 ``                          |
| [`93356f9d`](https://github.com/NixOS/nixpkgs/commit/93356f9d2b446eed3d212f0a8baa712f669f6316) | `` terraform-providers.turbot: 1.12.2 -> 1.12.3 ``                                |
| [`8ca63f4a`](https://github.com/NixOS/nixpkgs/commit/8ca63f4a9732073e777dff3ebf6371583400bb52) | `` terraform-providers.minio: 3.5.3 -> 3.5.4 ``                                   |
| [`cb8810db`](https://github.com/NixOS/nixpkgs/commit/cb8810db954620ea1683e9a2a1d6c623288c094b) | `` terraform-providers.tfe: 0.67.0 -> 0.67.1 ``                                   |
| [`d8b67334`](https://github.com/NixOS/nixpkgs/commit/d8b67334d3201280460db901448a3441ff8d92f3) | `` terraform-providers.acme: 2.32.0 -> 2.32.1 ``                                  |
| [`f9f2acee`](https://github.com/NixOS/nixpkgs/commit/f9f2aceeefc25d1c86fc6a6119c9a477ce8eec7b) | `` terraform-providers.rootly: 3.2.0 -> 3.4.0 ``                                  |
| [`55f8179b`](https://github.com/NixOS/nixpkgs/commit/55f8179bd61e26be1a10e9274791f09b8c09600c) | `` terraform-providers.buildkite: 1.20.0 -> 1.21.0 ``                             |
| [`92624515`](https://github.com/NixOS/nixpkgs/commit/92624515b8dd5faae187b600d124341c7ab98f81) | `` terraform-providers.dme: 1.0.7 -> 1.0.8 ``                                     |
| [`aadd9f16`](https://github.com/NixOS/nixpkgs/commit/aadd9f16c251fc545a5b7864bffe12993825f972) | `` terraform-providers.exoscale: 0.64.1 -> 0.64.3 ``                              |
| [`84f84402`](https://github.com/NixOS/nixpkgs/commit/84f844020d66313bf9364daabe4ea70411c804d6) | `` terraform-providers.scaleway: 2.55.0 -> 2.56.0 ``                              |
| [`8fbd2be5`](https://github.com/NixOS/nixpkgs/commit/8fbd2be535c9d6a40e792c23f60e5d7ee1820094) | `` terraform-providers.okta: 4.20.0 -> 5.0.0 ``                                   |
| [`1568424e`](https://github.com/NixOS/nixpkgs/commit/1568424ed0d4109b93f86938675adbdfa4faa695) | `` qbittorrent: 5.1.1 -> 5.1.2 ``                                                 |
| [`f96cca85`](https://github.com/NixOS/nixpkgs/commit/f96cca856c477dff3b4e7f2035c8076391a786f5) | `` storj-uplink: 1.131.4 -> 1.131.7 ``                                            |
| [`7159e3d7`](https://github.com/NixOS/nixpkgs/commit/7159e3d7b4096df4e32d419de3ee6965a0964706) | `` mame: fix darwin build ``                                                      |
| [`8c6307d1`](https://github.com/NixOS/nixpkgs/commit/8c6307d19b768aa54dec08d1ec4f3a7cfeca6878) | `` lib.systems.examples: Add rust.rustcTarget for ppc64-elfv1 ``                  |
| [`fa2929b8`](https://github.com/NixOS/nixpkgs/commit/fa2929b89f08e40e2a2a773a5164b086d7f72fd1) | `` python3Packages.torch-geometric: disable failing tests ``                      |
| [`ae1645f3`](https://github.com/NixOS/nixpkgs/commit/ae1645f344d211a80612a2645cd2f587529aa17a) | `` libretro.scummvm: 0-unstable-2025-06-03 -> 0-unstable-2025-07-03 ``            |
| [`3a676b01`](https://github.com/NixOS/nixpkgs/commit/3a676b016d290c867062b50b94792e389eea4ba9) | `` python3Packages.optuna: disable flaky test ``                                  |
| [`6f4745b6`](https://github.com/NixOS/nixpkgs/commit/6f4745b6dddcfcd928c6479f75b0b2bb5c08d920) | `` maintainers-list: remove stray maintainer entry of primeos ``                  |
| [`766ad54f`](https://github.com/NixOS/nixpkgs/commit/766ad54fde046b7970dcfa45a95a0de77eb26b9e) | `` treewide: remove primeos from maintainers ``                                   |
| [`b8900ee7`](https://github.com/NixOS/nixpkgs/commit/b8900ee731be8c5b2e62a1275af45eb6c9bcd016) | `` siyuan: 3.1.32 -> 3.2.0 ``                                                     |
| [`19fa24c3`](https://github.com/NixOS/nixpkgs/commit/19fa24c354af59b076eb1b4d030cd759660a956f) | `` better-commits: 1.17.0 -> 1.17.1 ``                                            |
| [`c90c29ba`](https://github.com/NixOS/nixpkgs/commit/c90c29bacc3d7fd2f1032d7dc5801bb57f995d0e) | `` nixos/bcachefs: Parse tags ``                                                  |
| [`8c2ea4e3`](https://github.com/NixOS/nixpkgs/commit/8c2ea4e387bef1bac79a635c1a1b98ca54d95084) | `` python3Packages.pyedflib: 0.1.40 -> 0.1.42 ``                                  |
| [`c15ac932`](https://github.com/NixOS/nixpkgs/commit/c15ac932d355e231d05ed21d3e8bb929a317a0c0) | `` clightning: add postgresql support (#422151) ``                                |
| [`9d5a7b5a`](https://github.com/NixOS/nixpkgs/commit/9d5a7b5abba591fd8f4bd5d61d1706805cbd34c4) | `` warp-terminal: 0.2025.06.25.08.12.stable_01 -> 0.2025.07.02.08.36.stable_02 `` |
| [`7a1853ed`](https://github.com/NixOS/nixpkgs/commit/7a1853ed4801c1d72a55233dbfe847c81025f730) | `` dns-collector: 1.7.0 -> 1.8.0 ``                                               |
| [`369f15b0`](https://github.com/NixOS/nixpkgs/commit/369f15b0a451221b080a69788d690ade38c42001) | `` jjui: 0.8.11 -> 0.8.12 ``                                                      |
| [`96c8f59c`](https://github.com/NixOS/nixpkgs/commit/96c8f59c8099de4702b63ac21649187cd2ce9614) | `` eduke32: 0-unstable-2025-04-11 -> 0-unstable-2025-07-04 ``                     |
| [`5451a057`](https://github.com/NixOS/nixpkgs/commit/5451a057f1abac4290121d32f76df2832efd969f) | `` particle-cli: 3.37.0 -> 3.38.1 ``                                              |
| [`76af9af8`](https://github.com/NixOS/nixpkgs/commit/76af9af8547cf7602a6040a08320ea0539218536) | `` nixos/drupal: extend module tests ``                                           |
| [`02597e4b`](https://github.com/NixOS/nixpkgs/commit/02597e4b654105d052e2dffe75d4e9705650d198) | `` s0ix-selftest-tool: 0-unstable-2024-09-22 -> 0-unstable-2025-07-01 ``          |
| [`cb1c1c24`](https://github.com/NixOS/nixpkgs/commit/cb1c1c2413f300ab3f40c0f5dd8f4bddd065027a) | `` maintainers: drop pimeys ``                                                    |
| [`87951b76`](https://github.com/NixOS/nixpkgs/commit/87951b76c081c850e31b08ab6373ae6f3db8290a) | `` databricks-cli: 0.257.0 -> 0.258.0 ``                                          |
| [`4acc22ca`](https://github.com/NixOS/nixpkgs/commit/4acc22caf616f5958042d2746921f39203277edc) | `` opencode: 0.1.185 -> 0.1.194 ``                                                |
| [`5ea515a7`](https://github.com/NixOS/nixpkgs/commit/5ea515a7eb1356dfcd58dc9c88d481ceb5acca85) | `` python3Packages.django-pghistory: init at 3.7.0 ``                             |
| [`50044f22`](https://github.com/NixOS/nixpkgs/commit/50044f22b7a9550089c33cc2922d5de81cab97c3) | `` python3Packages.pyscf: fix build ``                                            |
| [`f95d830a`](https://github.com/NixOS/nixpkgs/commit/f95d830aa32a978d59e375bdf2af9033f1ebcde8) | `` jacktrip: 2.6.0 -> 2.7.1 ``                                                    |
| [`237787db`](https://github.com/NixOS/nixpkgs/commit/237787db5aa8426e0956fa3b265b276e30151e24) | `` forecast: 0-unstable-2025-05-25 -> 0-unstable-2025-07-03 ``                    |
| [`587c9559`](https://github.com/NixOS/nixpkgs/commit/587c9559d08946963d3366a592c45298b5fd8917) | `` codex: 0.02506060849 -> 0.2.0 ``                                               |
| [`19e27676`](https://github.com/NixOS/nixpkgs/commit/19e276769275fc624b407b8d85ebd6aaf5d20603) | `` txtpbfmt: 0-unstable-2025-06-25 -> 0-unstable-2025-06-27 ``                    |
| [`355dbb13`](https://github.com/NixOS/nixpkgs/commit/355dbb134c8b7e010e773c5b49c6fc0a66bbeb26) | `` basedpyright: 1.29.4 -> 1.29.5 ``                                              |
| [`f9339c85`](https://github.com/NixOS/nixpkgs/commit/f9339c853ee7806e91ded637738fc1c794cce460) | `` nixos/postgresql: document beta versioning ``                                  |
| [`82248a6f`](https://github.com/NixOS/nixpkgs/commit/82248a6f7ae165e9061c3c5d607261ff40635588) | `` nixos/postgresql: warn about unstable status ``                                |
| [`350b5236`](https://github.com/NixOS/nixpkgs/commit/350b52366a35f681c6e12bd4f4892d204e7d4f24) | `` cfspeedtest: add changelog to meta ``                                          |
| [`4ca6869c`](https://github.com/NixOS/nixpkgs/commit/4ca6869c8cfdc570d6b5970f15cfaf626ead6877) | `` shortscan: init at 0.9.2 ``                                                    |
| [`9d74feb9`](https://github.com/NixOS/nixpkgs/commit/9d74feb9563627b3674485fd4ca17a4b7e4d0483) | `` cfspeedtest: 1.3.4 -> 1.4.1 ``                                                 |
| [`ff75103a`](https://github.com/NixOS/nixpkgs/commit/ff75103a7c54ad352565d0dd8c02c43c7b1dc238) | `` nixos/monero: allow pruning with option (#421289) ``                           |
| [`f3341335`](https://github.com/NixOS/nixpkgs/commit/f33413359f7d612da94f320f1955954b6d5046e6) | `` unwaf: init at 0-unstable-2025-07-04 ``                                        |
| [`5a6f0a43`](https://github.com/NixOS/nixpkgs/commit/5a6f0a43ae1d7c4a8ec71e749cf623076c9dcfa1) | `` nixos/nextcloud: document nextcloud-occ command ``                             |
| [`3d6e7bc3`](https://github.com/NixOS/nixpkgs/commit/3d6e7bc34e8e8face9d0781f6e6d0f35cf838520) | `` nhost-cli: 1.29.9 -> 1.31.0 ``                                                 |
| [`7dc50f45`](https://github.com/NixOS/nixpkgs/commit/7dc50f45d3cace41e19adf4887ea85691fbb2ec0) | `` zed-editor: skip test test_open_workspace_with_directory on darwin ``          |
| [`8096d0bf`](https://github.com/NixOS/nixpkgs/commit/8096d0bf377d88037d0b51d10ef2e0116370a96f) | `` barman: specify path to file ``                                                |
| [`21f2901d`](https://github.com/NixOS/nixpkgs/commit/21f2901d0c54f5b3f4fa168dfefd910a9c8ec1ae) | `` vesta: init at 1.0.10 ``                                                       |
| [`abc5cff3`](https://github.com/NixOS/nixpkgs/commit/abc5cff372a30fdd7f26444757496a3b539f7297) | `` nixos/postgresql: deduplicate `postgresql` and use cfg.finalPackage ``         |
| [`ec2006af`](https://github.com/NixOS/nixpkgs/commit/ec2006affb0f3d65b8e608ae297dcb43f3fb00e3) | `` postgresql_18: support curl/numa/uring ``                                      |
| [`6cdfc25a`](https://github.com/NixOS/nixpkgs/commit/6cdfc25ae47ecc37f8d96c839e384a67e64f44e8) | `` postgresql_18: init at 18beta1 ``                                              |
| [`7201afec`](https://github.com/NixOS/nixpkgs/commit/7201afec6ec5b8649077fc88cf8495697fd6aa50) | `` dbeaver-bin: fix app bundle on darwin ``                                       |
| [`2fe51a2d`](https://github.com/NixOS/nixpkgs/commit/2fe51a2d2c3539b82152ea49f3cd3194a488959b) | `` fusee-launcher: drop ``                                                        |