### PR TITLE
chore(flake/nixvim): `3d09c8ea` -> `29edaafd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1753487377,
-        "narHash": "sha256-dEr3pYtC4/1PhP5ADIV8Fjjmxv6WC6UisQAUqtwdews=",
+        "lastModified": 1753533009,
+        "narHash": "sha256-4KlfDVsYL9c3ogEehJcQOBZ+pUBH7Lwvlu2J6FCtSJc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "3d09c8eaceb7a78ef9f5568024da1616f00c33e3",
+        "rev": "29edaafdb088cee3d8c616a4a5bb48b5eecc647c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`29edaafd`](https://github.com/nix-community/nixvim/commit/29edaafdb088cee3d8c616a4a5bb48b5eecc647c) | `` flake/dev/flake.lock: Update `` |
| [`a6d48026`](https://github.com/nix-community/nixvim/commit/a6d4802653c35d1ac26cd340699ec06487b05916) | `` flake.lock: Update ``           |