### PR TITLE
chore(flake/nixvim): `832de87d` -> `7b53322d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1754682350,
-        "narHash": "sha256-4Dgf0cA/ZJtj9eTzG0yNMRBcd5fll3hhWx2WdwltAP8=",
+        "lastModified": 1754921951,
+        "narHash": "sha256-KY+/livAp6l3fI8SdNa+CLN/AA4Z038yL/pQL2PaW7g=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "832de87d40f9a40430372552ab0b583680187cf3",
+        "rev": "7b53322d75a1c66f84fb145e4b5f0f411d9edc6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`7b53322d`](https://github.com/nix-community/nixvim/commit/7b53322d75a1c66f84fb145e4b5f0f411d9edc6b) | `` maintainers: update JanKremer's github ``   |
| [`286895f9`](https://github.com/nix-community/nixvim/commit/286895f9d78ba1a6d5b7ae34731dcb806ad579c6) | `` maintainers: update DanielLaing's github `` |