### PR TITLE
chore(flake/nixvim): `1c802b3e` -> `0a721c85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1759101862,
-        "narHash": "sha256-Ybe+/vYCPA520Wm9DveaOJa7TQF2M82AtUKUh82vr7U=",
+        "lastModified": 1759276282,
+        "narHash": "sha256-I7ZZtJu5sj1rPSg4nhEC2EXHDSL0fmAk7cPHfJIo7NA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1c802b3efe45625737d36b3d4b9710193fa39e2a",
+        "rev": "0a721c85dc51a8e7cd6464805319e0ced193c0a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`0a721c85`](https://github.com/nix-community/nixvim/commit/0a721c85dc51a8e7cd6464805319e0ced193c0a1) | `` plugins/marks: migrate to mkNeovimPlugin ``                                        |
| [`28377535`](https://github.com/nix-community/nixvim/commit/283775355b180e2ce689bc6e011b508fb16e6f56) | `` plugins/neogit: remove (most) explicit option declarations from settingsOptions `` |
| [`c6b45bb6`](https://github.com/nix-community/nixvim/commit/c6b45bb66e549622adba1983c2f189d0612e7932) | `` plugins/neogit: remove deprecation warnings ``                                     |
| [`1f003e44`](https://github.com/nix-community/nixvim/commit/1f003e44d5bb25f155f9be8b7b30b3158b0a0e1b) | `` plugins/neogit: remove 'with lib;' ``                                              |
| [`f0cd7d4f`](https://github.com/nix-community/nixvim/commit/f0cd7d4fb37da8c04730753c01721fe927804041) | `` plugins/package-info: remove explicit option declarations from settingsOptions ``  |
| [`94331cc5`](https://github.com/nix-community/nixvim/commit/94331cc50d47e63b926f702340510d2514dbea86) | `` plugins/lsp: use the new lsp module under the hood ``                              |
| [`cb3653a1`](https://github.com/nix-community/nixvim/commit/cb3653a1a8be9aff2102cfea37bd23d2ec197616) | `` modules/lsp: select relevant fields in keymaps table ``                            |
| [`f421af99`](https://github.com/nix-community/nixvim/commit/f421af99fe4bb134688b9343db470d8e76a19524) | `` modules/lsp: print keymaps table multiline ``                                      |
| [`4f858eb0`](https://github.com/nix-community/nixvim/commit/4f858eb004c557991a99c6daeb82ae18b025d482) | `` tests/modules/lsp: test lsp keymaps ``                                             |
| [`d3e7315b`](https://github.com/nix-community/nixvim/commit/d3e7315bf7a39eaae4ef9c33a235e500da6bd170) | `` modules/test: add `extraInputs` option ``                                          |
| [`4f03ca05`](https://github.com/nix-community/nixvim/commit/4f03ca05d9add2217554c4706bac84559f1211c6) | `` docs/lib: generalise `menu` impl using module system ``                            |
| [`2f952af4`](https://github.com/nix-community/nixvim/commit/2f952af4a74879913548496acd7c15bb18c7634d) | `` docs/lib: rename 'name' → 'category' ``                                            |
| [`c146f6e0`](https://github.com/nix-community/nixvim/commit/c146f6e09c3b5ac8ced75dbf5e02b154f0fad3db) | `` docs/lib: simplify default title-heading ``                                        |
| [`4414d8aa`](https://github.com/nix-community/nixvim/commit/4414d8aa142a7737e73c63cad7d802352dda9109) | `` docs/modules: init ``                                                              |
| [`9faa339d`](https://github.com/nix-community/nixvim/commit/9faa339d9e930be3eb7d751af35ecfed7c493d14) | `` modules/lsp: use a for loop to create LSP keymaps ``                               |