### PR TITLE
chore(flake/nixvim): `1db17950` -> `832de87d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1754572513,
-        "narHash": "sha256-BN2a2Lft9BwdDPBplaWe8kYW2wLaaVLDwcWwMJeBw3I=",
+        "lastModified": 1754682350,
+        "narHash": "sha256-4Dgf0cA/ZJtj9eTzG0yNMRBcd5fll3hhWx2WdwltAP8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1db179502524f21fe4e3175e3348202ed0ef253f",
+        "rev": "832de87d40f9a40430372552ab0b583680187cf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`832de87d`](https://github.com/nix-community/nixvim/commit/832de87d40f9a40430372552ab0b583680187cf3) | `` plugins/dashboard: add option ``                            |
| [`9d076b03`](https://github.com/nix-community/nixvim/commit/9d076b033d734be2cd02716ad43b40508bb29931) | `` tests/plugins-by-name: simplify by-name-enable-opts impl `` |
| [`09b736b7`](https://github.com/nix-community/nixvim/commit/09b736b7a161babe682ff472f8c98e09c65ca948) | `` tests/plugins-by-name: simplify namespace assertion ``      |
| [`14f5ea74`](https://github.com/nix-community/nixvim/commit/14f5ea7431dda945c907851536a4a41cc0618526) | `` tests/plugins-by-name: remove unnecessary copy-to-store ``  |
| [`9cbd617a`](https://github.com/nix-community/nixvim/commit/9cbd617a3ffc16b16a43509fde3d97ed08e38caa) | `` flake/dev/flake.lock: Update ``                             |