### PR TITLE
chore(flake/nixvim): `8d47a075` -> `085ef669`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1754397955,
-        "narHash": "sha256-4hQT8mDSRNgPKiPdpYwr2QVJdA4FaUhOjT2lKkW8QHQ=",
+        "lastModified": 1754506651,
+        "narHash": "sha256-LcpDSjGtTVU0S+aWJPE3/8RONQV0q8dDuanfCj7mAW0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8d47a07563120b36af149edf2273034563339a91",
+        "rev": "085ef66994f94226dd3d62921e1d48bf731b663a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`085ef669`](https://github.com/nix-community/nixvim/commit/085ef66994f94226dd3d62921e1d48bf731b663a) | `` tests/issues: fix deprecation warning ``                                |
| [`251f348b`](https://github.com/nix-community/nixvim/commit/251f348b22b1b14b50292d367618734e8b71ba94) | `` tests/nvim-tree: update test ``                                         |
| [`8fdfc8c1`](https://github.com/nix-community/nixvim/commit/8fdfc8c1cad1d4549c727d3ab585c81a35462579) | `` plugins/nvim-tree: migrate to mkNeovimPlugin ``                         |
| [`a63b826e`](https://github.com/nix-community/nixvim/commit/a63b826efdd9bfb8fd8f89093529a7c5d4dbc5e8) | `` test/lspkind: update test ``                                            |
| [`0049aca6`](https://github.com/nix-community/nixvim/commit/0049aca693bbee2e293cf489602f3d71293b2daa) | `` plugins/lspkind: migrate to mkNeovimPlugin ``                           |
| [`346ebc9c`](https://github.com/nix-community/nixvim/commit/346ebc9c18831226c693221f211ecd7b20f46650) | `` colorschemes/gruvbox-material: rename to gruvbox-material-nvim ``       |
| [`abc17edf`](https://github.com/nix-community/nixvim/commit/abc17edf07cb9ba9eb65bf2246be2b2d5cef8aac) | `` plugins/deprecation: allow renaming/removing different plugin scopes `` |
| [`cb33b76f`](https://github.com/nix-community/nixvim/commit/cb33b76f416d5925d0c4020b4ddd6505690788dd) | `` plugins/deprecation: reformat ``                                        |
| [`a96854d3`](https://github.com/nix-community/nixvim/commit/a96854d3ea1561ee4b1cf7ad9964cc3920c206ba) | `` colorschemes/gruvbox-baby: init ``                                      |
| [`98307977`](https://github.com/nix-community/nixvim/commit/98307977fe464371266c0f9fdadee9a5132011fb) | `` plugins/yaml-schema-detect: init ``                                     |
| [`ed0ae660`](https://github.com/nix-community/nixvim/commit/ed0ae6600fa39f6e97cedfb8d546e5f1cc1a99ed) | `` license: wrap to 80 chars ``                                            |
| [`4028598e`](https://github.com/nix-community/nixvim/commit/4028598e2bf3b92da7e546c766a19a438390571f) | `` license: update copyright year and add nixvim contributors ``           |
| [`14849765`](https://github.com/nix-community/nixvim/commit/14849765d47a78e83e0d2d60e95a5e9c0b94c19f) | `` plugins/colorful-winsep: init ``                                        |
| [`d6b9cce8`](https://github.com/nix-community/nixvim/commit/d6b9cce8bd92b9239c51d8ff635df3307169936c) | `` flake/dev/flake.lock: Update ``                                         |
| [`c42ebc31`](https://github.com/nix-community/nixvim/commit/c42ebc31a2145ef71b4b59d283a5806fc91640e0) | `` flake.lock: Update ``                                                   |