### PR TITLE
chore(flake/nixvim): `db1a991f` -> `7f45eae6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1757864383,
-        "narHash": "sha256-oMoFAEC8A8BGBHIYiUNsgsVhEyNwTbn066J68LtbelY=",
+        "lastModified": 1758061611,
+        "narHash": "sha256-WJJDjNu80dWMSlpexhgRybPsvwl8C2tPwT6yM918Tsg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "db1a991f33fb43cf0e2a4aff54a8c53b4dc12128",
+        "rev": "7f45eae65baa38d77d09e0fcf5bfeab6c0f733c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`7f45eae6`](https://github.com/nix-community/nixvim/commit/7f45eae65baa38d77d09e0fcf5bfeab6c0f733c0) | `` endec: add module ``                                                    |
| [`ff3a250b`](https://github.com/nix-community/nixvim/commit/ff3a250bd0ff4dcfdb7857eb038d105b1fd34a83) | `` treewide: support `mini-icons.mockdevIcons` ``                          |
| [`a1d59a55`](https://github.com/nix-community/nixvim/commit/a1d59a5542a850f1b96462cb72b4164d70829dec) | `` plugins/lazy: add `performance` option ``                               |
| [`334d2eb2`](https://github.com/nix-community/nixvim/commit/334d2eb26eb3680d21ee26af2d7e66604468f61b) | `` docs/mdbook: general cleanup and renames ``                             |
| [`b999bdf5`](https://github.com/nix-community/nixvim/commit/b999bdf5e113f52550fc4bfd31e0b1dec3a86241) | `` plugins/image: add support for sixel backend ``                         |
| [`ef367c45`](https://github.com/nix-community/nixvim/commit/ef367c456b8f18d5b5143aab1ab66942746dc2a7) | `` dependencies: move imagemagick definition in dependencies.nix ``        |
| [`e0f0c945`](https://github.com/nix-community/nixvim/commit/e0f0c94593d1c2a92f61c5cbd6e38fb0966dc529) | `` plugins/image: cosmetic change in dependencies ``                       |
| [`e1e056e8`](https://github.com/nix-community/nixvim/commit/e1e056e82e12fcf434fc4955bd247ba84cd5ec82) | `` dependencies: ensure __depPackages.foo.* options are set only once ``   |
| [`796d6624`](https://github.com/nix-community/nixvim/commit/796d662401c420ba11d34901185718059aa3bfb5) | `` tests/all-package-defaults: re-enable vectorcode on x86_64-darwin ``    |
| [`701b6fa0`](https://github.com/nix-community/nixvim/commit/701b6fa0dd48284ed02e74a8cca0bba2d06792ab) | `` tests/all-package-defaults: disable zls on x86_64-darwin ``             |
| [`d362e5df`](https://github.com/nix-community/nixvim/commit/d362e5df6e7e557b8b4b76bdad171ee3e2e86303) | `` tests/all-package-defaults: disable fpc on x86_64-darwin ``             |
| [`eff48e3f`](https://github.com/nix-community/nixvim/commit/eff48e3f6c1d3ccc02371531dd24042081c3b32b) | `` plugins/lsp/packages: update dockerfile-language-server package name `` |
| [`1326ea29`](https://github.com/nix-community/nixvim/commit/1326ea298354ee8af26c8e24376f1929cf198b33) | `` flake/dev/flake.lock: Update ``                                         |
| [`574aec39`](https://github.com/nix-community/nixvim/commit/574aec3959ec138399084846e90d4de71331c586) | `` flake.lock: Update ``                                                   |