### PR TITLE
chore(flake/nixvim): `085ef669` -> `1db17950`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1754506651,
-        "narHash": "sha256-LcpDSjGtTVU0S+aWJPE3/8RONQV0q8dDuanfCj7mAW0=",
+        "lastModified": 1754572513,
+        "narHash": "sha256-BN2a2Lft9BwdDPBplaWe8kYW2wLaaVLDwcWwMJeBw3I=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "085ef66994f94226dd3d62921e1d48bf731b663a",
+        "rev": "1db179502524f21fe4e3175e3348202ed0ef253f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`1db17950`](https://github.com/nix-community/nixvim/commit/1db179502524f21fe4e3175e3348202ed0ef253f) | `` flake/dev/flake.lock: Update `` |
| [`cab4ec00`](https://github.com/nix-community/nixvim/commit/cab4ec000ef3b06c151d0af1aef0022bdb72ff3d) | `` flake.lock: Update ``           |