### PR TITLE
chore(flake/git-hooks): `9c523728` -> `4b04db83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754416808,
-        "narHash": "sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef+6fRcofA=",
+        "lastModified": 1755446520,
+        "narHash": "sha256-I0Ok1OGDwc1jPd8cs2VvAYZsHriUVFGIUqW+7uSsOUM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
+        "rev": "4b04db83821b819bbbe32ed0a025b31e7971f22e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`2f127b06`](https://github.com/cachix/git-hooks.nix/commit/2f127b06aba1ceed178e00c6478562f944888ebc) | `` chore(deps): update actions/checkout action to v5 `` |