### PR TITLE
chore(flake/nixvim): `1fb1bf8a` -> `0c50ed93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1752546848,
-        "narHash": "sha256-WzHqmJ1wEZoUGAedomwcVLCuNsiB9bZzZXk7K9ZDBwk=",
+        "lastModified": 1752976861,
+        "narHash": "sha256-59HcrqHfbSJUdmpzrAa9x8fW1PoS+ZGhCjL5k5HbyV8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1fb1bf8a73ccf207dbe967cdb7f2f4e0122c8bd5",
+        "rev": "0c50ed9349199219583cb1ed1a972d71e06039ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`0c50ed93`](https://github.com/nix-community/nixvim/commit/0c50ed9349199219583cb1ed1a972d71e06039ec) | `` lsp-packages: rename starpls-bin to starpls `` |
| [`01b7101b`](https://github.com/nix-community/nixvim/commit/01b7101bdc91616ea6a45093f3cbd1bedf5fcd21) | `` render-markdown: correct link to docs ``       |
| [`60556b5d`](https://github.com/nix-community/nixvim/commit/60556b5df9b70b7be88de760e695892b9ce74b9e) | `` plugins/no-neck-pain: init ``                  |
| [`cebc5458`](https://github.com/nix-community/nixvim/commit/cebc5458ce95c1fb7fdeaae96c357d04e5f3920c) | `` maintainers: add ChelseaWilkinson ``           |
| [`bc0555c8`](https://github.com/nix-community/nixvim/commit/bc0555c8694d43fb63ae2c7afec08b6987431a04) | `` plugins/img-clip: init ``                      |
| [`7ad0cadd`](https://github.com/nix-community/nixvim/commit/7ad0cadd8b0e7025f4c4d6cb073d79a0b75e4446) | `` plugins/lualine: fix description ``            |