### PR TITLE
chore(flake/nixvim): `43c6f729` -> `db1a991f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1757619215,
-        "narHash": "sha256-AAg3S94zMF4BtByF2k9/K/tbC0awNHCc50GxCjccUhw=",
+        "lastModified": 1757864383,
+        "narHash": "sha256-oMoFAEC8A8BGBHIYiUNsgsVhEyNwTbn066J68LtbelY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "43c6f7293eba3fa5ff699e339e55270305e51cab",
+        "rev": "db1a991f33fb43cf0e2a4aff54a8c53b4dc12128",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                   |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`db1a991f`](https://github.com/nix-community/nixvim/commit/db1a991f33fb43cf0e2a4aff54a8c53b4dc12128) | `` tests/all-package-defaults: disable neotest dependees on aarch64-linux ``              |
| [`c9f56ea2`](https://github.com/nix-community/nixvim/commit/c9f56ea275dae1c056e52d8dd3ce9849c7a5dacd) | `` tests/plugins/project-nvim: set datapath to a writable directory ``                    |
| [`f9e602a3`](https://github.com/nix-community/nixvim/commit/f9e602a3c39389fa0ac16ac3e2f7b867d95a9cb6) | `` tests/plugins/pckr: use official vim.fs.joinpath instead of removed util.join_paths `` |
| [`f342a5dd`](https://github.com/nix-community/nixvim/commit/f342a5dd53a859fb41d212cf6a720f435072bc30) | `` Revert "tests/all-package-defaults: disable buck2 on darwin (build failure)" ``        |
| [`48198f2d`](https://github.com/nix-community/nixvim/commit/48198f2dfe2a4e609b36f4ff54ed470003a164ff) | `` flake/dev/flake.lock: Update ``                                                        |
| [`a208b644`](https://github.com/nix-community/nixvim/commit/a208b644686ffef9f39c4d653e470977758e1b95) | `` flake.lock: Update ``                                                                  |
| [`cd427977`](https://github.com/nix-community/nixvim/commit/cd427977f36a525babfd833d8c1652466ba07e5d) | `` modules/performance: add excludedPlugins option to byte compilation ``                 |