### PR TITLE
chore(flake/nixvim): `0a721c85` -> `fc779c6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1759276282,
-        "narHash": "sha256-I7ZZtJu5sj1rPSg4nhEC2EXHDSL0fmAk7cPHfJIo7NA=",
+        "lastModified": 1759362848,
+        "narHash": "sha256-rhx4Spn5F4brp50udGNo7zZml3vqUGEBzHe0Og0RFHw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0a721c85dc51a8e7cd6464805319e0ced193c0a1",
+        "rev": "fc779c6e8279226a128d3c0f06afebf08cfadc1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`fc779c6e`](https://github.com/nix-community/nixvim/commit/fc779c6e8279226a128d3c0f06afebf08cfadc1b) | `` plugins/project-nvim: place config before telescope ``                                     |
| [`ba7e691a`](https://github.com/nix-community/nixvim/commit/ba7e691a31fd19e27b02aeae972c7115389209b1) | `` tests/plugins/lean: disable runNvim when LSP is enabed (using deprecated lspconfig API) `` |
| [`3607c2db`](https://github.com/nix-community/nixvim/commit/3607c2dbd2fac476d5098adb52a713e8029e122c) | `` tests/plugins/neogit: update defaults ``                                                   |
| [`c162a49c`](https://github.com/nix-community/nixvim/commit/c162a49c38f188812b19905d2d5aac4ebd44ec74) | `` tests/plugins/package-info: update defaults ``                                             |
| [`523444bf`](https://github.com/nix-community/nixvim/commit/523444bf996b5ad3463032fbcd1b2ec76c7d8498) | `` tests: disable test relying on the idris2 plugin (using deprecated lspconfig API) ``       |
| [`cf808765`](https://github.com/nix-community/nixvim/commit/cf808765c51d542469854c273008ecf2a961a6c7) | `` tests/all-package-defaults: disable open-policy-agent on darwin ``                         |
| [`d363851e`](https://github.com/nix-community/nixvim/commit/d363851efc8f187570672d9cbc09c8c611bb38c8) | `` flake/dev/flake.lock: Update ``                                                            |
| [`05dca882`](https://github.com/nix-community/nixvim/commit/05dca88231276a72014d374cd1ee995fcf51431a) | `` flake.lock: Update ``                                                                      |
| [`16302b08`](https://github.com/nix-community/nixvim/commit/16302b08f02b92a4db2baa6442cf730c0684a690) | `` plugins/kitty-scrollback: add settingsExample ``                                           |
| [`4ecc08df`](https://github.com/nix-community/nixvim/commit/4ecc08df4805432b66b054cc48d600e1125a0078) | `` plugins/kitty-scrollback: init ``                                                          |
| [`fe059cd3`](https://github.com/nix-community/nixvim/commit/fe059cd395575c00d475ab1c8200dcc3495724d9) | `` flake: add nixf-diagnose to treefmt config ``                                              |
| [`74423f4a`](https://github.com/nix-community/nixvim/commit/74423f4a535b7be7a847b6db03f4279d6344cfc3) | `` plugins/haskell-tools: init ``                                                             |
| [`b9e5bac7`](https://github.com/nix-community/nixvim/commit/b9e5bac7bc8a165dd6eb16d10d6093e54168f037) | `` docs: improve consistency ``                                                               |
| [`583d5d89`](https://github.com/nix-community/nixvim/commit/583d5d8982a364ec049dde5bbd2bd12e8337adfd) | `` plugins/opencode: add opencode dependency ``                                               |
| [`70386754`](https://github.com/nix-community/nixvim/commit/7038675452dadfa062e31588dca5c5356fea4d92) | `` modules/dependencies: add gemini and opencode ``                                           |
| [`b58be698`](https://github.com/nix-community/nixvim/commit/b58be698677944abe92c6b413b6b3d6abb6ddbd2) | `` plugins/nvim-notify: add more render styles ``                                             |