### PR TITLE
chore(flake/nixvim): `2365afc0` -> `d38eb947`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1757281943,
-        "narHash": "sha256-unFS/EV6dJqf//aSIqm35X9LIJ0C0kpY9P05EqToN14=",
+        "lastModified": 1757343218,
+        "narHash": "sha256-GqyytaTh5JFJVraOQefSnxuQNVVSFFGwsJPT/M6St84=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2365afc0d51d71279b54ab702f8145f069664e2c",
+        "rev": "d38eb947272dd4e6d138648b1b49360301db6859",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`d38eb947`](https://github.com/nix-community/nixvim/commit/d38eb947272dd4e6d138648b1b49360301db6859) | `` flake/dev/flake.lock: Update ``                                                  |
| [`d7b69bd0`](https://github.com/nix-community/nixvim/commit/d7b69bd0218d826edd031640e1347984e8557973) | `` flake.lock: Update ``                                                            |
| [`cf170ed6`](https://github.com/nix-community/nixvim/commit/cf170ed677fa595ec0370e83278c0d40c6c2638c) | `` tests/all-package-defaults: disable mint on darwin (build failure) ``            |
| [`8ef2d284`](https://github.com/nix-community/nixvim/commit/8ef2d2845169ccedbd0465faad13cfdafca9611f) | `` tests/all-package-defaults: disable texlive on aarch64-darwin too ``             |
| [`1500565d`](https://github.com/nix-community/nixvim/commit/1500565d53c3bde9956d7b486791b99f8d22a202) | `` tests/all-package-defaults: disable buck2 on darwin (build failure) ``           |
| [`3fe2a1f2`](https://github.com/nix-community/nixvim/commit/3fe2a1f253ab98283b8f1d3b735129ffae2e3f08) | `` tests/all-package-defaults: disable verible on aarch64-darwin (build failure) `` |
| [`6394d43f`](https://github.com/nix-community/nixvim/commit/6394d43f255ac596eecbafd2c1993da3b2b2bd3d) | `` plugins/codecompanion: adapt options ``                                          |
| [`f77a33e8`](https://github.com/nix-community/nixvim/commit/f77a33e8738ba0de5e1b5adde1349aad872fa198) | `` plugins/project-nvim: fix moduleName ``                                          |
| [`f329e8fa`](https://github.com/nix-community/nixvim/commit/f329e8faf211adbadc71b8e9b74639597a549d20) | `` flake/dev/flake.lock: Update ``                                                  |
| [`66c32ff5`](https://github.com/nix-community/nixvim/commit/66c32ff5068af61be504086f1bc842a5d3d727f9) | `` flake.lock: Update ``                                                            |