### PR TITLE
chore(flake/nixvim): `7b53322d` -> `ecc7880e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1754921951,
-        "narHash": "sha256-KY+/livAp6l3fI8SdNa+CLN/AA4Z038yL/pQL2PaW7g=",
+        "lastModified": 1755095763,
+        "narHash": "sha256-cFwtMaONA4uKYk/rBrmFvIAQieZxZytoprzIblTn1HA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7b53322d75a1c66f84fb145e4b5f0f411d9edc6b",
+        "rev": "ecc7880e00a2a735074243d8a664a931d73beace",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`ecc7880e`](https://github.com/nix-community/nixvim/commit/ecc7880e00a2a735074243d8a664a931d73beace) | `` fix(copilot-chat): fix default model to one supported `` |
| [`d086c93d`](https://github.com/nix-community/nixvim/commit/d086c93de9f0351cc6073abe6816db80ec6e03fc) | `` fix(blink-cmp): "exact" fuzzy sort ``                    |
| [`b06bbe0c`](https://github.com/nix-community/nixvim/commit/b06bbe0cfad5e6c55204b713eb9f2f4222c2600f) | `` plugins/telescope: add defaultText for highlightTheme `` |
| [`1d481682`](https://github.com/nix-community/nixvim/commit/1d4816820c8efb731a8b967581db916728fbd9e2) | `` ci: bump actions/download-artifact from 4 to 5 ``        |
| [`584a9938`](https://github.com/nix-community/nixvim/commit/584a993831f6f5f43ddeb79169b8e6de5f4ed8bd) | `` ci: bump actions/checkout from 4 to 5 ``                 |