### PR TITLE
chore(flake/nixvim): `8e3ca3fc` -> `b7e96214`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1756148061,
-        "narHash": "sha256-9QlWBvwDlizUa7YwlBnrmdXvh5pjaVGLG7u1N68VX5k=",
+        "lastModified": 1756305488,
+        "narHash": "sha256-+6cgFdac+DN5PAZg3YtRXAEdk++r6msy7wfFMNMNsEY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8e3ca3fc1f3ae23dee0e6d35dd4a70ea8ef7164c",
+        "rev": "b7e96214e8e7244eceae73c606dcd243f6d180a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`b7e96214`](https://github.com/nix-community/nixvim/commit/b7e96214e8e7244eceae73c606dcd243f6d180a3) | `` ci: bump actions/upload-pages-artifact from 3 to 4 `` |
| [`6392a2f4`](https://github.com/nix-community/nixvim/commit/6392a2f44f3a54e00c4095e8ba0dea378a52ca89) | `` ci: bump actions/checkout from 4 to 5 ``              |