### PR TITLE
chore(flake/nixvim): `0b87d944` -> `8d47a075`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1754264148,
-        "narHash": "sha256-i73/RHYnrRj1AW7r42qzEX1CruxAdVLXcn2iuWBQy64=",
+        "lastModified": 1754397955,
+        "narHash": "sha256-4hQT8mDSRNgPKiPdpYwr2QVJdA4FaUhOjT2lKkW8QHQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0b87d94432f3d2e2154a055f18dcb6531c6c90ab",
+        "rev": "8d47a07563120b36af149edf2273034563339a91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                   |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`8d47a075`](https://github.com/nix-community/nixvim/commit/8d47a07563120b36af149edf2273034563339a91) | `` flake/dev/flake.lock: Update ``                                                        |
| [`c1f6b2bf`](https://github.com/nix-community/nixvim/commit/c1f6b2bf773ce85c3301520f5f51f1bc64771780) | `` flake.lock: Update ``                                                                  |
| [`cd4fac45`](https://github.com/nix-community/nixvim/commit/cd4fac45a450706c466af3bd5715b617b9efa1c6) | `` docs/mdbook: remove unused highlight.js ``                                             |
| [`f2903e2a`](https://github.com/nix-community/nixvim/commit/f2903e2a109b39afebfc840d9367edf6d7036cee) | `` plugins/quarto: fix by enforcing enabling otter when settings.codeRunner is enabled `` |
| [`15022053`](https://github.com/nix-community/nixvim/commit/150220536afb9c2b785e13955b6e2dc136bf4e0e) | `` tests/plugins/dap-view: update default config ``                                       |
| [`b58a9d06`](https://github.com/nix-community/nixvim/commit/b58a9d06b57c6505de3a006d82193bb735b73a0c) | `` flake/dev/flake.lock: Update ``                                                        |
| [`6c8a7412`](https://github.com/nix-community/nixvim/commit/6c8a741287d185a5dc9122b337b4ac779a98ee68) | `` flake.lock: Update ``                                                                  |