### PR TITLE
chore(flake/treefmt-nix): `ac8e6f32` -> `c9d477b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -188,11 +188,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750931469,
-        "narHash": "sha256-0IEdQB1nS+uViQw4k3VGUXntjkDp7aAlqcxdewb/hAc=",
+        "lastModified": 1752055615,
+        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "ac8e6f32e11e9c7f153823abc3ab007f2a65d3e1",
+        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                  |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`c9d477b5`](https://github.com/numtide/treefmt-nix/commit/c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9) | `` feat: add xmllint formatter (#377) `` |