### PR TITLE
chore(flake/nixvim): `4cec6765` -> `1c802b3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1759016999,
-        "narHash": "sha256-UhQmUPSWYpKJQutTzy9TKiRBMg/qVJn6AoNsFR+5Zmc=",
+        "lastModified": 1759101862,
+        "narHash": "sha256-Ybe+/vYCPA520Wm9DveaOJa7TQF2M82AtUKUh82vr7U=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4cec67651a6dfdab9a79e68741282e3be8231a61",
+        "rev": "1c802b3efe45625737d36b3d4b9710193fa39e2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`1c802b3e`](https://github.com/nix-community/nixvim/commit/1c802b3efe45625737d36b3d4b9710193fa39e2a) | `` plugins/lsp: simplify `extraSettings` deprecation ``           |
| [`167ea865`](https://github.com/nix-community/nixvim/commit/167ea865e519667258dc94b69ef7c1593dda4e77) | `` modules/lsp: port `packageFallback` option from plugins.lsp `` |