### PR TITLE
chore(flake/nixpkgs): `8d4ddb19` -> `0147c2f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758035966,
-        "narHash": "sha256-qqIJ3yxPiB0ZQTT9//nFGQYn8X/PBoJbofA7hRKZnmE=",
+        "lastModified": 1758198701,
+        "narHash": "sha256-7To75JlpekfUmdkUZewnT6MoBANS0XVypW6kjUOXQwc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8d4ddb19d03c65a36ad8d189d001dc32ffb0306b",
+        "rev": "0147c2f1d54b30b5dd6d4a8c8542e8d7edf93b5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`d89600b7`](https://github.com/NixOS/nixpkgs/commit/d89600b7e9db6af86dc59d08c8ab3ada047b1650) | `` pantheon.elementary-session-settings: Drop x11 session ``                          |
| [`a9ce047d`](https://github.com/NixOS/nixpkgs/commit/a9ce047de60d1c22863ef2e20dbc4d2fe8696211) | `` nixos/tests/pantheon: Always use `pgrep -xf` ``                                    |
| [`e6822a54`](https://github.com/NixOS/nixpkgs/commit/e6822a540ae9138275dd60f94b11339b6325c7e5) | `` zipline: remove vips override ``                                                   |
| [`7852c02c`](https://github.com/NixOS/nixpkgs/commit/7852c02cd7c79a7031f9340db8c7448fb55ad673) | `` python3Packages.libknot: 3.4.8 -> 3.5.0 ``                                         |
| [`05cf1dbd`](https://github.com/NixOS/nixpkgs/commit/05cf1dbdd2c227ac6f5616874de9f62f44a61918) | `` prometheus-knot-exporter: 3.4.8 -> 3.5.0 ``                                        |
| [`66658778`](https://github.com/NixOS/nixpkgs/commit/66658778bdcf4dc97c9918bfc5c765392fddb642) | `` knot-dns: 3.4.8 -> 3.5.0 ``                                                        |
| [`01960007`](https://github.com/NixOS/nixpkgs/commit/019600076d2a448c48d23ab09095bbc4b5cded2a) | `` vscode-extensions.gitlab.gitlab-workflow: 6.40.1 -> 6.44.1 ``                      |
| [`1e66baf7`](https://github.com/NixOS/nixpkgs/commit/1e66baf758ea888bb7e3fe67bd81038131465bfd) | `` tektoncd-cli-pac: init at 0.37.0 ``                                                |
| [`624e68e8`](https://github.com/NixOS/nixpkgs/commit/624e68e8aa9eebedca3b5f41c06b0493dc17d322) | `` maintainers: add netbrain ``                                                       |
| [`dbc9aff6`](https://github.com/NixOS/nixpkgs/commit/dbc9aff63064f12bca29e19aef6d5089d7aa3789) | `` copilot-language-server: 1.367.0 -> 1.373.0 ``                                     |
| [`157a0c0c`](https://github.com/NixOS/nixpkgs/commit/157a0c0c54e5f31294525458826eb9a7fe01442a) | `` nixos/podman: Ensure the network-online.target to be reached ``                    |
| [`cc021878`](https://github.com/NixOS/nixpkgs/commit/cc021878faed2b00eeba98e2e0b449822f713126) | `` google-chorme: 140.0.7339.127 -> 140.0.7339.185 ``                                 |
| [`6c5f5fe1`](https://github.com/NixOS/nixpkgs/commit/6c5f5fe19a7442adcdf49a6431282c2e42e44eb0) | `` fish: 4.0.6 -> 4.0.8 ``                                                            |
| [`c27a4a6d`](https://github.com/NixOS/nixpkgs/commit/c27a4a6de197efa03b69d459f9d0239798946e57) | `` pfetch: 1.9.2 -> 1.9.3 ``                                                          |
| [`913f572f`](https://github.com/NixOS/nixpkgs/commit/913f572ff4d9106e8d1d6f4e398f3710d2234f6b) | `` slack: 4.45.69 -> 4.46.96 ``                                                       |
| [`ae734abb`](https://github.com/NixOS/nixpkgs/commit/ae734abb374c7310f8dd6cb1e3a731ba59136524) | `` nixos/postfix-exporter: fix test ``                                                |
| [`e9a8b919`](https://github.com/NixOS/nixpkgs/commit/e9a8b919efc10880750f095edc5418d0a3704afc) | `` steel: 0-unstable-2025-09-06 -> 0-unstable-2025-09-17 ``                           |
| [`2df3d7d9`](https://github.com/NixOS/nixpkgs/commit/2df3d7d96d20d29ea89891042bd1275fbf36f268) | `` nixos/netbird: update path to desktop icon ``                                      |
| [`42944d48`](https://github.com/NixOS/nixpkgs/commit/42944d4879ef154ff8268212663b7f77a5d1991c) | `` attic-client: 0-unstable-2025-08-28 -> 0-unstable-2025-09-12 ``                    |
| [`e3af3d63`](https://github.com/NixOS/nixpkgs/commit/e3af3d63149d2c640744d7754ca5fd6f5424de4d) | `` klipper: 0.13.0-unstable-2025-08-15 -> 0.13.0-unstable-2025-09-16 ``               |
| [`1d0d0168`](https://github.com/NixOS/nixpkgs/commit/1d0d0168a2c7fccfa9e5c7321e33a066ac28f743) | `` terraform-providers.bitbucket: 2.48.0 -> 2.49.0 ``                                 |
| [`0c729cc8`](https://github.com/NixOS/nixpkgs/commit/0c729cc82d20fa01e4b4b3728de83985487c04fc) | `` zed-editor: 0.203.5 -> 0.204.1 ``                                                  |
| [`bcb95200`](https://github.com/NixOS/nixpkgs/commit/bcb952004eb32d536fd13ed0e1aaf3dec932cdf8) | `` openbabel: enable tests ``                                                         |
| [`36c66d63`](https://github.com/NixOS/nixpkgs/commit/36c66d6310aac92c4886273f3872098a7e3b6aef) | `` openbabel: fix build with CMake 4 ``                                               |
| [`47aa468f`](https://github.com/NixOS/nixpkgs/commit/47aa468f70d76bf32c5670b8165219458919c8ae) | `` openbabel: unstable-06-12-23 -> 3.1.1-unstable-2024-12-21 ``                       |
| [`e58b1240`](https://github.com/NixOS/nixpkgs/commit/e58b12406ca79ea220e85a7519569c480a105ff7) | `` home-assistant-custom-lovelace-modules.material-you-utilities: 2.0.12 -> 2.0.13 `` |
| [`6fb9ed6c`](https://github.com/NixOS/nixpkgs/commit/6fb9ed6ca63fcfe9203a8bcdaf5468872ad0b378) | `` filebot: 5.1.7 -> 5.2.0 ``                                                         |
| [`706fcecf`](https://github.com/NixOS/nixpkgs/commit/706fcecf8fb6df485d491d80c81cd81dbad92cad) | `` thunderbird-esr-unwrapped: 140.2.1esr -> 140.3.0esr ``                             |
| [`d0add0f1`](https://github.com/NixOS/nixpkgs/commit/d0add0f1b2cdcf0bff6667c71b5f47698430c80d) | `` thunderbird-latest-unwrapped: 142.0 -> 143.0 ``                                    |
| [`34d5b942`](https://github.com/NixOS/nixpkgs/commit/34d5b9426e4287644eb15ba3405aa8dc94b9884c) | `` why3: 1.8.1 -> 1.8.2 ``                                                            |
| [`8ee365a7`](https://github.com/NixOS/nixpkgs/commit/8ee365a7097bfc9729fd18a9fc3670319e2905e7) | `` nix-update: 1.12.1 -> 1.13.0 ``                                                    |
| [`89db1dc7`](https://github.com/NixOS/nixpkgs/commit/89db1dc79394db1b8e0f49dbfac5e9ad143ee2d2) | `` chromium,chromedriver: 140.0.7339.127 -> 140.0.7339.185 ``                         |
| [`27028772`](https://github.com/NixOS/nixpkgs/commit/27028772eb8f0474cb56e9e73974431e84fcdcf2) | `` cirrus-cli: 0.153.3 -> 0.153.5 ``                                                  |
| [`dfbce9a4`](https://github.com/NixOS/nixpkgs/commit/dfbce9a4d45d67edf7f7add221f6c5133f6b12ea) | `` python3Packages.torchrl: 0.9.2 -> 0.10.0 ``                                        |
| [`70da0d20`](https://github.com/NixOS/nixpkgs/commit/70da0d206d78434e30152a734a2d8cfe21201251) | `` cinnamon-session: 6.4.1 -> 6.4.2 ``                                                |
| [`a5686da5`](https://github.com/NixOS/nixpkgs/commit/a5686da5153699dc60c235f80ba0c303f05b1e61) | `` python3Packages.meshcore: 2.1.6 -> 2.1.7 ``                                        |
| [`97cc677a`](https://github.com/NixOS/nixpkgs/commit/97cc677ad3bf717ceb1e03ecb2dfd3b0b40d2499) | `` python3Packages.pylibjpeg-rle: 2.1.0 -> 2.2.0 ``                                   |
| [`914244c3`](https://github.com/NixOS/nixpkgs/commit/914244c37e54a332982482b1371b50ab2533a222) | `` wivrn: 25.8 -> 25.9 ``                                                             |
| [`deddb93e`](https://github.com/NixOS/nixpkgs/commit/deddb93e08e6c6c9b91bc19c8cf369134f9a8ac7) | `` Fix paths in podman-user-wait-network-online.service ``                            |
| [`87a91602`](https://github.com/NixOS/nixpkgs/commit/87a916024e1493051289f60d19b1172cefdcfb56) | `` maintainers: remove wackbyte ``                                                    |
| [`fa8196fb`](https://github.com/NixOS/nixpkgs/commit/fa8196fb8ab7781deee6570d2b80e7f48fdc549a) | `` mullvad-browser: 14.5.6 -> 14.5.7 ``                                               |
| [`99af4fc5`](https://github.com/NixOS/nixpkgs/commit/99af4fc544464663b29dbd8546c0ebcab14a2300) | `` tor-browser: 14.5.6 -> 14.5.7 ``                                                   |
| [`e8f40168`](https://github.com/NixOS/nixpkgs/commit/e8f40168fbd024866f22e2c8d18fe040e3691022) | `` spotify/darwin: add warning to check timestamp ``                                  |
| [`f2621f1c`](https://github.com/NixOS/nixpkgs/commit/f2621f1cd8d5b3aadcab05e9da25804f7c909a12) | `` atlas: 0.36.1 -> 0.37.0 ``                                                         |
| [`b4acca19`](https://github.com/NixOS/nixpkgs/commit/b4acca19bf444d0a49a49d3a6332c85b8c098362) | `` anyrun: 25.9.2 -> 25.9.3 ``                                                        |
| [`a27db0ff`](https://github.com/NixOS/nixpkgs/commit/a27db0ff606bac12a4bbba07fc291a04eef3c7f0) | `` zulu*: fix top-level package error from nixpkgs-vet ``                             |
| [`620e2210`](https://github.com/NixOS/nixpkgs/commit/620e2210e5d5a87074b64694398a13102be2f49e) | `` bambu-studio: 02.02.01.60 -> 02.02.02.56 ``                                        |
| [`294f3f27`](https://github.com/NixOS/nixpkgs/commit/294f3f2767465d0128f96b8beccff7dc437e68bb) | `` mesa: 25.2.2 -> 25.2.3 ``                                                          |
| [`add1684d`](https://github.com/NixOS/nixpkgs/commit/add1684d35fe156b69aaf50b3c6a85e6ed3009e8) | `` openbabel: move to `by-name` ``                                                    |
| [`e82865a8`](https://github.com/NixOS/nixpkgs/commit/e82865a812ee589314ee3d4a3be205f16fa9be6b) | `` openbabel3: move to aliases ``                                                     |
| [`451dc1d5`](https://github.com/NixOS/nixpkgs/commit/451dc1d57198afec1e454485a9f20474cdc4fa24) | `` openbabel2: drop ``                                                                |
| [`bedad1ed`](https://github.com/NixOS/nixpkgs/commit/bedad1edf43ad10ca159bf78c2e792a80a174bf0) | `` coordgenlibs: fix build with LLVM 21 ``                                            |
| [`293b5d5a`](https://github.com/NixOS/nixpkgs/commit/293b5d5ad6bf78d55258aeb4086b90812f1f4ad5) | `` coordgenlibs: fix build with CMake 4 ``                                            |
| [`fda07478`](https://github.com/NixOS/nixpkgs/commit/fda0747863457e1661a7ad3374f17aa9f9642595) | `` glaxnimate: alias to `kdePackages.glaxnimate` ``                                   |
| [`179bdc02`](https://github.com/NixOS/nixpkgs/commit/179bdc02d69884781172e4921f7a560280e4bf02) | `` kdePackage.glaxnimate: init at 0.5.80 ``                                           |
| [`75683b63`](https://github.com/NixOS/nixpkgs/commit/75683b632a392050bfd5e71f840e24b2eed6b461) | `` lazygit: 0.55.0 -> 0.55.1 ``                                                       |
| [`4ef23df8`](https://github.com/NixOS/nixpkgs/commit/4ef23df814ce9a8e4505c28fac116dd97256b1b2) | `` python3Packages.mongoquery: 1.4.2 -> 1.4.3 ``                                      |
| [`ad66cc4d`](https://github.com/NixOS/nixpkgs/commit/ad66cc4d16483a77d860488e863b83e19989ff17) | `` onnxruntime: require macOS 13.3 ``                                                 |
| [`9588be72`](https://github.com/NixOS/nixpkgs/commit/9588be72dd5a133d6448a5355425e4e0f275afdd) | `` osm2pgsql: 2.1.1 -> 2.2.0 ``                                                       |
| [`58854b75`](https://github.com/NixOS/nixpkgs/commit/58854b75a3435209bb60438d6b84179c95e7a01a) | `` python3Packages.ingredient-parser-nlp: 2.2.0 -> 2.3.0 ``                           |
| [`07e18d92`](https://github.com/NixOS/nixpkgs/commit/07e18d922d136570f2996684acc093ec75127530) | `` nixos/profiles/perlless: remove redundant lessopen default ``                      |
| [`711dec36`](https://github.com/NixOS/nixpkgs/commit/711dec36524a0568d86c28f5f41a6230686981a0) | `` nixos/profiles/minimal: remove redundant lessopen default ``                       |
| [`0dd2e6e3`](https://github.com/NixOS/nixpkgs/commit/0dd2e6e3fc8e2cbbcc4d688f69b33e74539da100) | `` poco: 1.14.1 -> 1.14.2 ``                                                          |
| [`49f3a9f7`](https://github.com/NixOS/nixpkgs/commit/49f3a9f7cbb34c23f3d2661d98e6b6bcdc915741) | `` pgbackrest: 2.55.1 -> 2.56.0 ``                                                    |
| [`d545df44`](https://github.com/NixOS/nixpkgs/commit/d545df44dc7cb5f2a566fccc9e5968485b41c6ab) | `` nightfox-gtk-theme: 0-unstable-2025-09-02 -> 0-unstable-2025-09-09 ``              |
| [`967f74d0`](https://github.com/NixOS/nixpkgs/commit/967f74d00b26bcc4ccf7c047dee68b57b0315c1c) | `` cryfs: 0.11.4 -> 1.0.1 ``                                                          |
| [`b4058ee0`](https://github.com/NixOS/nixpkgs/commit/b4058ee062cfdcb9c79c116b99ed4f0fd4e726ca) | `` graalvm-oracle_24: drop ``                                                         |
| [`ed315646`](https://github.com/NixOS/nixpkgs/commit/ed31564636d600a9edd63073cf1245ee67e5e68a) | `` python313Packages.scikit-build: add patch for CMake 4 ``                           |
| [`0786c504`](https://github.com/NixOS/nixpkgs/commit/0786c504c9562d93df95f6a8293b84340c77c777) | `` warp-plus: 1.2.6-unstable-2025-08-13 -> 1.2.6-unstable-2025-09-13 ``               |
| [`813e7336`](https://github.com/NixOS/nixpkgs/commit/813e73365785f6fa47c6857d744fcce89883360f) | `` nixos/pgbackrest: add commands option for specific settings ``                     |
| [`569ae772`](https://github.com/NixOS/nixpkgs/commit/569ae77252e412c4046f1a124ae274d883bb9821) | `` gitu: 0.35.0 -> 0.36.0 ``                                                          |
| [`a5cc0e39`](https://github.com/NixOS/nixpkgs/commit/a5cc0e3947cc4dd49f04813433bdcb15fd487cfe) | `` vscode-extensions.pollywoggames.pico8-ls: 0.5.7 -> 0.6.0 ``                        |
| [`9d2567bb`](https://github.com/NixOS/nixpkgs/commit/9d2567bb8f227bc70107785768f13ada52a7381e) | `` terragrunt: 0.86.0 -> 0.86.3 ``                                                    |
| [`4278df77`](https://github.com/NixOS/nixpkgs/commit/4278df7785f57285a34565f92a60fa5b3bf35f7b) | `` onnxruntime: update `dlpack` pin ``                                                |
| [`30164d39`](https://github.com/NixOS/nixpkgs/commit/30164d395c5508284298856acb8a5006d483a0e1) | `` onnxruntime: drop unused `pytorch_clog` dependency ``                              |
| [`f8e3fc18`](https://github.com/NixOS/nixpkgs/commit/f8e3fc18b60256244bec637822fd7e964b96d4f9) | `` microsoft-gsl: 4.0.0 -> 4.2.0 ``                                                   |
| [`ecf4830b`](https://github.com/NixOS/nixpkgs/commit/ecf4830b9c0f9e7009bbcd4992e3c6b3ec9dceb4) | `` redpanda-client: 25.2.3 -> 25.2.4 ``                                               |
| [`2db22fad`](https://github.com/NixOS/nixpkgs/commit/2db22fad4a8486305ac23e329228692a10600be2) | `` floorp-bin-unwrapped: 12.1.4 -> 12.2.0 ``                                          |
| [`d7c09493`](https://github.com/NixOS/nixpkgs/commit/d7c0949377042591d6ddfb04228d823b0a7fedac) | `` maccy: 2.3.0 -> 2.5.1 ``                                                           |
| [`03c98e53`](https://github.com/NixOS/nixpkgs/commit/03c98e53bc384b794bdc5c0e3284a2c31ba8aa57) | `` vscode-extensions.amazonwebservices.amazon-q-vscode: 1.93.0 -> 1.94.0 ``           |
| [`47249c56`](https://github.com/NixOS/nixpkgs/commit/47249c566dc3a6f300eeaac8f1297c33aed51947) | `` linux-firmware: 20250808 -> 20250917 ``                                            |
| [`95b5f8e1`](https://github.com/NixOS/nixpkgs/commit/95b5f8e1a7750ce7d1e48663c229fbd4fb80a3b7) | `` art: 1.25.8 -> 1.25.9 ``                                                           |
| [`2b061fd8`](https://github.com/NixOS/nixpkgs/commit/2b061fd800b2ac2dc69e83e3a4b7204690a55774) | `` devenv: 1.8.2 -> 1.9 ``                                                            |