### PR TITLE
chore(flake/nixvim): `4f80458d` -> `7afdd40b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1757086676,
-        "narHash": "sha256-q79kLb0sjIEx6bIa5xcKACR5s8rDL7avOM+6ZLYa18g=",
+        "lastModified": 1757176284,
+        "narHash": "sha256-j4SBmYsARwNG0DHljZ1uzZlGqCIU5fzCMA2g+GjD0xw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4f80458d351a204e35dbc6a127b20e3f69462c7f",
+        "rev": "7afdd40b96c9168aa4cb49b86fc67eccd441cae5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`7afdd40b`](https://github.com/nix-community/nixvim/commit/7afdd40b96c9168aa4cb49b86fc67eccd441cae5) | `` tests/none-ls: typo ``                                      |
| [`7a6d7730`](https://github.com/nix-community/nixvim/commit/7a6d7730d90b0cafc429cba7287407d4741e3559) | `` tests: add all-package-defaults ``                          |
| [`dac16230`](https://github.com/nix-community/nixvim/commit/dac162306761ce5ea0aaaa59a3792dec928f990c) | `` tests: move pkgsForTests definition to tests/default.nix `` |
| [`a04b93fa`](https://github.com/nix-community/nixvim/commit/a04b93fa7bf4160a9dc60d0713fff44c0fff9af6) | `` treewide: Disable fixup phase for builds ``                 |