### PR TITLE
chore(flake/nixvim): `fc779c6e` -> `eb54f65d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1759362848,
-        "narHash": "sha256-rhx4Spn5F4brp50udGNo7zZml3vqUGEBzHe0Og0RFHw=",
+        "lastModified": 1759445396,
+        "narHash": "sha256-ofMqAEC6NcFSDGC6qMMG+XFtmlnOghuxh89SzN40+sc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "fc779c6e8279226a128d3c0f06afebf08cfadc1b",
+        "rev": "eb54f65d9b24310a55de000e62ff6053aa8874ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`eb54f65d`](https://github.com/nix-community/nixvim/commit/eb54f65d9b24310a55de000e62ff6053aa8874ed) | `` plugins/ethersync: init ``                                              |
| [`18b8d53e`](https://github.com/nix-community/nixvim/commit/18b8d53e23eb2ab91744f5a66a74537bcd218560) | `` plugins/telescope/extensions/fzf-native: remove old renamed warnings `` |
| [`a19a0164`](https://github.com/nix-community/nixvim/commit/a19a0164584801d1d1b7cde863976f97d9ca155c) | `` plugins/copilot-lua: add copilot-lsp ``                                 |
| [`dca0aa2d`](https://github.com/nix-community/nixvim/commit/dca0aa2defa89b02ed17d45e955af73be17e0178) | `` tests/all-package-defaults: disable superhtml on x86_64-darwin ``       |
| [`5874f35f`](https://github.com/nix-community/nixvim/commit/5874f35f71dee6091bd23826f1f12ecb32085757) | `` flake/dev/flake.lock: Update ``                                         |
| [`4f922f60`](https://github.com/nix-community/nixvim/commit/4f922f607a99530bfd6a9b3e8dd7f87078a8ebcc) | `` flake.lock: Update ``                                                   |
| [`5c4a1009`](https://github.com/nix-community/nixvim/commit/5c4a10093d5367af740c04f2bbe3bab7310d9ad0) | `` plugins.lsp: automatically remove unsupported servers ``                |