### PR TITLE
chore(flake/nixvim): `0c867f9e` -> `fd0c4235`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1758134550,
-        "narHash": "sha256-Rj0v5VZuljxG4trz3IHJedEKghNDd1HsK6yVwTNPyJ0=",
+        "lastModified": 1758405527,
+        "narHash": "sha256-3OMGX/chlzLpL7OMjXUfcI+xGu5GMeldCnBQ5kM9lZE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0c867f9e635ce70e829a562b20851cfc17a94196",
+        "rev": "fd0c42355026185678e93bca152cbdb3b1a67563",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`fd0c4235`](https://github.com/nix-community/nixvim/commit/fd0c42355026185678e93bca152cbdb3b1a67563) | `` plugins/conform-nvim: add automatic installation of formatters ``                     |
| [`d113982e`](https://github.com/nix-community/nixvim/commit/d113982eba5533b9157e778dbd16fd6466b43b65) | `` generated: conform-nvim formatters ``                                                 |
| [`bcbb109e`](https://github.com/nix-community/nixvim/commit/bcbb109e0983561f3096ac63dfa7207da9ef2256) | `` ci: add generation script for conform-nvim ``                                         |
| [`3706fd81`](https://github.com/nix-community/nixvim/commit/3706fd81120d5c34aae9d2cefb95d29ef15862d9) | `` ci: refactor generate script ``                                                       |
| [`2d3a0102`](https://github.com/nix-community/nixvim/commit/2d3a01021b1a8193963b35c93a7aca39e39ace3b) | `` plugins/papis: adapt settings to latest release ``                                    |
| [`e77eff7d`](https://github.com/nix-community/nixvim/commit/e77eff7db2b5b644e03eeb2ae1dd68d1fc995d43) | `` tests/all-package-defaults: disable aider.nvim on aarch64-linux (hm build failure) `` |
| [`86bfd525`](https://github.com/nix-community/nixvim/commit/86bfd52539ca0b06406a973522e7bde5e0831917) | `` flake/dev/flake.lock: Update ``                                                       |
| [`f82da014`](https://github.com/nix-community/nixvim/commit/f82da014a1a6f83297b525cb8ee0595955fe1e86) | `` flake.lock: Update ``                                                                 |
| [`6f976d5b`](https://github.com/nix-community/nixvim/commit/6f976d5b23a628d848e7e92fc5063dcf94f76f32) | `` plugins/papis: drop settings options declaration ``                                   |