### PR TITLE
chore(flake/nixvim): `7afdd40b` -> `2365afc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1757176284,
-        "narHash": "sha256-j4SBmYsARwNG0DHljZ1uzZlGqCIU5fzCMA2g+GjD0xw=",
+        "lastModified": 1757281943,
+        "narHash": "sha256-unFS/EV6dJqf//aSIqm35X9LIJ0C0kpY9P05EqToN14=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7afdd40b96c9168aa4cb49b86fc67eccd441cae5",
+        "rev": "2365afc0d51d71279b54ab702f8145f069664e2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`2365afc0`](https://github.com/nix-community/nixvim/commit/2365afc0d51d71279b54ab702f8145f069664e2c) | `` ci: only build packages on x86_64-linux ``                            |
| [`d241216e`](https://github.com/nix-community/nixvim/commit/d241216ede79a3938f764649a1b70c8758ba6c3d) | `` ci: only build "grouped" tests on x86_64-linux ``                     |
| [`3813f183`](https://github.com/nix-community/nixvim/commit/3813f183bc97100065554050b8b818b741a4e502) | `` ci/all-packages-defaults: disable broken packages on x86_64-darwin `` |
| [`225e8c01`](https://github.com/nix-community/nixvim/commit/225e8c019836b23eeb7eefa1cbf5c0f2394cb76f) | `` ci: build all-packages-defaults on all platforms ``                   |
| [`1a7905ec`](https://github.com/nix-community/nixvim/commit/1a7905eced82dbfb21e9d7d1a8ee4fccdf608637) | `` colorschemes/gruvbox-material: init ``                                |
| [`d5990763`](https://github.com/nix-community/nixvim/commit/d59907633aa0f233d367f1631e0814b271ec992a) | `` plugins/deprecation: remove gruvbox-material deprecation ``           |