### PR TITLE
chore(flake/nixvim): `03fa28a6` -> `1fb1bf8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1752496197,
-        "narHash": "sha256-yADANK6gJL+BJrL0f450RGCZlUixCuYSoEqdjmBE5nY=",
+        "lastModified": 1752546848,
+        "narHash": "sha256-WzHqmJ1wEZoUGAedomwcVLCuNsiB9bZzZXk7K9ZDBwk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "03fa28a65f23210934cb3a3c0454eb8870af748b",
+        "rev": "1fb1bf8a73ccf207dbe967cdb7f2f4e0122c8bd5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`1fb1bf8a`](https://github.com/nix-community/nixvim/commit/1fb1bf8a73ccf207dbe967cdb7f2f4e0122c8bd5) | `` flake: move formatting and git hooks into dedicated modules `` |
| [`97819ce5`](https://github.com/nix-community/nixvim/commit/97819ce539618efb4e4e6c5c340f5a59273cd177) | `` ci/buildbot: build treefmt checks ``                           |
| [`bd295bd3`](https://github.com/nix-community/nixvim/commit/bd295bd3993716d024afd99fb59fd9232ca63d0a) | `` ci/tag-maintainers: run treefmt ``                             |