### PR TITLE
chore(flake/nixvim): `d38eb947` -> `51edc33c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1757343218,
-        "narHash": "sha256-GqyytaTh5JFJVraOQefSnxuQNVVSFFGwsJPT/M6St84=",
+        "lastModified": 1757437784,
+        "narHash": "sha256-GFbRW1QCBNK/0di2Dj0WZJxdN+EZgTTn6gm7af4/r9s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d38eb947272dd4e6d138648b1b49360301db6859",
+        "rev": "51edc33c9763e486beacf6a066ae41a3c18827fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`51edc33c`](https://github.com/nix-community/nixvim/commit/51edc33c9763e486beacf6a066ae41a3c18827fa) | `` modules/output: add `waylandSupport` option `` |
| [`e3faa69c`](https://github.com/nix-community/nixvim/commit/e3faa69c0d094b94249225d4d98c29d73d26b87e) | `` flake/dev/flake.lock: Update ``                |
| [`77eb9ea9`](https://github.com/nix-community/nixvim/commit/77eb9ea9cccd71a80d10b47d324ceb6390ba3c2b) | `` Removing old repo ``                           |