### PR TITLE
chore(flake/treefmt-nix): `58bd4da4` -> `1298185c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -188,11 +188,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754061284,
-        "narHash": "sha256-ONcNxdSiPyJ9qavMPJYAXDNBzYobHRxw0WbT38lKbwU=",
+        "lastModified": 1754492133,
+        "narHash": "sha256-B+3g9+76KlGe34Yk9za8AF3RL+lnbHXkLiVHLjYVOAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "58bd4da459f0a39e506847109a2a5cfceb837796",
+        "rev": "1298185c05a56bff66383a20be0b41a307f52228",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                        |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`1298185c`](https://github.com/numtide/treefmt-nix/commit/1298185c05a56bff66383a20be0b41a307f52228) | `` feat: add dockerfmt formatter (#395) ``                     |
| [`bf87ce8f`](https://github.com/numtide/treefmt-nix/commit/bf87ce8fa33f7f94e3a9e4801d833791d1798511) | `` chore: update nixpkgs (#396) ``                             |
| [`7828e728`](https://github.com/numtide/treefmt-nix/commit/7828e728df154b000fdef00a6a41a2256b5adbd3) | `` feat(module): add self-describing meta attributes (#399) `` |
| [`962f3a9e`](https://github.com/numtide/treefmt-nix/commit/962f3a9e7665d592b3cb39924797377167472de1) | `` zizmor: add katexochen as maintainer ``                     |
| [`5fe6a8b9`](https://github.com/numtide/treefmt-nix/commit/5fe6a8b93f63d6586d7762468f3fddadf7985280) | `` zizmor: also lint github actions ``                         |