### PR TITLE
chore(flake/nixvim): `d96069b1` -> `18a1b512`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1755814403,
-        "narHash": "sha256-2iULLpTIzhRF+7ppTlfAfTGqFJknKOPjjUHlm2lqFMs=",
+        "lastModified": 1755900473,
+        "narHash": "sha256-UxpKQvD3dTT4/ueJBDccmHeHfnuUD+864Mzu8GPJZig=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d96069b1e14c7d9b756cc7c1dcf59f04ef35756b",
+        "rev": "18a1b5126f917fbcd65397b9ee429387fdbd51a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`18a1b512`](https://github.com/nix-community/nixvim/commit/18a1b5126f917fbcd65397b9ee429387fdbd51a6) | `` flake/dev/flake.lock: Update `` |
| [`4a84f480`](https://github.com/nix-community/nixvim/commit/4a84f4804828bdca958cbadd1f7cc906a18ddd5e) | `` flake.lock: Update ``           |
| [`09126049`](https://github.com/nix-community/nixvim/commit/09126049a487262ba5f00ea6962c4e85e24abf24) | `` plugins/cutlass-nvim: init ``   |