### PR TITLE
chore(flake/treefmt-nix): `7d81f6fb` -> `74e1a52d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -188,11 +188,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754847726,
-        "narHash": "sha256-2vX8QjO5lRsDbNYvN9hVHXLU6oMl+V/PsmIiJREG4rE=",
+        "lastModified": 1755934250,
+        "narHash": "sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "7d81f6fb2e19bf84f1c65135d1060d829fae2408",
+        "rev": "74e1a52d5bd9430312f8d1b8b0354c92c17453e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                             |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`74e1a52d`](https://github.com/numtide/treefmt-nix/commit/74e1a52d5bd9430312f8d1b8b0354c92c17453e5) | `` fix(typos): run with '--force-exclude' (#394) `` |
| [`4b25a4a3`](https://github.com/numtide/treefmt-nix/commit/4b25a4a3f647a4aaad1ad81f6d3d2e747f879983) | `` feat(ruff-check): extendSelect option (#402) ``  |
| [`50c32186`](https://github.com/numtide/treefmt-nix/commit/50c321864a158eed3d94f5c1eab92c74a5b13ac2) | `` Update csharpier: 0.30.6 -> 1.0.2 (#369) ``      |