### PR TITLE
chore(flake/nixvim): `4b068551` -> `eeec7f7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1752358818,
-        "narHash": "sha256-Txnm5vJqZgaHpEM/9OANg1Ux4e9xHQ7iXfQ8EqtqM9s=",
+        "lastModified": 1752447041,
+        "narHash": "sha256-n5DPC4+lI9/gM0cdogohOUjiz50jhZ5l+Xg5Ucrj76w=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4b068551d85cb4984fc60268a95097cf7af1ae48",
+        "rev": "eeec7f7c31f84b33d3c52365b073e06c21104521",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`eeec7f7c`](https://github.com/nix-community/nixvim/commit/eeec7f7c31f84b33d3c52365b073e06c21104521) | `` tests/plugins/clipboard-image: set platform-specific clipboardPackage `` |
| [`4348aa9f`](https://github.com/nix-community/nixvim/commit/4348aa9fad9f92b55c3525d5ccfafaf46d0dfb0a) | `` tests/modules/clipboard: do not enable wl-copy on non-linux platforms `` |
| [`134963b2`](https://github.com/nix-community/nixvim/commit/134963b24be51eef11ae3f1f9c38a4b87b3cf30f) | `` generated: Updated rust-analyzer.nix ``                                  |
| [`c601e136`](https://github.com/nix-community/nixvim/commit/c601e136cbd472584ec96a7da24d44a8476342ff) | `` flake/dev/flake.lock: Update ``                                          |
| [`7275ccaf`](https://github.com/nix-community/nixvim/commit/7275ccaf71b1d05e6b034353a3a70dc9924b3fdf) | `` flake.lock: Update ``                                                    |