### PR TITLE
chore(flake/nixvim): `63496f00` -> `4f80458d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1756946299,
-        "narHash": "sha256-N4PjGA0rittpNZGscKPel+mr/dMcKF73j0yr4rbG3T0=",
+        "lastModified": 1757086676,
+        "narHash": "sha256-q79kLb0sjIEx6bIa5xcKACR5s8rDL7avOM+6ZLYa18g=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "63496f00c681b3e200bd17878a43ec68b7139a66",
+        "rev": "4f80458d351a204e35dbc6a127b20e3f69462c7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`4f80458d`](https://github.com/nix-community/nixvim/commit/4f80458d351a204e35dbc6a127b20e3f69462c7f) | `` maintainers: update generated/all-maintainers.nix ``     |
| [`4316f24a`](https://github.com/nix-community/nixvim/commit/4316f24a676faf0e9a702bd5751e1d3cb0b419c4) | `` ci/update-maintainers: drop `issues:write` permission `` |