### PR TITLE
chore(flake/nixvim): `0c15f88f` -> `fd835f3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1758665797,
-        "narHash": "sha256-RIN05AhWIFCXL2OOXGoFdF/k8Q6OBhi/WcRtsYuTF5Q=",
+        "lastModified": 1758718199,
+        "narHash": "sha256-xbkAs3NM9K2sPEhz0MB9kDfDPBXNkkEDueKpPkZzzSc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0c15f88f1fc01c8799c5ce2a432fadc47f20e307",
+        "rev": "fd835f3dd13872841ef394e97be71276f75957b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`fd835f3d`](https://github.com/nix-community/nixvim/commit/fd835f3dd13872841ef394e97be71276f75957b9) | `` flake/dev/flake.lock: Update `` |
| [`aabad55a`](https://github.com/nix-community/nixvim/commit/aabad55a74092c550d3aff007a72ff5ad374d07b) | `` flake.lock: Update ``           |