### PR TITLE
chore(flake/nixpkgs): `8a6d5427` -> `dfb2f12e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756266583,
-        "narHash": "sha256-cr748nSmpfvnhqSXPiCfUPxRz2FJnvf/RjJGvFfaCsM=",
+        "lastModified": 1756386758,
+        "narHash": "sha256-1wxxznpW2CKvI9VdniaUnTT2Os6rdRJcRUf65ZK9OtE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a6d5427d99ec71c64f0b93d45778c889005d9c2",
+        "rev": "dfb2f12e899db4876308eba6d93455ab7da304cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`dfb2f12e`](https://github.com/NixOS/nixpkgs/commit/dfb2f12e899db4876308eba6d93455ab7da304cd) | `` crosvm: 0-unstable-2025-08-07 -> 0-unstable-2025-08-18 ``                     |
| [`6ae4f18e`](https://github.com/NixOS/nixpkgs/commit/6ae4f18e21c59ae8d704e87d8c8373e917aeb5af) | `` planify: 4.13.2 -> 4.13.4 ``                                                  |
| [`9d297032`](https://github.com/NixOS/nixpkgs/commit/9d297032b8db9ed914dd996b417887f4856cae9f) | `` python3Packages.beetcamp: override beets with correct pythonPackages ``       |
| [`831cc087`](https://github.com/NixOS/nixpkgs/commit/831cc0879a2b52a956de5b2e363b43b3c964212d) | `` homebox: 0.20.2 -> 0.21.0 ``                                                  |
| [`1657a4e5`](https://github.com/NixOS/nixpkgs/commit/1657a4e5f6f42e5532a4e9e7f82a7f51f0265889) | `` python3Packages.beetcamp: skip failing test ``                                |
| [`6f8dee5d`](https://github.com/NixOS/nixpkgs/commit/6f8dee5d3c6be313f12e77f69d4213b8fa7feff3) | `` python3Packages.whisperx: fix by relaxing ctranslate2 dependency ``           |
| [`3311f2a5`](https://github.com/NixOS/nixpkgs/commit/3311f2a5cc6737b6050e2d935269d4fa4a830677) | `` python3Packages.optuna: 4.4.0 -> 4.5.0 ``                                     |
| [`bf26ef2d`](https://github.com/NixOS/nixpkgs/commit/bf26ef2d0852e4bbe81161fabe541d265769a07f) | `` python3Packages.kserve: skip failing tests ``                                 |
| [`f34cc264`](https://github.com/NixOS/nixpkgs/commit/f34cc264aa0bd048361426931986f24d8f90c949) | `` python3Packages.flashinfer: 0.2.9 -> 0.2.14 ``                                |
| [`d332f296`](https://github.com/NixOS/nixpkgs/commit/d332f29622dc3eda57680a3f03ab2c67b1146c23) | `` python3Packages.mistral-common: 1.8.3 -> 1.8.4 ``                             |
| [`5f2dd653`](https://github.com/NixOS/nixpkgs/commit/5f2dd6539df62b6bf69ae7650025b7f2276275a4) | `` python3Packages.vllm: 0.10.0 -> 0.10.1.1 ``                                   |
| [`50d4df87`](https://github.com/NixOS/nixpkgs/commit/50d4df879c1f26846a50a65bd67e07a6b0ff30fe) | `` python3Packages.openai-harmony: init at 0.4.0 ``                              |
| [`eb041346`](https://github.com/NixOS/nixpkgs/commit/eb041346267f6710776a56e4ee49c5b682013dd1) | `` python3Packages.vllm: 0.9.1 -> 0.10.0 ``                                      |
| [`bcd38e11`](https://github.com/NixOS/nixpkgs/commit/bcd38e11bf3b6410d31b55d94931b674a5d5c3da) | `` nixos/systemd: fix enabling non-existent service ``                           |
| [`f24637f0`](https://github.com/NixOS/nixpkgs/commit/f24637f047b1f5f1a31bba17c501531968d7a9db) | `` paperless-ngx: unpin rapidfuzz version ``                                     |
| [`a30076d5`](https://github.com/NixOS/nixpkgs/commit/a30076d5de66bb7ae5f7994664be85027608b8b7) | `` python3Packages.duckduckgo-search: fix ``                                     |
| [`b648158f`](https://github.com/NixOS/nixpkgs/commit/b648158feb7a6a1c052893e6134f0cf2b0610dfd) | `` feh: 3.10.3 -> 3.11 ``                                                        |
| [`0633a9d6`](https://github.com/NixOS/nixpkgs/commit/0633a9d6405a3324037d7c4cb16a7044523b9cb0) | `` python3Packages.llama-index-vector-stores-chroma: 0.5.0 -> 0.5.2 ``           |
| [`079b7a00`](https://github.com/NixOS/nixpkgs/commit/079b7a006c021a2a378400fe286d1a49830bca46) | `` scx.rustscheds: restore RUSTFLAGS ``                                          |
| [`4adf5a21`](https://github.com/NixOS/nixpkgs/commit/4adf5a21d5d19f2bdd974b9e8ddc122f748341e0) | `` nixosTests.scx: remove scx_central test ``                                    |
| [`f447c7c0`](https://github.com/NixOS/nixpkgs/commit/f447c7c08d6c38218f671a22c0834a555e999c6c) | `` nixosTests.scx: add production ready schedulers ``                            |
| [`f14f77b5`](https://github.com/NixOS/nixpkgs/commit/f14f77b5e6b94cfe56d15fcf9a755a9157bfedb1) | `` nixos/scx: inherit pkgs.scx.full.meta maintainers ``                          |
| [`14c8785c`](https://github.com/NixOS/nixpkgs/commit/14c8785cb8bcf9707fbb70be03cf2f28bdf7550b) | `` nixos/scx: add missing schedulers ``                                          |
| [`35049497`](https://github.com/NixOS/nixpkgs/commit/350494975943afe5036f8165c15fdcaa106fb05d) | `` scx.full: 1.0.14 -> 1.0.15 ``                                                 |
| [`3bc770c7`](https://github.com/NixOS/nixpkgs/commit/3bc770c7d4f67d48408d905400d8fd50ff5b9b45) | `` python313Packages.fastapi-mcp: use pytest-asyncio_0 ``                        |
| [`dc881d34`](https://github.com/NixOS/nixpkgs/commit/dc881d34786a10f9a4f1af65ae062b4857c16ac0) | `` python313Packages.skops: update formatting ``                                 |
| [`fba9afc2`](https://github.com/NixOS/nixpkgs/commit/fba9afc2f63678462d7213b49840dd8d303e1fb5) | `` python313Packages.skops: update inputs ``                                     |
| [`6bde05ba`](https://github.com/NixOS/nixpkgs/commit/6bde05bafe8e622dd8f46357d953a83cc72fcecc) | `` tideways-daemon: 1.9.48 -> 1.9.52 ``                                          |
| [`63aa3b43`](https://github.com/NixOS/nixpkgs/commit/63aa3b433f2ea5b3735549ab8045e063c705f299) | `` feh: move to pkgs/by-name ``                                                  |
| [`d4c11bea`](https://github.com/NixOS/nixpkgs/commit/d4c11beaf170365931764857f04a63cfa56d2f98) | `` feh: get rid of generic arguments ``                                          |
| [`fbada41e`](https://github.com/NixOS/nixpkgs/commit/fbada41e91787b5e6ed29fd121e340668c77488a) | `` golds: 0.7.6 -> 0.7.8 ``                                                      |
| [`625c4787`](https://github.com/NixOS/nixpkgs/commit/625c47875de341b6f722afed7651eb68d8049876) | `` python3Packages.tlds: 2025051700 -> 2025082700 ``                             |
| [`b96d72bd`](https://github.com/NixOS/nixpkgs/commit/b96d72bd940b0b35b81c20f6ecd23cdb3d7baa36) | `` memray: 1.17.2 -> 1.18.0 ``                                                   |
| [`f7570e0d`](https://github.com/NixOS/nixpkgs/commit/f7570e0dc7cbf28c45a71011d332598c8524f94a) | `` linuxPackages.tmon: don't inherit makeFlags from kernel ``                    |
| [`56aac88f`](https://github.com/NixOS/nixpkgs/commit/56aac88f6f77cb60688522de6d8a376e54e43ebe) | `` linuxKernel.kernels.linux_zen: 6.16.1 -> 6.16.3 ``                            |
| [`667f803b`](https://github.com/NixOS/nixpkgs/commit/667f803bb4fe6a38b1cb9800d0741b08806757d4) | `` gst_all_1.gst-plugins-rs: add test patch from upstream and re-enable tests `` |
| [`54747c2e`](https://github.com/NixOS/nixpkgs/commit/54747c2ed778d9140058b99b5439f04c3d29e084) | `` claude-code: 1.0.93 -> 1.0.95 ``                                              |
| [`c17a3e73`](https://github.com/NixOS/nixpkgs/commit/c17a3e73c7cefb20aafe766d10aa70173da7026b) | `` python3Packages.stripe: 12.4.0 -> 12.5.0 ``                                   |
| [`97916ecd`](https://github.com/NixOS/nixpkgs/commit/97916ecd8e17e24bc73c8dc6843c28e8855776ad) | `` root: 6.36.04 -> 6.36.06 (#436912) ``                                         |
| [`e0bba73a`](https://github.com/NixOS/nixpkgs/commit/e0bba73a3ad1b019b9f56a5c8c86465b088c6d9e) | `` yaziPlugins.recycle-bin: init at 1.0.0 ``                                     |
| [`6906f43b`](https://github.com/NixOS/nixpkgs/commit/6906f43bf5b85979a45c8bdf10ffba95d341973a) | `` maintainers: add guttermonk ``                                                |
| [`5bb9c235`](https://github.com/NixOS/nixpkgs/commit/5bb9c2355e7e69df64c81e1b6a34959f26ba266b) | `` zed-editor: 0.201.4 -> 0.201.5 ``                                             |
| [`e9a76a7b`](https://github.com/NixOS/nixpkgs/commit/e9a76a7bfa1986b797f306df6e53416e12007770) | `` python3Packages.pytest-shared-session-scope: 0.5.0 -> 0.5.1 ``                |
| [`dc2fc470`](https://github.com/NixOS/nixpkgs/commit/dc2fc470b33ecc381f6620994617bdcec8ee53e1) | `` datafusion-cli: 49.0.0 -> 49.0.2 ``                                           |
| [`348a7e89`](https://github.com/NixOS/nixpkgs/commit/348a7e899b85f611addeaa59b8ae9a8d251f7f74) | `` ledger-live-desktop: 2.124.0 -> 2.126.0 ``                                    |
| [`c9ffcb16`](https://github.com/NixOS/nixpkgs/commit/c9ffcb161e8668e40347df7d6a1d4a67bad9e631) | `` scrounge-ntfs: fix build ``                                                   |
| [`0dd502f9`](https://github.com/NixOS/nixpkgs/commit/0dd502f91750c22981831f21e9648860d90f5832) | `` python3Packages.linode-api: 5.33.1 -> 5.34.0 ``                               |
| [`ae08c080`](https://github.com/NixOS/nixpkgs/commit/ae08c080c07f473494595123aa8b334ef23d8af5) | `` python3Packages.hf-xet: 1.1.8 -> 1.1.9 ``                                     |
| [`4385a2c0`](https://github.com/NixOS/nixpkgs/commit/4385a2c0ba0b597c35828f79395dfeab1772d9bf) | `` libgnome-games-support_2_0: 2.0.1 → 2.0.2 ``                                  |
| [`16a7e4d2`](https://github.com/NixOS/nixpkgs/commit/16a7e4d2f1e445d8909ec381584a63a4e0282297) | `` networkmanager-openvpn: 1.12.2 → 1.12.3 ``                                    |
| [`f05a6901`](https://github.com/NixOS/nixpkgs/commit/f05a6901cb7355b629db3326c4e86e21f6c54fab) | `` librest_1_0: 0.9.1 → 0.10.2 ``                                                |
| [`503e3922`](https://github.com/NixOS/nixpkgs/commit/503e392247e5e59262b4a456ea14cd5ec4800d3f) | `` simple-scan: 46.0 → 48.1 ``                                                   |
| [`974f16a0`](https://github.com/NixOS/nixpkgs/commit/974f16a0c9123d757febbb4fe9a1f113e8a31cc1) | `` libspelling: 0.4.8 → 0.4.9 ``                                                 |
| [`01b70961`](https://github.com/NixOS/nixpkgs/commit/01b70961dfbaf8f844737c9dfc261bde54e6df7a) | `` jsonrpc-glib: 3.44.1 → 3.44.2 ``                                              |
| [`c003c121`](https://github.com/NixOS/nixpkgs/commit/c003c1212cd98548f96f8e5a0a777fd3a8837d7a) | `` gupnp-av: 0.14.3 → 0.14.4 ``                                                  |
| [`c85b688b`](https://github.com/NixOS/nixpkgs/commit/c85b688b0ed2d9acf33949e3a5a204bc610286d6) | `` grilo-plugins: 0.3.16 → 0.3.18 ``                                             |
| [`19d1c62d`](https://github.com/NixOS/nixpkgs/commit/19d1c62d31e3ef2672924a0d243640e25ca8cc95) | `` gnome-music: 48.0 → 48.1 ``                                                   |
| [`b05f9ca8`](https://github.com/NixOS/nixpkgs/commit/b05f9ca8f456a7f3ca2427135621fe2b72fcb6bd) | `` ghex: 48.beta2 → 48.0 ``                                                      |
| [`d7eaa2c4`](https://github.com/NixOS/nixpkgs/commit/d7eaa2c4b3d7c8261f4e00f367741a5bb1029839) | `` gexiv2: 0.14.5 → 0.14.6 ``                                                    |
| [`7eddef3b`](https://github.com/NixOS/nixpkgs/commit/7eddef3b60e4cbad073762ba99169de7f6c7c51e) | `` home-assistant: pin py-madvr2 at 1.6.33 ``                                    |
| [`78a7790f`](https://github.com/NixOS/nixpkgs/commit/78a7790fb919ed3da5983a45b8528d3e23c201d8) | `` python3Packages.py-madvr2: 1.6.33 -> 1.8.14 ``                                |
| [`64af039e`](https://github.com/NixOS/nixpkgs/commit/64af039e71ca124567e2c96bbdbb020fa5bd9703) | `` python3Packages.schemdraw: 0.20 -> 0.21 ``                                    |
| [`40f97f02`](https://github.com/NixOS/nixpkgs/commit/40f97f02c7bddb8d6378396080b5591a07118f30) | `` siyuan: 3.2.1 -> 3.3.0 ``                                                     |
| [`647c5bcf`](https://github.com/NixOS/nixpkgs/commit/647c5bcfcd3a203311e09acb25f64f5de40e6124) | `` pcl: 1.15.0 -> 1.15.1 ``                                                      |
| [`035445ea`](https://github.com/NixOS/nixpkgs/commit/035445eaaa84134d4433dceef07aa4e0e89118c9) | `` python3Packages.pandas-stubs: 2.2.3.250308 -> 2.3.2.250827 ``                 |
| [`0bf66c63`](https://github.com/NixOS/nixpkgs/commit/0bf66c63af5aab5f0ed357d331184afea469dabd) | `` python3Packages.uv-dynamic-versioning: 0.8.2 -> 0.11.0 ``                     |
| [`6e7f9c62`](https://github.com/NixOS/nixpkgs/commit/6e7f9c62d1f5b59aca435894917d47c2a96de2a8) | `` python313Packages.adafruit-platformdetect: 3.82.0 -> 3.83.0 ``                |
| [`ca766a91`](https://github.com/NixOS/nixpkgs/commit/ca766a9183df858ada69d8c63857a7929337e8a4) | `` python3Packages.griffe: 1.12.1 -> 1.13.0 ``                                   |
| [`75fe7dbb`](https://github.com/NixOS/nixpkgs/commit/75fe7dbb27b9dc644efdeed1a7c447cfcdfc2502) | `` radicle-node: fix update script ``                                            |
| [`cfd8de4d`](https://github.com/NixOS/nixpkgs/commit/cfd8de4d2d82259e31a0bb638f7caa668b249461) | `` sensible-utils: 0.0.24 -> 0.0.26 ``                                           |
| [`dcf47c07`](https://github.com/NixOS/nixpkgs/commit/dcf47c07ad723f2b6ffa7b9ad560d5564cd537c7) | `` cmake-language-server: move to by-name ``                                     |
| [`45385f59`](https://github.com/NixOS/nixpkgs/commit/45385f597d21e353baf374f9b4db0731d7225b60) | `` soft-serve: 0.9.1 -> 0.10.0 ``                                                |
| [`cb8df6ac`](https://github.com/NixOS/nixpkgs/commit/cb8df6ac63102a47e3914209d2e5f0c63549fed3) | `` cmake-language-server: fix and cleanup ``                                     |
| [`c0750cee`](https://github.com/NixOS/nixpkgs/commit/c0750cee3d328bf0bc6da910a9a58045e1252f5f) | `` mtk-uartboot: init at 0-unstable-2024-12-07 ``                                |
| [`63f44083`](https://github.com/NixOS/nixpkgs/commit/63f44083d91533e53818c8e0dad605514de96b1c) | `` python3Packages.unsloth: 2025.8.1 -> 2025.8.9 ``                              |
| [`997db277`](https://github.com/NixOS/nixpkgs/commit/997db27784fa2c9ab4fb8de79ff56aec7d4ce4fa) | `` python3Packages.cut-cross-entropy: 25.5.1 -> 25.7.2 ``                        |
| [`ca7b5666`](https://github.com/NixOS/nixpkgs/commit/ca7b56662fc9f71d797669f28617d4b26c9ecad0) | `` python3Packages.trl: 0.20.0 -> 0.21.0 ``                                      |
| [`5fc03533`](https://github.com/NixOS/nixpkgs/commit/5fc0353343ade68fdfb955d19d7b0443a78701f9) | `` python3Packages.cmudict: init at 1.1.1 ``                                     |
| [`30b1371c`](https://github.com/NixOS/nixpkgs/commit/30b1371c96f0c070157caa6202f4de0f8570551f) | `` dooit: fix tests ``                                                           |
| [`590b5a47`](https://github.com/NixOS/nixpkgs/commit/590b5a47a53f51b1af8694f10bea3e137078c52e) | `` wizer: 9.0.0 -> 10.0.0 ``                                                     |
| [`2cda3362`](https://github.com/NixOS/nixpkgs/commit/2cda336293a10de179202ca965b64acdc954aab9) | `` particle-cli: 3.40.1 -> 3.41.0 ``                                             |
| [`522edf61`](https://github.com/NixOS/nixpkgs/commit/522edf6120693f924a03a18ab4faa6267abb3bf0) | `` uv: mark as broken for 32-bit buildPlatforms ``                               |
| [`a344c8b1`](https://github.com/NixOS/nixpkgs/commit/a344c8b1d4655af8b5d167442c0792d83150d045) | `` python3Packages.panphon: update dependencies ``                               |
| [`f7bf875d`](https://github.com/NixOS/nixpkgs/commit/f7bf875d55bd0e12b7e46aeea439b9176e213f7b) | `` fittrackee: relax deps for fitdecode ``                                       |
| [`1b7637ff`](https://github.com/NixOS/nixpkgs/commit/1b7637ff0806095b09bfd4380d435050acffd006) | `` nix_2_24: remove ``                                                           |
| [`bb10e76e`](https://github.com/NixOS/nixpkgs/commit/bb10e76e01521838eeb6285d4220b94b86948c0a) | `` git-autofixup: 0.004001 -> 0.004007 ``                                        |
| [`48267321`](https://github.com/NixOS/nixpkgs/commit/4826732155881cde1fe8274e939d60abd1232f9a) | `` python3Packages.jiwer: fix build-system ``                                    |
| [`2fc4da0c`](https://github.com/NixOS/nixpkgs/commit/2fc4da0c7ad9f7b3814e8fbb33cd9f8fac309109) | `` gnunet{,-gtk}: move to by-name ``                                             |
| [`247fd56d`](https://github.com/NixOS/nixpkgs/commit/247fd56d6fe58d388d4794fa319b895ceaecbc28) | `` nix-heuristic-gc: bump to nix 2.30 ``                                         |
| [`25226fd8`](https://github.com/NixOS/nixpkgs/commit/25226fd860faa45141a7a78ace93e7fc991d1912) | `` home-assistant-custom-components.octopus_energy: 16.1.0 -> 16.2.0 ``          |
| [`b7eeb7e8`](https://github.com/NixOS/nixpkgs/commit/b7eeb7e876495e43dabfd54a8d68f77b47e6520e) | `` python3Packages.torchao: 0.11.0 -> 0.12.0 ``                                  |
| [`1c0cd648`](https://github.com/NixOS/nixpkgs/commit/1c0cd6484a879a39b18874ad3adb3d05cf386b6b) | `` weblate: unpin rapidfuzz ``                                                   |
| [`eb2e35dd`](https://github.com/NixOS/nixpkgs/commit/eb2e35dd9dd54e1fc01a0430f66c353b6d312787) | `` python3Packages.brother: 5.0.0 -> 5.0.1 ``                                    |
| [`505c6999`](https://github.com/NixOS/nixpkgs/commit/505c6999a9e314529594455dae36fa7799e35e5c) | `` databricks-cli: 0.264.2 -> 0.266.0 ``                                         |
| [`58312e19`](https://github.com/NixOS/nixpkgs/commit/58312e19fcb2b01c0563a2d00e6a7f3cd69069e2) | `` go-judge: 1.9.5 -> 1.9.6 ``                                                   |
| [`4a2ad813`](https://github.com/NixOS/nixpkgs/commit/4a2ad8134b8b40f198c71f7d8d84467d250cd714) | `` emacs: replace fetchFromSavannah with mirror ``                               |
| [`b8076a50`](https://github.com/NixOS/nixpkgs/commit/b8076a50d9f10b75eba71a980341e885c39813cf) | `` python3Packages.draccus: init at 0.11.5 ``                                    |
| [`355ea396`](https://github.com/NixOS/nixpkgs/commit/355ea3960769515661ff9703dbd280d84c9ed69a) | `` ghmap: 1.0.3 -> 1.0.4 ``                                                      |
| [`5051bfc7`](https://github.com/NixOS/nixpkgs/commit/5051bfc798bcd70df900aceb38f0aceca12a375f) | `` jaq: init passthru.tests ``                                                   |
| [`5b339312`](https://github.com/NixOS/nixpkgs/commit/5b33931290890391db659ea418102a135135d1fb) | `` sbom-tool: 4.1.0 -> 4.1.2 ``                                                  |
| [`69bda6c8`](https://github.com/NixOS/nixpkgs/commit/69bda6c84d88c96ece9e119ff3cf04905963b2e2) | `` Revert "emacs: replace `fetchFromSavannah` with mirror; adjust build" ``      |
| [`217bdbb9`](https://github.com/NixOS/nixpkgs/commit/217bdbb99ed08bd0fcf1e2892c862aa19e965af9) | `` kas: 4.7 -> 4.8.2 ``                                                          |
| [`3c78a85e`](https://github.com/NixOS/nixpkgs/commit/3c78a85e77cb610bc6274c59b222cdffce4a8bd8) | `` consul-alerts: fix meta description (#437476) ``                              |
| [`e3647452`](https://github.com/NixOS/nixpkgs/commit/e3647452600bdd4f577cb9d8681eb879f4cb5615) | `` python3Packages.smolagents: fix duckduckgo-search renamed ddgs ``             |
| [`48b0e31a`](https://github.com/NixOS/nixpkgs/commit/48b0e31a544f7bf3c99f41689b2e68476f890e03) | `` python3Packages.smolagents: 1.20.0 -> 1.21.2 ``                               |