### PR TITLE
chore(flake/nixvim): `42d87fd4` -> `2f8fbcdf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1759527752,
-        "narHash": "sha256-+sncyvy1dkwRBeq7vw/YpsKqB18UuaKuW2lKRRv6/EI=",
+        "lastModified": 1759618379,
+        "narHash": "sha256-4j73b+t3B5sN1JAcwAT9XD4P38o3qvBqCkfXPvnAY3o=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "42d87fd4d8f51ea8c591b0b72af76b0aba991f54",
+        "rev": "2f8fbcdfd02b16e7392f5cfa3600aa77cd559d37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`2f8fbcdf`](https://github.com/nix-community/nixvim/commit/2f8fbcdfd02b16e7392f5cfa3600aa77cd559d37) | `` plugins/multicursors: migrate to mkNeovimPlugin ``       |
| [`ce149cac`](https://github.com/nix-community/nixvim/commit/ce149cac11440e4f325b7a11a3bf21df2858e6b4) | `` plugins/illuminate: migrate to mkNeovimPlugin ``         |
| [`35b7251d`](https://github.com/nix-community/nixvim/commit/35b7251d83dfea09648c7c35764e38edfdd31046) | `` plugins/leap: migrate to mkNeovimPlugin ``               |
| [`a33eee71`](https://github.com/nix-community/nixvim/commit/a33eee710fbd5cb5b4960a2b3c51d7cd42b2792c) | `` plugins/mkdnflow: migrate to mkNeovimPlugin ``           |
| [`8fcf8a9e`](https://github.com/nix-community/nixvim/commit/8fcf8a9ef1a6aedd50c17259e7efba55838efaed) | `` plugins/lsp/vue_ls: add a `tslsIntegration` option ``    |
| [`3fa0e487`](https://github.com/nix-community/nixvim/commit/3fa0e487260af16dde609940e49c3ddc6c31c6ed) | `` flake/dev/flake.lock: Update ``                          |
| [`71708a77`](https://github.com/nix-community/nixvim/commit/71708a77de0568b09a870f8a8c9d700261c31477) | `` plugins/lsp: remove erlang-ls ``                         |
| [`61f1475f`](https://github.com/nix-community/nixvim/commit/61f1475f7f9085d4508f95f5a953d6850038b5d7) | `` plugins/rainbow-delimiters: migrate to mkNeovimPlugin `` |
| [`aa47ed38`](https://github.com/nix-community/nixvim/commit/aa47ed384a23fd7ddac68120319c6e319656a39d) | `` plugins/copilot-lsp: add module ``                       |
| [`e87e4b18`](https://github.com/nix-community/nixvim/commit/e87e4b1812b3ed77eba0528f1c12af8de25c5a1b) | `` plugins/sidekick: init module ``                         |
| [`138a387a`](https://github.com/nix-community/nixvim/commit/138a387afba1777cde5d33a92b8c159207118754) | `` dependencies: add copilot ``                             |