### PR TITLE
chore(flake/nixvim): `8bad4d40` -> `f5026663`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1756587208,
-        "narHash": "sha256-pATHF/7rZeEYxnkvLZgrLbCjG4xBJDJ4zkjUiu+hhiU=",
+        "lastModified": 1756727835,
+        "narHash": "sha256-767guSN146cmLD1lvjYzU4Bh7Ry3fzXzj+6hXEtF7rY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8bad4d407dace583ebf6a41d32cab479788898fe",
+        "rev": "f5026663f68261a201cd0700ced14971945d8dd9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                   |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`f5026663`](https://github.com/nix-community/nixvim/commit/f5026663f68261a201cd0700ced14971945d8dd9) | `` plugins/rainbow: init ``               |
| [`93d7a97e`](https://github.com/nix-community/nixvim/commit/93d7a97e2a6fcb73cf22d70be86c25e49c79c282) | `` Added nicklundin08/dots user config `` |