### PR TITLE
chore(flake/git-hooks): `54df955a` -> `cfc9f7bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758108966,
-        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
+        "lastModified": 1759523803,
+        "narHash": "sha256-PTod9NG+i3XbbnBKMl/e5uHDBYpwIWivQ3gOWSEuIEM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
+        "rev": "cfc9f7bb163ad8542029d303e599c0f7eee09835",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`c167450c`](https://github.com/cachix/git-hooks.nix/commit/c167450ce569b4e7a9f989fca92734cb419a3a72) | `` Update nix/run.nix ``                        |
| [`eb23b79b`](https://github.com/cachix/git-hooks.nix/commit/eb23b79b4e6cf5848de127f2f4b0a4468b3819f9) | `` Use prek as default package if available. `` |