### PR TITLE
chore(flake/nixpkgs): `62e0f05e` -> `6e987485`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752480373,
-        "narHash": "sha256-JHQbm+OcGp32wAsXTE/FLYGNpb+4GLi5oTvCxwSoBOA=",
+        "lastModified": 1752687322,
+        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62e0f05ede1da0d54515d4ea8ce9c733f12d9f08",
+        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`6a74f383`](https://github.com/NixOS/nixpkgs/commit/6a74f3839d0d4a5440822af3b9d9348a00a2070f) | `` gccNGPackages_15.gcc: drop unused `libelf` dependency ``                              |
| [`30cee69b`](https://github.com/NixOS/nixpkgs/commit/30cee69bb9ccfb280a9edafbb39b7eef713de47b) | `` haskellPackages.Agda: set `mainProgram` ``                                            |
| [`cde1ef6d`](https://github.com/NixOS/nixpkgs/commit/cde1ef6d8822a87f4de8d9a1fb8b2b3125e14565) | `` python3Packages.inequality: 1.1.1 -> 1.1.2 ``                                         |
| [`0e7fd3eb`](https://github.com/NixOS/nixpkgs/commit/0e7fd3eb2ca6427fc5bdf73e2974de2065876e97) | `` mint-themes: 2.2.6 -> 2.3.0 ``                                                        |
| [`4c3870b2`](https://github.com/NixOS/nixpkgs/commit/4c3870b23dded4e75292be48bdb03cd870fb1719) | `` mesa: 25.1.5 -> 25.1.6 ``                                                             |
| [`4d3c5d0d`](https://github.com/NixOS/nixpkgs/commit/4d3c5d0dc3217d356c123080ac0c5ca58002c031) | `` agda: use `getBin Agda` instead of `Agda.bin` ``                                      |
| [`6b5d556b`](https://github.com/NixOS/nixpkgs/commit/6b5d556b4f6823062f362280969aba6b48f8549c) | `` vectorchord: update for rust 1.88.0 ``                                                |
| [`75ec16f9`](https://github.com/NixOS/nixpkgs/commit/75ec16f97e572c110af0200615ef7dae8bd4b697) | `` esp-generate: 0.4.0 -> 0.5.0 ``                                                       |
| [`1c840ff2`](https://github.com/NixOS/nixpkgs/commit/1c840ff21d41136e3e7c6aa880a9f10ef4376a07) | `` makeSetupHook: add propagatedNativeBuildInputs argument ``                            |
| [`3e2c2cd8`](https://github.com/NixOS/nixpkgs/commit/3e2c2cd8f45e8b360fd09e44ae6c95b511fc2fa5) | `` buildComposerProject: change propagatedBuildInputs to propagatedNativeBuildInputs ``  |
| [`33260f2e`](https://github.com/NixOS/nixpkgs/commit/33260f2ea02e6bf2703eef8d42ddc4835e06e6a5) | `` basiliskii: unstable-2022-09-30 -> unstable-2025-07-16 ``                             |
| [`233710fd`](https://github.com/NixOS/nixpkgs/commit/233710fd297d543ca77b606af55ddee77bcf1829) | `` basiliskii: add sheep_net comment to src ``                                           |
| [`c58a266a`](https://github.com/NixOS/nixpkgs/commit/c58a266a1eafa8711e33729ccea15c40fa6b7ba0) | `` sheep_net: init ``                                                                    |
| [`bdb2e09e`](https://github.com/NixOS/nixpkgs/commit/bdb2e09e486a7e5052676575ad334fd6cdb11ae1) | `` dnscontrol: 4.21.0 -> 4.22.0 ``                                                       |
| [`ff93fe23`](https://github.com/NixOS/nixpkgs/commit/ff93fe234660fe9c878ba1dff30963554cc16dbb) | `` python3Packages.django-pydantic-field: init at 0.3.13 ``                              |
| [`228ceaaa`](https://github.com/NixOS/nixpkgs/commit/228ceaaa7f775cc0d5e8387b8955f56c550566d9) | `` syslogng: 4.8.3 -> 4.9.0 ``                                                           |
| [`59c6bfcf`](https://github.com/NixOS/nixpkgs/commit/59c6bfcfaa069d22194e8def4ec361cb61c701ca) | `` mongodb-atlas-cli: 1.45.1 -> 1.46.2 ``                                                |
| [`0f964599`](https://github.com/NixOS/nixpkgs/commit/0f964599a57346d0408372e4df7652908cac6abe) | `` nixos/nginx: remove usage of recommendedZstdSettings and zstd settings duplication `` |
| [`2de11e1e`](https://github.com/NixOS/nixpkgs/commit/2de11e1e9620fb7695abc3d8f40ae0b0f3dea444) | `` buildComposerProject: Drop moreutils dependency ``                                    |
| [`d709e791`](https://github.com/NixOS/nixpkgs/commit/d709e7915788297f013d382b3c821f7d5187b21a) | `` nix-ld: 2.0.4 -> 2.0.5 ``                                                             |
| [`4e8394cf`](https://github.com/NixOS/nixpkgs/commit/4e8394cfa77c9e26dbd7ca070f3c33901c31a767) | `` esphome: 2025.6.3 -> 2025.7.0 ``                                                      |
| [`e23883f0`](https://github.com/NixOS/nixpkgs/commit/e23883f0175ec1ec268c4042c0fba94fedc71408) | `` meli: include notmuch in LD_LIBRARY_PATH by default ``                                |
| [`3c51f84b`](https://github.com/NixOS/nixpkgs/commit/3c51f84b8b24e17033dff4ab4036728f9a7015be) | `` reaper: 7.41 -> 7.42 ``                                                               |
| [`b46cb232`](https://github.com/NixOS/nixpkgs/commit/b46cb23251b43bd963ea48fd414fd2cf9ac739f6) | `` ci/github-script/commits: init from ci/check-cherry-picks ``                          |
| [`a15f79a5`](https://github.com/NixOS/nixpkgs/commit/a15f79a5d2abace70512fe3bdd2b7338baa85c1d) | `` scx.cscheds: fix build ``                                                             |
| [`ff86cbb5`](https://github.com/NixOS/nixpkgs/commit/ff86cbb5c2d89dcd0cbbc5e7fd0de780ab65a59f) | `` scx.full: 1.0.13 -> 1.0.14 ``                                                         |
| [`42e21ee3`](https://github.com/NixOS/nixpkgs/commit/42e21ee3fef148e0fc4fd48b0d754caabe8a2578) | `` python3Packages.docling-serve: 0.11.0 -> 0.14.0 ``                                    |
| [`f22b5226`](https://github.com/NixOS/nixpkgs/commit/f22b522642dae1e65a370b5a79605e6b9ba98643) | `` docling: 2.31.2 -> 2.41.0 ``                                                          |
| [`5420ae11`](https://github.com/NixOS/nixpkgs/commit/5420ae11ea6a0925e2b6a9e1155a96531e789ab6) | `` nixos/minio: harden service ``                                                        |
| [`b7657a9a`](https://github.com/NixOS/nixpkgs/commit/b7657a9acd98caf35916d97ce90d68166f5d3b08) | `` python3Packages.docling-core: 2.31.2 -> 2.43.0 ``                                     |
| [`ebd4b7c9`](https://github.com/NixOS/nixpkgs/commit/ebd4b7c9ab413858bbf94c561b17d6587a2f0ddc) | `` libeufin: update deps ``                                                              |
| [`b0c67402`](https://github.com/NixOS/nixpkgs/commit/b0c674021e3876c066aaad5889a4f9c308637961) | `` kitty: 0.42.1 -> 0.42.2 ``                                                            |
| [`2134b7b4`](https://github.com/NixOS/nixpkgs/commit/2134b7b44120c3b440d7bf081ec9c6ad0a88d5a8) | `` gimp: fix build with gettext 0.25 ``                                                  |
| [`26066e3f`](https://github.com/NixOS/nixpkgs/commit/26066e3f3fd4ad9bc76cc7a59e60be92cd87c485) | `` python3Packages.posthog: 6.0.2 -> 6.1.0 ``                                            |
| [`1c844362`](https://github.com/NixOS/nixpkgs/commit/1c844362864edc2f449e98564a3dd7ac7ee6e5f3) | `` plantuml: 1.2025.3 -> 1.2025.4 ``                                                     |
| [`6c88746b`](https://github.com/NixOS/nixpkgs/commit/6c88746b3ef830565b10d24587a7e5ff741dea7c) | `` spek: unpin autoconf ``                                                               |
| [`429401d7`](https://github.com/NixOS/nixpkgs/commit/429401d7e5b8bb9da5a464bc84a7c61e14f87673) | `` python3Packages.docling-ibm-models: 3.4.4 -> 3.8.1 ``                                 |
| [`4763c096`](https://github.com/NixOS/nixpkgs/commit/4763c0969483b517212c7e1ada89943b4977d249) | `` fselect: 0.8.12 -> 0.9.0 ``                                                           |
| [`1c82e688`](https://github.com/NixOS/nixpkgs/commit/1c82e688dc81a11c9d5eeacb65e4b7f24032b45a) | `` mdbtools: improve ``                                                                  |
| [`c8f05bbd`](https://github.com/NixOS/nixpkgs/commit/c8f05bbd5cfbfd6cfcb92c5b6312a11c69a2629c) | `` vscode: 1.101.2 -> 1.102.0 ``                                                         |
| [`3794b8a2`](https://github.com/NixOS/nixpkgs/commit/3794b8a20b196aa08ef8b6a46f042ff5031b2cb3) | `` mdbtools: fix build failure ``                                                        |
| [`8a84087d`](https://github.com/NixOS/nixpkgs/commit/8a84087de6e322bb049b5c6f7e0d741d188d5757) | `` rqlite: 8.38.3 -> 8.39.1 ``                                                           |
| [`b3c1f474`](https://github.com/NixOS/nixpkgs/commit/b3c1f47452061613315064a4b6ed2b2cbf23495e) | `` openstack-rs: 0.12.3 -> 0.12.4 ``                                                     |
| [`bd16676f`](https://github.com/NixOS/nixpkgs/commit/bd16676f18040e23761b54a98e9d906a962220ae) | `` mdbook: 0.4.51 -> 0.4.52 ``                                                           |
| [`a3beea84`](https://github.com/NixOS/nixpkgs/commit/a3beea842d63eee116ed7caf6eb6aeb153a916ee) | `` plasma-plugin-blurredwallpaper: 3.2.1 -> 3.3.1 ``                                     |
| [`82c97886`](https://github.com/NixOS/nixpkgs/commit/82c97886e6ea076f22f97dc888d90b7a5924036d) | `` vimPlugins.jdd-nvim: use correct package ``                                           |
| [`c5fd7044`](https://github.com/NixOS/nixpkgs/commit/c5fd704443f445e67fed65ffd700457318de6378) | `` zoneminder: set platforms to linux ``                                                 |
| [`64b3184e`](https://github.com/NixOS/nixpkgs/commit/64b3184ee24d7973f8c6098165557b3af3d6220a) | `` python3Packages.elevenlabs: 2.5.0 -> 2.7.1 ``                                         |
| [`bbb9e7bc`](https://github.com/NixOS/nixpkgs/commit/bbb9e7bc731e49942ad57c47c892b9174b816fc3) | `` emacsPackages.lsp-bridge: 0-unstable-2025-02-10 -> 0-unstable-2025-06-28 ``           |
| [`30b23cd8`](https://github.com/NixOS/nixpkgs/commit/30b23cd88ff8406e97d25ce07dad87c05c92e6b4) | `` polarity: latest-unstable-2025-07-06 -> latest-unstable-2025-07-15 ``                 |
| [`8270f9a3`](https://github.com/NixOS/nixpkgs/commit/8270f9a3eb6a1641d5aed823488bd7e79946ab28) | `` cargo-sonar: 1.3.0 -> 1.3.1 ``                                                        |
| [`98d8c2c1`](https://github.com/NixOS/nixpkgs/commit/98d8c2c1fc74beb14c21471559094e19b45b1cc0) | `` rockcraft: 1.12.0 -> 1.13.0 ``                                                        |
| [`1fc68917`](https://github.com/NixOS/nixpkgs/commit/1fc68917415080b32068d545748b202ef5076fc3) | `` aider-chat: move to top-level ``                                                      |
| [`909511f5`](https://github.com/NixOS/nixpkgs/commit/909511f5157a6e98b4305e76a04fe3ad22266d2e) | `` gowebly: 3.0.4 -> 3.0.5 ``                                                            |
| [`57020c8a`](https://github.com/NixOS/nixpkgs/commit/57020c8a24508332ee6b4420dc5093429fe7cf6d) | `` inputplumber: 0.59.2 -> 0.60.2 ``                                                     |
| [`e8ff439e`](https://github.com/NixOS/nixpkgs/commit/e8ff439e4eda48ad937e2af5eadf8a90a1d76e9a) | `` hmcl: 3.6.13 -> 3.6.14 ``                                                             |
| [`bbc5f300`](https://github.com/NixOS/nixpkgs/commit/bbc5f300fd0bc88483216a60484523e0fa7dfc69) | `` audacious: 4.4.2 -> 4.5 ``                                                            |
| [`c8adab7a`](https://github.com/NixOS/nixpkgs/commit/c8adab7afc510a58907089eb3bd3aa80801c61b8) | `` audacious-bare: 4.4.2 -> 4.5 ``                                                       |
| [`12d4ca9b`](https://github.com/NixOS/nixpkgs/commit/12d4ca9bc82c4d35a403c4f721dde49445ec9e5c) | `` olympus-unwrapped: 25.06.28.03 -> 25.07.12.01 ``                                      |
| [`74a4f8c2`](https://github.com/NixOS/nixpkgs/commit/74a4f8c287ed2c0b8bd1b244e63ba7f30ca33a85) | `` moonlight: 1.3.22 -> 1.3.23 ``                                                        |
| [`364d351e`](https://github.com/NixOS/nixpkgs/commit/364d351e266764902980e4a533986b692aceab14) | `` python3Packages.edk2-pytool-library: 0.23.4 -> 0.23.6 ``                              |
| [`74c6279d`](https://github.com/NixOS/nixpkgs/commit/74c6279d5b8040f5c05adae12483e1d3666c8777) | `` pds: 0.4.107 -> 0.4.158 ``                                                            |
| [`ba8fd8b1`](https://github.com/NixOS/nixpkgs/commit/ba8fd8b12413706dc48cdf5118dc8977f0ab9eae) | `` andcli: 2.2.0 -> 2.3.0 ``                                                             |
| [`db33c32e`](https://github.com/NixOS/nixpkgs/commit/db33c32e8949ad4b4ba2efcb4994a514fd7d2340) | `` gatekeeper: 3.19.2 -> 3.19.3 ``                                                       |
| [`08238dfe`](https://github.com/NixOS/nixpkgs/commit/08238dfea5af214af627900bd9e7aa96dbfcf8a8) | `` libretro-shaders-slang: 0-unstable-2025-07-03 -> 0-unstable-2025-07-13 ``             |
| [`9ac1f181`](https://github.com/NixOS/nixpkgs/commit/9ac1f1812b524074dd479bc40396a0700ecf078b) | `` vencord: add myself as maintainer ``                                                  |
| [`ac000d58`](https://github.com/NixOS/nixpkgs/commit/ac000d58a62196c95673271c9459802281b5e493) | `` xloadimage: fix patch application ``                                                  |
| [`3586f415`](https://github.com/NixOS/nixpkgs/commit/3586f415fff32b9f6b4a182c3164123fe8bb77ba) | `` jdk8: disable structuredAttrs ``                                                      |
| [`fbc56958`](https://github.com/NixOS/nixpkgs/commit/fbc56958afdf83f0b1bc3be6d9540bcc0deb0971) | `` nixos/pfix-srsd: migrate postfix integration from postfix module ``                   |
| [`ed74f025`](https://github.com/NixOS/nixpkgs/commit/ed74f025156f1e4c57664607324dcd58a94d21a4) | `` nixos-facter: 0.4.0 -> 0.4.1 ``                                                       |
| [`b8536c60`](https://github.com/NixOS/nixpkgs/commit/b8536c602f90bb2b770b5f90f9b6300c19c5ba59) | `` helix: 25.01.1 -> 25.07 ``                                                            |
| [`3ef5cc31`](https://github.com/NixOS/nixpkgs/commit/3ef5cc311650f366cfa59904e5f672621f4d0db1) | `` python3Packages.fabric: fix build ``                                                  |
| [`ed5d1cd5`](https://github.com/NixOS/nixpkgs/commit/ed5d1cd52f28286176253f647b254a8a09b8a094) | `` python3Packages.django-types: 0.20.0 -> 0.22.0 ``                                     |
| [`e5d9fa40`](https://github.com/NixOS/nixpkgs/commit/e5d9fa401609cbacc89440be2847710e4a67930a) | `` chromium,chromedriver: 138.0.7204.100 -> 138.0.7204.157 ``                            |
| [`1f4c9bb1`](https://github.com/NixOS/nixpkgs/commit/1f4c9bb1a68701c50a88069da1d22ff35a6767dd) | `` python3Packages.posthog: add missing dep `typing-extensions` ``                       |
| [`966fc630`](https://github.com/NixOS/nixpkgs/commit/966fc630ddfae521af2fc9f5575a78275145827d) | `` tests.srcOnly: Work around duplication of attr on darwin ``                           |
| [`d93bb6f4`](https://github.com/NixOS/nixpkgs/commit/d93bb6f46ab4e33732f403a4f0aaff45ac020237) | `` tests.srcOnly: Use zlib instead of glibc ``                                           |
| [`af9b49ed`](https://github.com/NixOS/nixpkgs/commit/af9b49edab7bb92b319ff459c9ed52bd4a45f1ec) | `` tests.srcOnly: Add test cases for equivalences in the interface ``                    |
| [`f7b948a4`](https://github.com/NixOS/nixpkgs/commit/f7b948a4da244c8083a725f4e3bcf63b1ff3767a) | `` pluto: 5.21.8 -> 5.22.0 ``                                                            |
| [`c915f104`](https://github.com/NixOS/nixpkgs/commit/c915f104b0c8f231855a451d71678085ca9eab01) | `` nixos/postsrsd: add package option, migrate enable option ``                          |
| [`9a9073fc`](https://github.com/NixOS/nixpkgs/commit/9a9073fc8971a700fb08bb105adc2100fd3fc26f) | `` nixos/postsrsd: integrate with postfix by default ``                                  |
| [`3a501b6a`](https://github.com/NixOS/nixpkgs/commit/3a501b6a430182bc2cdd289b4633fb54ba9cb2f0) | `` python3Packages.aider-chat: disable additional tests that require network access ``   |
| [`3cf7dc23`](https://github.com/NixOS/nixpkgs/commit/3cf7dc230744f7667d2ec1a2c951d8e610172ba9) | `` tor.updateScript: use callPackage ``                                                  |
| [`338121d8`](https://github.com/NixOS/nixpkgs/commit/338121d8754466a9c69a878b9d07e77edc9eab2a) | `` tor: sandbox is no longer broken on aarch64-linux ``                                  |
| [`9783bde2`](https://github.com/NixOS/nixpkgs/commit/9783bde2f4bfa5bcf65423925520118c38e08300) | `` nixos/sheep-net: init ``                                                              |
| [`819c34cb`](https://github.com/NixOS/nixpkgs/commit/819c34cb7f485c4f813e0dd87f6ba842970c864b) | `` nixos/postsrsd: harden and modernize systemd unit ``                                  |
| [`83af4a9a`](https://github.com/NixOS/nixpkgs/commit/83af4a9aed805366fc92a249eaf6d8e6617733d5) | `` nixos/postsrsd: migrate to rfc42 settings ``                                          |
| [`dba9b2cb`](https://github.com/NixOS/nixpkgs/commit/dba9b2cb9c73110b5603e209a187f8617a8c9966) | `` nixos/kryoflux: fix typo programs.kryoflux -> hardware.kryoflux ``                    |