### PR TITLE
chore(flake/git-hooks): `b084b2c2` -> `302af509`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757588530,
-        "narHash": "sha256-tJ7A8mID3ct69n9WCvZ3PzIIl3rXTdptn/lZmqSS95U=",
+        "lastModified": 1757974173,
+        "narHash": "sha256-4DpXmct/2rcLgScT1CXOLr0TUeIlrBB1rnFqCOf5MUw=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "b084b2c2b6bc23e83bbfe583b03664eb0b18c411",
+        "rev": "302af509428169db34f268324162712d10559f74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`d9d4a28c`](https://github.com/cachix/git-hooks.nix/commit/d9d4a28c7c5f24a5c0997a7c05b02a55b8e980f4) | `` lint ``                                               |
| [`f9c8c3fa`](https://github.com/cachix/git-hooks.nix/commit/f9c8c3fab7fef6e7677cfb8e9b586e92e5fe0ac8) | `` feat: Add comrak formatter ``                         |
| [`3200f1fc`](https://github.com/cachix/git-hooks.nix/commit/3200f1fccb682e28860be8f9eccf73828d654bcb) | `` Do not pass filenames to ansible-lint by default ``   |
| [`222d5504`](https://github.com/cachix/git-hooks.nix/commit/222d5504823a26d320a59356d5a4a55ddb7a0654) | `` feat(convco): add option configPath ``                |
| [`6bd8ba28`](https://github.com/cachix/git-hooks.nix/commit/6bd8ba28a461c6b4f4339703663238596b1ac52d) | `` feat(alejandra): add option configPath ``             |
| [`a2c1b352`](https://github.com/cachix/git-hooks.nix/commit/a2c1b352a1b98085dce6fa2f436956b360a714a2) | `` Add enabledPackages example to flake-parts example `` |
| [`9ebfc7b3`](https://github.com/cachix/git-hooks.nix/commit/9ebfc7b303a51808e9f50f7b708d958bfa05a013) | `` Fix terraform-fmt hook ``                             |
| [`6007ee95`](https://github.com/cachix/git-hooks.nix/commit/6007ee9515d68f90df845e831456a646725a7288) | `` feat(typos): multiple exclude globs ``                |
| [`ff52e34b`](https://github.com/cachix/git-hooks.nix/commit/ff52e34ba9354532dace8958f84db0711dee6009) | `` feat(typos): set `--force-exclude` by default ``      |
| [`8e35904c`](https://github.com/cachix/git-hooks.nix/commit/8e35904c288570cbf7467a227e4ba4e8d608064e) | `` feat: add action-validator hook ``                    |
| [`f73b7bbe`](https://github.com/cachix/git-hooks.nix/commit/f73b7bbe1564b8f4e91e204765ebe4d3c867d2b1) | `` feat: add woodpecker-cli lint hook ``                 |
| [`457b222b`](https://github.com/cachix/git-hooks.nix/commit/457b222b7a1c9a62445803409e2a740695f45f91) | `` refactor(typos): structured attrs configuration ``    |
| [`1cd5759f`](https://github.com/cachix/git-hooks.nix/commit/1cd5759f4626b483824ef1adc0f2fcf9c69ca121) | `` fix(selene): do not print a summary ``                |
| [`c3b6489a`](https://github.com/cachix/git-hooks.nix/commit/c3b6489a1d860af63bdf91cbd4602f37e54cb4d9) | `` feat: add nbstripout hook ``                          |