### PR TITLE
chore(flake/treefmt-nix): `421b5631` -> `2673921c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -188,11 +188,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753006367,
-        "narHash": "sha256-tzbhc4XttkyEhswByk5R38l+ztN9UDbnj0cTcP6Hp9A=",
+        "lastModified": 1753439394,
+        "narHash": "sha256-Bv9h1AJegLI8uAhiJ1sZ4XAndYxhgf38tMgCQwiEpmc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "421b56313c65a0815a52b424777f55acf0b56ddf",
+        "rev": "2673921c03d6e75fdf4aa93e025772608d1482cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`2673921c`](https://github.com/numtide/treefmt-nix/commit/2673921c03d6e75fdf4aa93e025772608d1482cf) | `` fix: Fix flake check not working in repository with git-lfs (#376) `` |
| [`7abcb412`](https://github.com/numtide/treefmt-nix/commit/7abcb412b5402f8828236fb40432af023af3f51d) | `` Add Hujsonfmt formatter (#367) ``                                     |
| [`2105d68a`](https://github.com/numtide/treefmt-nix/commit/2105d68a0c0b2bfcb2cc3c01646136d5b139de4e) | `` feat: add dockfmt formatter (#388) ``                                 |