### PR TITLE
chore(flake/nixpkgs): `fc02ee70` -> `7fd36ee8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753250450,
-        "narHash": "sha256-i+CQV2rPmP8wHxj0aq4siYyohHwVlsh40kV89f3nw1s=",
+        "lastModified": 1753429684,
+        "narHash": "sha256-9h7+4/53cSfQ/uA3pSvCaBepmZaz/dLlLVJnbQ+SJjk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fc02ee70efb805d3b2865908a13ddd4474557ecf",
+        "rev": "7fd36ee82c0275fb545775cc5e4d30542899511d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`ab80b6e3`](https://github.com/NixOS/nixpkgs/commit/ab80b6e327563e8a1ad54725720ed064733b9f73) | `` clash-verge-rev: unmaintain ``                                    |
| [`4481a556`](https://github.com/NixOS/nixpkgs/commit/4481a556b4727bcbe0fbb1267ddc1247c7eb0cc5) | `` plexRaw: 1.41.8.9834-071366d65 -> 1.41.9.9961-46083195d ``        |
| [`64f71834`](https://github.com/NixOS/nixpkgs/commit/64f718340334fc462eeecda20feb2eb58ff0953a) | `` tippecanoe: 2.78.0 -> 2.79.0 ``                                   |
| [`7882a4d8`](https://github.com/NixOS/nixpkgs/commit/7882a4d8d03aefde992bfaafe8e847bab2dcd242) | `` goreleaser: 2.11.0 -> 2.11.1 ``                                   |
| [`1fab4916`](https://github.com/NixOS/nixpkgs/commit/1fab4916ef2e755ecad224ece333c73cd3e1f6b5) | `` pkgsite: 0-unstable-2025-07-14 -> 0-unstable-2025-07-21 ``        |
| [`2a7af117`](https://github.com/NixOS/nixpkgs/commit/2a7af117f69e31ba118dfd277ea272fae3c1ea92) | `` owmods-gui: 0.15.0 -> 0.15.3 ``                                   |
| [`4f93d9a2`](https://github.com/NixOS/nixpkgs/commit/4f93d9a2d14a0cf36c9e0c357f107959521d9658) | `` mx-puppet-discord: remove ``                                      |
| [`9bc7e0c5`](https://github.com/NixOS/nixpkgs/commit/9bc7e0c5586f653f3440847660930705d838e2c5) | `` claude-code: 1.0.58 -> 1.0.60 ``                                  |
| [`9bc133cb`](https://github.com/NixOS/nixpkgs/commit/9bc133cb47e24dc8963eb4e0d452aa47e42b9c5e) | `` clash-verge-rev: add hhr2020 as maintainer ``                     |
| [`bd5a4aea`](https://github.com/NixOS/nixpkgs/commit/bd5a4aea4c07244ca5e819df7d2ca7faaa02e2f9) | `` maintainers: add hhr2020 ``                                       |
| [`117b647f`](https://github.com/NixOS/nixpkgs/commit/117b647f095ab9ab9923f5c99364a2070d9bf9e0) | `` rimsort: run nixfmt ``                                            |
| [`1b2ebc4a`](https://github.com/NixOS/nixpkgs/commit/1b2ebc4a4dceefd02717adbe6de8646cd7694503) | `` cnquery: 11.60.0 -> 11.64.0 ``                                    |
| [`e8809a8f`](https://github.com/NixOS/nixpkgs/commit/e8809a8f5f64d1482f6f35e5237f25760952f980) | `` music-assistant: 2.5.2 -> 2.5.5 ``                                |
| [`baf4e2f5`](https://github.com/NixOS/nixpkgs/commit/baf4e2f5951652e107376ccc46fcf3ac277521d4) | `` python3Packages.py-opensonic: 5.3.1 -> 7.0.2 ``                   |
| [`126b37d7`](https://github.com/NixOS/nixpkgs/commit/126b37d7a3793ba77461fdb2d19933a074a46510) | `` python3Packages.dmsuite: init at 0.3.0 ``                         |
| [`576771e9`](https://github.com/NixOS/nixpkgs/commit/576771e90b781a046a513f5328bafd9d0f420ec8) | `` python3Packages.unidecode: 1.3.8 -> 1.4.0 ``                      |
| [`40374217`](https://github.com/NixOS/nixpkgs/commit/40374217e3a2a3e3c4fc4fa068bf2d46471b3595) | `` python3Packages.oslo-db: 17.2.1 -> 17.3.0 ``                      |
| [`de39e660`](https://github.com/NixOS/nixpkgs/commit/de39e660bba6405d5722addcd93aa8c02131c44f) | `` vscode-extensions.saoudrizwan.claude-dev: 3.19.5 -> 3.20.1 ``     |
| [`65a1a798`](https://github.com/NixOS/nixpkgs/commit/65a1a7985a7024cce00cf77a688a9f08184f92b5) | `` nixos/mautrix-whatsapp: adapt to new config file format ``        |
| [`07215ec6`](https://github.com/NixOS/nixpkgs/commit/07215ec60f521b471b2db70dd293e4bc581a761e) | `` jetbrains-jdk: add missing runtime dependency. ``                 |
| [`50fbd333`](https://github.com/NixOS/nixpkgs/commit/50fbd3334953a47b0bae0c9f88b98432c735fcfe) | `` jetbrains.jdk: 21.0.6-b895.109 -> 21.0.7-1038.58 ``               |
| [`a85752ec`](https://github.com/NixOS/nixpkgs/commit/a85752ec56d490bccd0522c3dbdd0b31003ee2bc) | `` snazy: 0.57.1 -> 0.57.2 ``                                        |
| [`ccc60473`](https://github.com/NixOS/nixpkgs/commit/ccc604730bd522e47473a3ff3439863f9751ba00) | `` comma: 2.2.0 -> 2.3.0 ``                                          |
| [`9beb04d0`](https://github.com/NixOS/nixpkgs/commit/9beb04d0b900e5312bb4d8694f104b8f52fc7472) | `` python3Packages.napalm-ros: add python313 support ``              |
| [`8caacb2e`](https://github.com/NixOS/nixpkgs/commit/8caacb2e8f3f3dfac34d4d44915a0885470dd00f) | `` jetbrains.jdk-17-*: 17.0.11-b1207.24 -> 17.0.15-b1381 ``          |
| [`969b2003`](https://github.com/NixOS/nixpkgs/commit/969b2003466122d52d5c9b608ad89bbb0865584b) | `` .git-blame-ignore-revs: add nixfmt 1.0.0 commits ``               |
| [`c3fc602d`](https://github.com/NixOS/nixpkgs/commit/c3fc602dc506c2bda5952c84473e61daab1173a1) | `` ast-grep: 0.38.7 -> 0.39.1 (#427073) ``                           |
| [`7f440c85`](https://github.com/NixOS/nixpkgs/commit/7f440c85b586286e843034357a799462ade3d7f1) | `` terraform-providers.newrelic: 3.63.0 -> 3.64.0 ``                 |
| [`27de43f7`](https://github.com/NixOS/nixpkgs/commit/27de43f766c095cf5371d862fa19ebd44a9aaa41) | `` jan: 0.5.17 -> 0.6.5 (#424117) ``                                 |
| [`61d4790d`](https://github.com/NixOS/nixpkgs/commit/61d4790d3d4dcdfb670185a764660bee54185629) | `` bloodhound: adjust repository ``                                  |
| [`1cc578e8`](https://github.com/NixOS/nixpkgs/commit/1cc578e8dbf3e9a9ed5584c234cf5b8298a9c820) | `` mergiraf: 0.12.1 -> 0.13.0 (#428020) ``                           |
| [`cb837e8b`](https://github.com/NixOS/nixpkgs/commit/cb837e8bfc9e52683015e4da36408f7880db16a5) | `` heroic-unwrapped: 2.17.2 -> 2.18.0 ``                             |
| [`81ec63b2`](https://github.com/NixOS/nixpkgs/commit/81ec63b2c945343500282ad3f66b2f11812168a8) | `` vimPlugins.blink-cmp: add llakala as maintainer ``                |
| [`53413b0c`](https://github.com/NixOS/nixpkgs/commit/53413b0ce1b11fd989e4eb43ac88fa08597f69c3) | `` vimPlugins.blink-cmp: 1.5.1 -> 1.6.0 ``                           |
| [`c3bca25b`](https://github.com/NixOS/nixpkgs/commit/c3bca25b1fae15c3ebf95d534f4dfa80e9fe0c2d) | `` bruno: 2.7.0 -> 2.8.0 ``                                          |
| [`b9c53291`](https://github.com/NixOS/nixpkgs/commit/b9c53291e9cf10c76dfbfbc3f2d0f27ea0f26e32) | `` multipass: 1.15.1 -> 1.16.0 ``                                    |
| [`5d08e168`](https://github.com/NixOS/nixpkgs/commit/5d08e168a58d835e08b97411f58eebdcc364ffa9) | `` opengamepadui: 0.40.3 -> 0.40.4 ``                                |
| [`41221c2f`](https://github.com/NixOS/nixpkgs/commit/41221c2fe992e3014a64556531621fc090ad5341) | `` olive-editor: fix building with newer robin-map ``                |
| [`2e1263f0`](https://github.com/NixOS/nixpkgs/commit/2e1263f05a34d9379c180dbd6862f5e94d179ca6) | `` robin-map: 1.3.0 -> 1.4.0 ``                                      |
| [`651aae58`](https://github.com/NixOS/nixpkgs/commit/651aae58b41a9f6463eb7190820b1d1a0bfb1cca) | `` openimageio_2: drop ``                                            |
| [`77e5b432`](https://github.com/NixOS/nixpkgs/commit/77e5b4329024605e02d3941f53121dc8589b0deb) | `` embree2: unpin openimageio ``                                     |
| [`e45acc03`](https://github.com/NixOS/nixpkgs/commit/e45acc03ce438dd5d15a9a588102ed694e78fe28) | `` gpupad: unpin openimageio ``                                      |
| [`ade1c6ec`](https://github.com/NixOS/nixpkgs/commit/ade1c6ec36b941f3be8471be567ce520d8e0c16c) | `` blender: unpin openimageio ``                                     |
| [`dd6fc34a`](https://github.com/NixOS/nixpkgs/commit/dd6fc34a7043f12cf2414c9bd4e8acf80844b274) | `` materialx: 1.38.10 -> 1.39.3 ``                                   |
| [`b6088b0d`](https://github.com/NixOS/nixpkgs/commit/b6088b0d8e13e8d18464d78935f0130052784658) | `` nixos/nextcloud: remove with lib usage ``                         |
| [`be6ae54b`](https://github.com/NixOS/nixpkgs/commit/be6ae54b7d13da8bd42a9b3906285bd831b12e30) | `` scudcloud: drop ``                                                |
| [`4944afac`](https://github.com/NixOS/nixpkgs/commit/4944afacdc8e8084d97a58b5f31eae1a63ab31d8) | `` consul-template: 0.41.0 -> 0.41.1 ``                              |
| [`cba7a76c`](https://github.com/NixOS/nixpkgs/commit/cba7a76c0f25ada1bf49ad7f85ee4c953fce394a) | `` chhoto-url: 6.2.10 -> 6.2.11 ``                                   |
| [`b9ddb3a8`](https://github.com/NixOS/nixpkgs/commit/b9ddb3a879868573d24e5ee26d74c020104267ce) | `` bcc: remove sed logic, add pythonImportsCheck ``                  |
| [`56c0cb43`](https://github.com/NixOS/nixpkgs/commit/56c0cb435105c250e31a67eff2ecafc94b847027) | `` python3Packages.trimesh: 4.7.0 -> 4.7.1 ``                        |
| [`3be3dfde`](https://github.com/NixOS/nixpkgs/commit/3be3dfdee406c8d39de582fad36f317de5341120) | `` cloneit: 0-unstable-2024-06-28 -> 1.0.0-unstable-2025-07-22 ``    |
| [`beba2af4`](https://github.com/NixOS/nixpkgs/commit/beba2af482507e132ca4cc14fb5c940e437887f5) | `` alsa-lib: provide update script ``                                |
| [`7f1ff6b9`](https://github.com/NixOS/nixpkgs/commit/7f1ff6b97628b0b4b0ab0b118e7916932ae9617d) | `` alsa-lib: remove use of with lib; ``                              |
| [`66e97f79`](https://github.com/NixOS/nixpkgs/commit/66e97f7960c74ad73e39722d85c562cbcb7d9900) | `` vimPlugins.opencode-nvim: init at 2025-07-24 ``                   |
| [`b4eee172`](https://github.com/NixOS/nixpkgs/commit/b4eee17286a2a4b616b144ef018071f8aee8e60b) | `` elixir-ls: fix elixir executable in path ``                       |
| [`1dd8808e`](https://github.com/NixOS/nixpkgs/commit/1dd8808e18962f73c6326f651b2db3435f5e0478) | `` inputplumber: 0.60.2 -> 0.60.7 ``                                 |
| [`8ab673b5`](https://github.com/NixOS/nixpkgs/commit/8ab673b5fa793fdf8a93633ea527d421cd9c0d3c) | `` gickup: 0.10.38 -> 0.10.39 ``                                     |
| [`be0aa910`](https://github.com/NixOS/nixpkgs/commit/be0aa9108769964a8f4b3c728241aff64c2ab9b0) | `` hmcl: 3.6.14 -> 3.6.15 ``                                         |
| [`d48a5a8a`](https://github.com/NixOS/nixpkgs/commit/d48a5a8a094429e8b0898583873e868597f2eb7c) | `` aliases.nix: add missing throws for removed packages ``           |
| [`5581cace`](https://github.com/NixOS/nixpkgs/commit/5581caceb95e5090dfbdc4ea20c8bdb612b92c56) | `` adios2: build on loongarch64 ``                                   |
| [`6680f22c`](https://github.com/NixOS/nixpkgs/commit/6680f22c413fed6683795bf8f5448e0b138589bd) | `` ocamlPackages.brisk-reconciler: unstable-2020-12-02 → 1.0.0-α1 `` |
| [`30f19cce`](https://github.com/NixOS/nixpkgs/commit/30f19cce69104f25418b92ef9ad023fa705714a0) | `` ci/eval: fail on asserts when generating attrpaths ``             |
| [`fc45a5f2`](https://github.com/NixOS/nixpkgs/commit/fc45a5f2c9fe7881f44877b861ae6c3ee8a3fba3) | `` ci/eval: don't evaluate variants ``                               |
| [`612e76db`](https://github.com/NixOS/nixpkgs/commit/612e76db5101fbaa52fe1478c870109869e13dbd) | `` pkgsx86_64Darwin: move behind allowVariants ``                    |
| [`8d781a1d`](https://github.com/NixOS/nixpkgs/commit/8d781a1dc3aeb92c1b692277e33db75e3112f910) | `` linux_6_1: 6.1.146 -> 6.1.147 ``                                  |
| [`727a3d57`](https://github.com/NixOS/nixpkgs/commit/727a3d5720886e58f1100fed60a3dd1d256fa605) | `` linux_6_6: 6.6.99 -> 6.6.100 ``                                   |
| [`7812de8e`](https://github.com/NixOS/nixpkgs/commit/7812de8ec7cb8d7a1e2befb17387ca135d4d52cf) | `` linux_6_12: 6.12.39 -> 6.12.40 ``                                 |
| [`b1b64033`](https://github.com/NixOS/nixpkgs/commit/b1b640337494c62c22dc765adc42971aa4732179) | `` linux_6_15: 6.15.7 -> 6.15.8 ``                                   |
| [`e82cff6c`](https://github.com/NixOS/nixpkgs/commit/e82cff6cb4966bd83bc6f2b35c44a8ae72cb5b7c) | `` linux_testing: 6.16-rc6 -> 6.16-rc7 ``                            |
| [`884309d9`](https://github.com/NixOS/nixpkgs/commit/884309d922aad0f9c9889a2c01101c791235c6ac) | `` envoy-bin: 1.34.3 -> 1.35.0 ``                                    |
| [`fb260322`](https://github.com/NixOS/nixpkgs/commit/fb260322f2587e3eabafb5b350e5c0a02af963f1) | `` railway-wallet: 5.22.3 -> 5.22.4 ``                               |
| [`65ba69b3`](https://github.com/NixOS/nixpkgs/commit/65ba69b31ec792c8c572af5c3ff08f15ce5bf1e2) | `` octodns-providers.ovh: init at 1.1.0 ``                           |
| [`fd46b00d`](https://github.com/NixOS/nixpkgs/commit/fd46b00d17d25e9859f7c8e1c1ff2c2f6b419c21) | `` saga: 9.9.0 -> 9.9.1 ``                                           |
| [`44d2b04d`](https://github.com/NixOS/nixpkgs/commit/44d2b04d67b34fd20f80252fa20ed86e7bcba628) | `` python3Packages.json-repair: 0.46.2 -> 0.47.8 ``                  |
| [`f1ff9aee`](https://github.com/NixOS/nixpkgs/commit/f1ff9aee779f92952133cda40b9cd29428ebb78a) | `` python3Packages.mkdocs-backlinks: init at 0.9.1 ``                |
| [`555fee28`](https://github.com/NixOS/nixpkgs/commit/555fee28f13e29ac463475c6cee1317a89ee8b89) | `` hclfmt: renew ``                                                  |
| [`be89d324`](https://github.com/NixOS/nixpkgs/commit/be89d324d31fa392462d318424149c4cf7086c89) | `` olympus-unwrapped: 25.07.12.01 -> 25.07.23.01 ``                  |
| [`5a071112`](https://github.com/NixOS/nixpkgs/commit/5a0711127cd8b916c3d3128f473388c8c79df0da) | `` treewide: run nixfmt 1.0.0 ``                                     |