### PR TITLE
chore(flake/nixvim): `51edc33c` -> `5b0a6eb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1757437784,
-        "narHash": "sha256-GFbRW1QCBNK/0di2Dj0WZJxdN+EZgTTn6gm7af4/r9s=",
+        "lastModified": 1757539853,
+        "narHash": "sha256-KjDtDYGe6DqcCPZVPwRdpwpc/KCNmE3upQnjvFUiIXw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "51edc33c9763e486beacf6a066ae41a3c18827fa",
+        "rev": "5b0a6eb34b94fe54c0759974962acc22d9c96d7b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`5b0a6eb3`](https://github.com/nix-community/nixvim/commit/5b0a6eb34b94fe54c0759974962acc22d9c96d7b) | `` plugins/perfanno: add perfanno-nvim plugin ``       |
| [`7660d9eb`](https://github.com/nix-community/nixvim/commit/7660d9ebb75285837531975828c2df7e5314605f) | `` plugins/harpoon: fix pack path name ``              |
| [`49333970`](https://github.com/nix-community/nixvim/commit/4933397031f2add4ecbb05eaa19accf9750b0e5f) | `` flake/dev/flake.lock: Update ``                     |
| [`c55042f7`](https://github.com/nix-community/nixvim/commit/c55042f7394a8c0494d779735c2a6a9d32151b4a) | `` plugins: fix duplicate URL definitions ``           |
| [`79533f91`](https://github.com/nix-community/nixvim/commit/79533f91c1c43d4f4c3dffbe1c6a48124c02a565) | `` lib/plugins: use the module system to merge URLs `` |