### PR TITLE
chore(flake/nixvim): `eeec7f7c` -> `03fa28a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1752447041,
-        "narHash": "sha256-n5DPC4+lI9/gM0cdogohOUjiz50jhZ5l+Xg5Ucrj76w=",
+        "lastModified": 1752496197,
+        "narHash": "sha256-yADANK6gJL+BJrL0f450RGCZlUixCuYSoEqdjmBE5nY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "eeec7f7c31f84b33d3c52365b073e06c21104521",
+        "rev": "03fa28a65f23210934cb3a3c0454eb8870af748b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`03fa28a6`](https://github.com/nix-community/nixvim/commit/03fa28a65f23210934cb3a3c0454eb8870af748b) | `` flake/dev/flake.lock: Update ``              |
| [`95fae10d`](https://github.com/nix-community/nixvim/commit/95fae10d35fe9f21bb350c2ea6448ed9eb9b4bd1) | `` tests/spider: update test ``                 |
| [`82271c28`](https://github.com/nix-community/nixvim/commit/82271c28efec30a2010687783c13d1a5eea1dfa3) | `` plugins/spider: migrate to mkNeovimPlugin `` |
| [`d80d42f0`](https://github.com/nix-community/nixvim/commit/d80d42f066365d67bf1eb966f58825e605541d4c) | `` maintainers: add saygo-png ``                |